### PR TITLE
Tj/check api key length and strip trailing and leading whitespace

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -61,7 +61,7 @@ DD_SOURCE = "ddsource"
 DD_CUSTOM_TAGS = "ddtags"
 DD_SERVICE = "service"
 DD_HOST = "host"
-DD_FORWARDER_VERSION = "1.2.1"
+DD_FORWARDER_VERSION = "1.2.2"
 
 # Pass custom tags as environment variable, ensure comma separated, no trailing comma in envvar!
 DD_TAGS = os.environ.get("DD_TAGS", "")

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -50,6 +50,9 @@ try:
 except Exception:
     pass
 
+# Strip any trailing and leading whitespace from the API key
+DD_API_KEY = DD_API_KEY.strip()
+
 cloudtrail_regex = re.compile(
     "\d+_CloudTrail_\w{2}-\w{4,9}-\d_\d{8}T\d{4}Z.+.json.gz$", re.I
 )
@@ -137,6 +140,11 @@ def lambda_handler(event, context):
     if DD_API_KEY == "<your_api_key>" or DD_API_KEY == "":
         raise Exception(
             "You must configure your API key before starting this lambda function (see #Parameters section)"
+        )
+    # Check if the API key is the correct number of characters
+    if len(DD_API_KEY) != 32:
+        raise Exception(
+            "The API key is not the expected length. Please confirm that your API key is correct"
         )
 
     metadata = {"ddsourcecategory": "aws"}


### PR DESCRIPTION
… API key is the correct length

### What does this PR do?

This PR strips the API key of any trailing or leading whitespace and later checks that the API key is the expected length

### Motivation

Support Issue where an automation tool was decrypting an API key and then populating the DD_API_KEY environment variable with the result.  No logs were coming through to Datadog, and the user had checked that the API key didn't have any typos.  It turned out that `len(DD_API_KEY)` was 33 and adding a `.strip()` resolved the issue for the user, but it took a while to track this down since the API key in the environment variable appeared to be a character-for-character match to the API key in their account.

The root cause with the automation tool was addressed, but the user wanted to have some checks on the API key to surface the issue more easily. 

### Additional Notes

