### PR TITLE
allows for capitalized elbname for hostname matching

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -425,7 +425,7 @@ def parse_service_arn(source, key, bucket, context):
         idsplit = key.split("/")
         if len(keysplit) > 3:
             region = keysplit[2].lower()
-            name = keysplit[3].lower()
+            name = keysplit[3]
             elbname = name.replace(".", "/")
             if len(idsplit) > 1:
                 idvalue = idsplit[1]


### PR DESCRIPTION
### What does this PR do?

Removes `.lower()` from being applied on the elb name when building the ARN string.  

### Motivation

Support case where hostname was not being properly associated with the ARN when the elbname included capitalization.

### Additional Notes
