### PR TITLE
Fix Overriding of DD_PORT in datadog collection lambda

### DIFF
--- a/Log/lambda_function.py
+++ b/Log/lambda_function.py
@@ -27,7 +27,7 @@ metadata = {"ddsourcecategory": "aws"}
 DD_URL = os.getenv("DD_URL", default="lambda-intake.logs.datadoghq.com")
 
 # Define the proxy port to forward the logs to
-DD_PORT = os.environ.get("DD_PORT", 10516)
+DD_PORT = int(os.environ.get("DD_PORT", 10516))
 
 # Scrubbing sensitive data
 # Option to redact all pattern that looks like an ip address


### PR DESCRIPTION
Overriding with value value was causing a type error because the env variable is a string, not a number

```
an integer is required: TypeError Traceback (most recent call last): File "/var/task/lambda/datadog-log-collection/lambda_function.py", line 137, in lambda_handler with DatadogConnection(DD_URL, DD_PORT, DD_API_KEY) as con: File "/var/task/lambda/datadog-log-collection/lambda_function.py", line 119, in __enter__ self._sock = self._connect() File "/var/task/lambda/datadog-log-collecti
```