### PR TITLE
Add "docdb" in the list of sources

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -399,6 +399,7 @@ def parse_event_source(event, key):
         "rds",
         "sns",
         "waf",
+        "docdb",
     ]:
         if source in key:
             return source


### PR DESCRIPTION
### What does this PR do?

Docdb recently released the ability to send logs to Cloudwatch and the log group is named `/aws/docdb/....`.
Therefore docdb is added to the list of sources to trigger the installation of the corresponding integration pipeline.

### Motivation

Setting the source automatically make sure that the integration pipeline on the server side is properly installed.

### Additional Notes

Anything else we should know when reviewing?
