### PR TITLE
Fix the Retry logic to take the local metadata into account

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -89,7 +89,7 @@ class DatadogConnection(object):
                 # make sure we don't keep old connections open
                 self._sock.close()
             self._sock = self._connect()
-            self.send_entry(log)
+            self.send_entry(log, metadata)
         return self
 
     def send_entry(self, log_entry, metadata):


### PR DESCRIPTION
### What does this PR do?

When an issue occurred while sending the logs ,there is a retry logic. The retry needs to forward the local metadata as well otherwise it fails.

### Motivation

The retry was not working anymore.

### Additional Notes

Anything else we should know when reviewing?
