### PR TITLE
Created a HTTP client to send batch of logs over HTTP to Datadog

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -94,7 +94,7 @@ class ScrubbingException(Exception):
 
 class DatadogClient(object):
     """
-    Client that implements a linear retrying logic to send a batch of logs.
+    Client that implements a exponential retrying logic to send a batch of logs.
     """
 
     def __init__(self, client, max_backoff=30):
@@ -258,8 +258,8 @@ class DatadogBatcher(object):
                 batch = []
                 size_bytes = 0
                 size_count = 0
+            # all logs exceeding max_log_size_bytes are dropped here
             if log_size_bytes <= self._max_log_size_bytes:
-                # all logs exceeding max_log_size_bytes are dropped here
                 batch.append(log)
                 size_bytes += log_size_bytes
                 size_count += 1
@@ -286,7 +286,7 @@ class DatadogScrubber(object):
                         )
                     )
             except Exception:
-                pass
+                raise Exception("could not compile rule with config: {}".format(config))
         self._rules = rules
 
     def scrub(self, payload):

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -150,7 +150,7 @@ class DatadogTCPClient(object):
     def _connect(self):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock = ssl.wrap_socket(sock)
-        sock.create_connection((self.host, self.port), timeout=self._timeout)
+        sock.connect((self.host, self.port))
         self._sock = sock
 
     def _close(self):

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -78,6 +78,10 @@ class RetriableException(Exception):
 
 
 class DatadogClient(object):
+    """
+    Client that implements a linear retrying logic to send a batch of logs.
+    """
+
     def __init__(self, client, max_retries=3, backoff=1):
         self._client = client
         self._max_retries = max_retries
@@ -106,6 +110,10 @@ class DatadogClient(object):
 
 
 class DatadogTCPClient(object):
+    """
+    Client that sends a batch of logs over TCP.
+    """
+
     def __init__(self, host, port, api_key):
         self.host = host
         self.port = port
@@ -133,7 +141,7 @@ class DatadogTCPClient(object):
             )
             self._sock.send(frame.encode("UTF-8"))
         except Exception as e:
-            # most likely a network error, reset the connection            
+            # most likely a network error, reset the connection
             if self._sock:
                 self.close()
             self.connect()
@@ -141,6 +149,9 @@ class DatadogTCPClient(object):
 
 
 class DatadogHTTPClient(object):
+    """
+    Client that sends a batch of logs over HTTP.
+    """
 
     _POST = "POST"
     _HEADERS = {"Content-type": "application/json"}
@@ -158,6 +169,9 @@ class DatadogHTTPClient(object):
         self._session.close()
 
     def send(self, logs, metadata):
