### PR TITLE
Fix Api gateway automatic source detection

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -395,6 +395,8 @@ def parse_event_source(event, key):
     ]:
         if source in key:
             return source
+    if "API-Gateway" in key:
+        return "apigateway"
     if is_cloudtrail(str(key)):
         return "cloudtrail"
     if "awslogs" in event:


### PR DESCRIPTION
### What does this PR do?

Fix the automated detection for apigateway logs. 

### Motivation

Apigateway logs actually contains "API-Gateway" in the log group name. Therefore we should leverage this to set the value instead of just asking to add "apigateway" in the log group prefix.

### Additional Notes

Anything else we should know when reviewing?
