### PR TITLE
sets host as cloudwatch log group for non-lambda cloudwatch logs

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -316,6 +316,10 @@ def awslogs_handler(event, context, metadata):
         }
     }
 
+    # Set host as log group where cloudwatch is source
+    if metadata[DD_SOURCE] == "cloudwatch":
+        metadata[DD_HOST] = aws_attributes["aws"]["awslogs"]["logGroup"]
+
     # For Lambda logs we want to extract the function name,
     # then rebuild the arn of the monitored lambda using that name.
     # Start by splitting the log group to get the function name


### PR DESCRIPTION
### What does this PR do?

For cloudwatch logs that are not lambda created, set metadata[DD_HOST]
as the cloudwatch log group.

### Motivation

The current behavior in DataDog is to not surface a host for logs that
are not lambda generated. More specifically, where `metadata[DD_SOURCE] == "cloudwatch"`.

We use a lot of ECS Fargate tasks where the only DataDog logging option is to use the lambda handler to forward cloudwatch logs. We prefer to designate the "service" the logs are being generated from before passing the logs through a parser.

This is where things get opinionated:

In all of our ECS Fargate tasks, we create a log group that is named for the service. All logs for a given service, regardless of environment, are then stored under this namespace. Conveniently this attribute, `logGroup`, is already being stored in `aws_attributes`.

### Additional Notes

Noticed the requirement for tests in the contribution guidelines, but don't see where to implement. Please let me know and I'll be happy to add if need be.