+        """
+        Sends a batch of log, only retry on server and network errors.
+        """
         try:
             resp = self._session.post(
                 self._url, data=json.dumps(logs), params=metadata, timeout=self._timeout

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -134,7 +134,7 @@ class DatadogTCPClient(object):
 
     def connect(self):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock = ssl.wrap_socket(s)
+        sock = ssl.wrap_socket(sock)
         sock.connect((self.host, self.port))
         self._sock = sock
 
@@ -235,7 +235,7 @@ class DatadogBatcher(object):
             r = (i + 1) * self._max_size
             batch = logs[l:r]
             if len(batch) > 0:
-                batches.append(logs[l:r])
+                batches.append(batch)
         return batches
 
 
@@ -277,7 +277,7 @@ def lambda_handler(event, context):
     with DatadogClient(cli) as client:
         for batch in batcher.batch(logs):
             try:
-                client.send(batch)
+                client.send(batch, metadata)
             except Exception as e:
                 print("Unexpected exception: {}, event: {}".format(str(e), event))
 

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -77,8 +77,12 @@ DD_API_KEY = DD_API_KEY.strip()
 # DD_MULTILINE_REGEX: Datadog Multiline Log Regular Expression Pattern
 if "DD_MULTILINE_LOG_REGEX_PATTERN" in os.environ:
     DD_MULTILINE_LOG_REGEX_PATTERN = os.environ["DD_MULTILINE_LOG_REGEX_PATTERN"]
-    multiline_regex = re.compile("(?<!^)\s+(?={})(?!.\s)".format(DD_MULTILINE_LOG_REGEX_PATTERN))
-    multiline_regex_start_pattern = re.compile("^{}".format(DD_MULTILINE_LOG_REGEX_PATTERN))
+    multiline_regex = re.compile(
+        "(?<!^)\s+(?={})(?!.\s)".format(DD_MULTILINE_LOG_REGEX_PATTERN)
+    )
+    multiline_regex_start_pattern = re.compile(
+        "^{}".format(DD_MULTILINE_LOG_REGEX_PATTERN)
+    )
 
 DD_SOURCE = "ddsource"
 DD_CUSTOM_TAGS = "ddtags"

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -131,13 +131,15 @@ class DatadogTCPClient(object):
 
     def send(self, logs, metadata):
         try:
-            frame = "".join(
-                [
-                    "%s %s\n".format(
-                        self._api_key, json.dumps(merge_dicts(log, metadata))
-                    )
-                    for log in logs
-                ]
+            frame = scrub(
+                "".join(
+                    [
+                        "%s %s\n".format(
+                            self._api_key, json.dumps(merge_dicts(log, metadata))
+                        )
+                        for log in logs
+                    ]
+                )
             )
             self._sock.send(frame.encode("UTF-8"))
         except Exception as e:
@@ -174,7 +176,10 @@ class DatadogHTTPClient(object):
         """
         try:
             resp = self._session.post(
-                self._url, data=json.dumps(logs), params=metadata, timeout=self._timeout
+                self._url,
+                data=scrub(json.dumps(logs)),
+                params=metadata,
+                timeout=self._timeout,
             )
         except Exception as e:
             # most likely a network error
@@ -293,6 +298,15 @@ def generate_metadata(context):
 
 
 # Utility functions
+
+
+def scrub(self, payload):
+    if is_ipscrubbing:
+        try:
+            return ip_regex.sub("xxx.xxx.xxx.xxx", payload)
+        except Exception as e:
+            raise e
+    return payload
 
 
 def normalize_logs(logs):

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -142,6 +142,10 @@ class DatadogTCPClient(object):
         if self._sock:
             self._sock.close()
 
+    def _reset(self):
+        self.close()
+        self.connect()
+
     def send(self, logs, metadata):
         try:
             frame = self._scrubber.scrub(
@@ -159,9 +163,7 @@ class DatadogTCPClient(object):
             raise Exception("could not scrub the payload")
         except Exception as e:
             # most likely a network error, reset the connection
-            if self._sock:
-                self.close()
-            self.connect()
+            self._reset()
             raise RetriableException()
 
 
@@ -298,7 +300,7 @@ def generate_logs(event, context, metadata):
             str(e), event
         )
         logs = [err_message]
-    return normalize_logs(logs, metadata)
+    return normalize_logs(logs)
 
 
 def generate_metadata(context):
@@ -342,7 +344,7 @@ def normalize_logs(logs):
             batches.append({"message": log})
         else:
             # drop this log
-            pass
+            continue
     return normalized
 
 

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -41,28 +41,28 @@ else:
 
 
 class ScrubbingRuleConfig(object):
-
-    DEFAULTS = [
-        ScrubbingRuleConfig(
-            "REDACT_IP", "\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}", "xxx.xxx.xxx.xxx"
-        ),
-        ScrubbingRuleConfig(
-            "REDACT_EMAIL",
-            "[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+",
-            "xxxxx@xxxxx.com",
-        ),
-    ]
-
     def __init__(self, name, pattern, placeholder):
         self.name = name
         self.pattern = pattern
         self.placeholder = placeholder
 
 
+SCRUBBING_RULE_CONFIGS = [
+    ScrubbingRuleConfig(
+        "REDACT_IP", "\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}", "xxx.xxx.xxx.xxx"
+    ),
+    ScrubbingRuleConfig(
+        "REDACT_EMAIL",
+        "[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+",
+        "xxxxx@xxxxx.com",
+    ),
+]
+
+
 # Scrubbing sensitive data
 # Option to redact all pattern that looks like an ip address / email address
 scrubbingRules = []
-for config in ScrubbingRuleConfig.DEFAULTS:
+for config in SCRUBBING_RULE_CONFIGS:
     try:
         if s.environ.get(config.name, False) == True:
             scrubbingRules.append(

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -267,7 +267,8 @@ class DatadogBatcher(object):
 
 class DatadogScrubber(object):
     def __init__(self, shouldScrubIPs):
-        self._ip_regex = re.compile("\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}", re.I)
+        if shouldScrubIPs:
+            self._ip_regex = re.compile("\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}", re.I)
 
     def scrub(self, payload):
         if self._ip_regex is not None:

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -19,10 +19,16 @@ import gzip
 
 import boto3
 
+# Client configuration
+DD_USE_HTTP = True
+
 # Proxy
 # Define the proxy endpoint to forward the logs to
 DD_SITE = os.getenv("DD_SITE", default="datadoghq.com")
-DD_URL = os.getenv("DD_URL", default="lambda-intake.logs." + DD_SITE)
+if DD_USE_HTTP:
+    DD_URL = os.getenv("DD_URL", default="lambda-http-intake.logs." + DD_SITE)
+else:
+    DD_URL = os.getenv("DD_URL", default="lambda-intake.logs." + DD_SITE)
 
 # Define the proxy port to forward the logs to
 try:
@@ -64,9 +70,6 @@ DD_CUSTOM_TAGS = "ddtags"
 DD_SERVICE = "service"
 DD_HOST = "host"
 DD_FORWARDER_VERSION = "1.3.0"
-
-# http specific
-DD_USE_HTTP = True
 DD_BATCH_SIZE = 10
 
 # Pass custom tags as environment variable, ensure comma separated, no trailing comma in envvar!

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -10,7 +10,7 @@ import json
 import urllib
 import os
 import socket
-import requests
+from botocore.vendored import requests
 import time
 import ssl
 import re

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -139,17 +139,18 @@ class DatadogTCPClient(object):
     Client that sends a batch of logs over TCP.
     """
 
-    def __init__(self, host, port, api_key, scrubber):
+    def __init__(self, host, port, api_key, scrubber, timeout=5):
         self.host = host
         self.port = port
         self._api_key = api_key
         self._scrubber = scrubber
+        self._timeout = timeout
         self._sock = None
 
     def _connect(self):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock = ssl.wrap_socket(sock)
-        sock.connect((self.host, self.port))
+        sock.create_connection((self.host, self.port), timeout=self._timeout)
         self._sock = sock
 
     def _close(self):
@@ -167,7 +168,7 @@ class DatadogTCPClient(object):
                     ["{} {}\n".format(self._api_key, json.dumps(log)) for log in logs]
                 )
             )
