### PR TITLE
Allow KMS exceptions to bubble up

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -43,16 +43,13 @@ except Exception:
 
 # DD_API_KEY: Datadog API Key
 DD_API_KEY = "<your_api_key>"
-try:
-    if "DD_KMS_API_KEY" in os.environ:
-        ENCRYPTED = os.environ["DD_KMS_API_KEY"]
-        DD_API_KEY = boto3.client("kms").decrypt(
-            CiphertextBlob=base64.b64decode(ENCRYPTED)
-        )["Plaintext"]
-    elif "DD_API_KEY" in os.environ:
-        DD_API_KEY = os.environ["DD_API_KEY"]
-except Exception:
-    pass
+if "DD_KMS_API_KEY" in os.environ:
+    ENCRYPTED = os.environ["DD_KMS_API_KEY"]
+    DD_API_KEY = boto3.client("kms").decrypt(
+        CiphertextBlob=base64.b64decode(ENCRYPTED)
+    )["Plaintext"]
+elif "DD_API_KEY" in os.environ:
+    DD_API_KEY = os.environ["DD_API_KEY"]
 
 cloudtrail_regex = re.compile(
     "\d+_CloudTrail_\w{2}-\w{4,9}-\d_\d{8}T\d{4}Z.+.json.gz$", re.I


### PR DESCRIPTION
### What does this PR do?
If there is a problem decrypting the Datadog API key from KMS the Lambda should fail fast and alert he user. As it stands now the exception is swallowed and the user has no idea the operation failed.

### Motivation
I spent a bit of time tracking down a failing Lambda only to realize I had improper AWS IAM permissions that were preventing the decryption of the API key.

### Additional Notes
N/A
