### PR TITLE
Bumping version after the de-duplicate of tags

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -65,7 +65,7 @@ DD_SOURCE = "ddsource"
 DD_CUSTOM_TAGS = "ddtags"
 DD_SERVICE = "service"
 DD_HOST = "host"
-DD_FORWARDER_VERSION = "1.2.2"
+DD_FORWARDER_VERSION = "1.2.3"
 
 # Pass custom tags as environment variable, ensure comma separated, no trailing comma in envvar!
 DD_TAGS = os.environ.get("DD_TAGS", "")


### PR DESCRIPTION
### What does this PR do?

Bump the version of the forwarder

### Motivation

A new fix was added to deduplicate functionname tags that was added several times when lambda logs were sent in batch.

### Additional Notes

Anything else we should know when reviewing?