-            self._sock.send(frame.encode("UTF-8"))
+            self._sock.sendall(frame.encode("UTF-8"))
         except ScrubbingException as e:
             raise Exception("could not scrub the payload")
         except Exception as e:

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -62,10 +62,6 @@ except Exception:
 # Strip any trailing and leading whitespace from the API key
 DD_API_KEY = DD_API_KEY.strip()
 
-cloudtrail_regex = re.compile(
-    "\d+_CloudTrail_\w{2}-\w{4,9}-\d_\d{8}T\d{4}Z.+.json.gz$", re.I
-)
-ip_regex = re.compile("\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}", re.I)
 DD_SOURCE = "ddsource"
 DD_CUSTOM_TAGS = "ddtags"
 DD_SERVICE = "service"
@@ -257,12 +253,12 @@ class DatadogBatcher(object):
 
 class DatadogScrubber(object):
     def __init__(self, shouldScrubIPs):
-        self._shouldScrubIPs = shouldScrubIPs
+        self._ip_regex = re.compile("\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}", re.I)
 
     def scrub(self, payload):
-        if self._shouldScrubIPs:
+        if self._ip_regex is not None:
             try:
-                return ip_regex.sub("xxx.xxx.xxx.xxx", payload)
+                return self._ip_regex.sub("xxx.xxx.xxx.xxx", payload)
             except Exception as e:
                 raise ScrubbingException()
         return payload
@@ -531,6 +527,11 @@ def merge_dicts(a, b, path=None):
         else:
             a[key] = b[key]
     return a
