### PR TITLE
Added CloudWatch via Kinesis support

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -441,13 +441,14 @@ def parse_event_source(event, key):
             return source
     if "API-Gateway" in key or "ApiGateway" in key:
         return "apigateway"
-    if is_cloudtrail(str(key)):
+    if is_cloudtrail(str(key)) or ('logGroup' in event and event['logGroup'] == 'CloudTrail'):
         return "cloudtrail"
     if "awslogs" in event:
         return "cloudwatch"
     if "Records" in event and len(event["Records"]) > 0:
         if "s3" in event["Records"][0]:
             return "s3"
+
     return "aws"
 
 def parse_service_arn(source, key, bucket, context):

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -435,6 +435,7 @@ def parse_event_source(event, key):
         "sns",
         "waf",
         "docdb",
+        "fargate"
     ]:
         if source in key:
             return source


### PR DESCRIPTION
### What does this PR do?

This change allows the Datadog log forwarder to be run as a consumer to a Kinesis stream of log events.

### Motivation

We have our CloudWatch logs configured to ship to a Kinesis stream via a log subscription filter. This change allows the Datadog log forwarder to support being run as a consumer to this stream instead of directly from the log subscription. This model significantly reduces the amount of concurrent lambda executions one would spend on log shipping while also providing an additional layer of indirection for log processing and handling by other tools.

### Additional Notes

There are also some minor bug fixes included:
* API Gateway logs were being marked as source: cloudwatch
* Log parsing was crashing due to an index out of bounds exception on some entries which didn't follow the LogGroup format "A/lambda/B".