+
+
+cloudtrail_regex = re.compile(
+    "\d+_CloudTrail_\w{2}-\w{4,9}-\d_\d{8}T\d{4}Z.+.json.gz$", re.I
+)
 
 
 def is_cloudtrail(key):

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -261,11 +261,13 @@ def generate_logs(event, context, metadata):
 
 
 def generate_metadata(context):
-    metadata = {"ddsourcecategory": "aws"}
-    aws_meta = {}
-    aws_meta["function_version"] = context.function_version
-    aws_meta["invoked_function_arn"] = context.invoked_function_arn
-    metadata["aws"] = aws_meta
+    metadata = {
+        "ddsourcecategory": "aws",
+        "aws": {
+            "function_version": context.function_version,
+            "invoked_function_arn": context.invoked_function_arn,
+        },
+    }
     # Add custom tags here by adding new value with the following format "key1:value1, key2:value2"  - might be subject to modifications
     dd_custom_tags_data = {
         "forwardername": context.function_name.lower(),

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -220,7 +220,9 @@ class DatadogBatcher(object):
         for i in range(0, nb_batchs):
             l = i * self._max_size
             r = (i + 1) * self._max_size
-            batches.append(logs[l:r])
+            batch = logs[l:r]
+            if len(batch) > 0:
+                batches.append(logs[l:r])
         return batches
 
 
@@ -247,7 +249,7 @@ def lambda_handler(event, context):
         batcher = DatadogBatcher(1)
 
     with DatadogClient(cli) as client:
-        for batch in batcher.batch(logs, metadata):
+        for batch in batcher.batch(logs):
             try:
                 client.send(batch)
             except Exception as e:

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -247,10 +247,10 @@ class DatadogBatcher(object):
         size_count = 0
         for log in logs:
             log_size_bytes = self._sizeof_bytes(log)
-            if (
+            if size_count > 0 and (
                 size_count >= self._max_size_count
                 or size_bytes + log_size_bytes > self._max_size_bytes
-            ) and size_count > 0:
+            ):
                 batches.append(batch)
                 batch = []
                 size_bytes = 0

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -19,6 +19,7 @@ import gzip
 
 import boto3
 
+
 # Client configuration
 DD_USE_HTTP = True
 
@@ -38,6 +39,8 @@ try:
         DD_PORT = int(os.environ.get("DD_PORT", 10516))
 except Exception:
     DD_PORT = 10516
+
+
 # Scrubbing sensitive data
 # Option to redact all pattern that looks like an ip address
 try:
@@ -130,7 +133,8 @@ class DatadogTCPClient(object):
         return s
 
     def close(self):
-        self._sock.close()
+        if self._sock:
+            self._sock.close()
 
     def send(self, logs, metadata):
         try:

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -529,28 +529,33 @@ def parse_service_arn(source, key, bucket, context):
         if bucket:
             return "arn:aws:s3:::" + bucket
     if source == "cloudfront":
-        #For Cloudfront logs we need to get the account and distribution id from the lambda arn and the filename
-        #1. We extract the cloudfront id  from the filename
-        #2. We extract the AWS account id from the lambda arn
-        #3. We build the arn
+        # For Cloudfront logs we need to get the account and distribution id from the lambda arn and the filename
+        # 1. We extract the cloudfront id  from the filename
+        # 2. We extract the AWS account id from the lambda arn
+        # 3. We build the arn
         namesplit = key.split("/")
         if len(namesplit) > 0:
-            filename = namesplit[len(namesplit)-1] 
-            #(distribution-ID.YYYY-MM-DD-HH.unique-ID.gz)
+            filename = namesplit[len(namesplit) - 1]
+            # (distribution-ID.YYYY-MM-DD-HH.unique-ID.gz)
             filenamesplit = filename.split(".")
             if len(filenamesplit) > 3:
-                distributionID = filenamesplit[len(filenamesplit)-4].lower()
+                distributionID = filenamesplit[len(filenamesplit) - 4].lower()
                 arn = context.invoked_function_arn
                 arnsplit = arn.split(":")
                 if len(arnsplit) == 7:
                     awsaccountID = arnsplit[4].lower()
-                    return "arn:aws:cloudfront::" + awsaccountID+":distribution/" + distributionID
+                    return (
+                        "arn:aws:cloudfront::"
+                        + awsaccountID
+                        + ":distribution/"
+                        + distributionID
+                    )
     if source == "redshift":
-        #For redshift logs we leverage the filename to extract the relevant information
-        #1. We extract the region from the filename
-        #2. We extract the account-id from the filename
-        #3. We extract the name of the cluster
-        #4. We build the arn: arn:aws:redshift:region:account-id:cluster:cluster-name
+        # For redshift logs we leverage the filename to extract the relevant information
+        # 1. We extract the region from the filename
+        # 2. We extract the account-id from the filename
+        # 3. We extract the name of the cluster
+        # 4. We build the arn: arn:aws:redshift:region:account-id:cluster:cluster-name
         namesplit = key.split("/")
         if len(namesplit) == 8:
             region = namesplit[3].lower()
@@ -559,5 +564,12 @@ def parse_service_arn(source, key, bucket, context):
             filesplit = filename.split("_")
             if len(filesplit) == 6:
                 clustername = filesplit[3]
-                return "arn:aws:redshift:" + region + ":" + accountID + ":cluster:" + clustername
+                return (
+                    "arn:aws:redshift:"
+                    + region
+                    + ":"
+                    + accountID
+                    + ":cluster:"
+                    + clustername
+                )
     return

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -104,10 +104,11 @@ class DatadogClient(object):
         raise Exception("max number of retries reached: {}".format(self._max_retries))
 
     def __enter__(self):
-        return self._client.__enter__()
+        self._client.__enter__()
+        return self
 
     def __exit__(self, ex_type, ex_value, traceback):
-        return self._client.__exit__(ex_type, ex_value, traceback)
+        self._client.__exit__(ex_type, ex_value, traceback)
 
 
 class DatadogTCPClient(object):
@@ -162,7 +163,6 @@ class DatadogTCPClient(object):
 
     def __exit__(self, ex_type, ex_value, traceback):
         self._close()
-        return self
 
 
 class DatadogHTTPClient(object):
@@ -222,7 +222,6 @@ class DatadogHTTPClient(object):
 
     def __exit__(self, ex_type, ex_value, traceback):
         self._close()
-        return self
 
 
 class DatadogBatcher(object):

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -141,7 +141,7 @@ class DatadogTCPClient(object):
             frame = scrub(
                 "".join(
                     [
-                        "%s %s\n".format(
+                        "{} {}\n".format(
                             self._api_key, json.dumps(merge_dicts(log, metadata))
                         )
                         for log in logs

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -22,7 +22,7 @@ import boto3
 
 # Change this value to change the underlying network client (HTTP or TCP),
 # by default, use the HTTP client.
-DD_USE_HTTP = True
+DD_USE_HTTP = os.getenv("DD_USE_HTTP", default=True)
 
 # Define the destination endpoint to send logs to
 DD_SITE = os.getenv("DD_SITE", default="datadoghq.com")

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -127,10 +127,10 @@ class DatadogTCPClient(object):
         self._sock = None
 
     def connect(self):
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s = ssl.wrap_socket(s)
-        s.connect((self.host, self.port))
-        return s
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock = ssl.wrap_socket(s)
+        sock.connect((self.host, self.port))
+        self._sock = sock
 
     def close(self):
         if self._sock:

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -267,8 +267,11 @@ class DatadogBatcher(object):
 
 class DatadogScrubber(object):
     def __init__(self, shouldScrubIPs):
-        if shouldScrubIPs:
-            self._ip_regex = re.compile("\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}", re.I)
+        self._ip_regex = (
+            re.compile("\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}", re.I)
+            if shouldScrubIPs
+            else None
+        )
 
     def scrub(self, payload):
         if self._ip_regex is not None:


### PR DESCRIPTION
### What does this PR do?

Added the logic to send logs over HTTP to Datadog:
- Created a HTTP client on top of `requests`
- Created a batcher
- Refactor the TCP client to isolate the retry logic

### Motivation

Migrate the integration to th HTTP API

### Additional Notes

Need to add unit-tests
