### PR TITLE
add multiline log support for s3 logs

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -10,6 +10,7 @@ AWS lambda function to ship ELB, S3, CloudTrail, VPC, CloudFront and CloudWatch 
 - SSL Security
 - JSON events providing details about S3 documents forwarded
 - Structured meta-information can be attached to the events
+- Multiline Log Support (S3 Only)
 
 # Quick Start
 
@@ -93,3 +94,9 @@ Two environment variables can be used to forward logs through a proxy:
 If the test "succeeded", you are all set! The test log will not show up in the platform.
 
 For S3 logs, there may be some latency between the time a first S3 log file is posted and the Lambda function wakes up.
+
+## 6. (optional) Multiline Log support for s3
+
+If there are multiline logs in s3, set `DD_MULTILINE_LOG_REGEX_PATTERN` environment variable to the specified regex pattern to detect for a new log line.
+
+- Example: for multiline logs beginning with pattern `11/10/2014`: `DD_MULTILINE_LOG_REGEX_PATTERN="\d{2}\/\d{2}\/\d{4}"`

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -58,6 +58,7 @@ DD_API_KEY = DD_API_KEY.strip()
 # DD_MULTILINE_REGEX: Datadog Multiline Log Regular Expression Patter
 if "DD_MULTILINE_LOG_REGEX_PATTERN" in os.environ:
     DD_MULTILINE_LOG_REGEX_PATTERN = os.environ["DD_MULTILINE_LOG_REGEX_PATTERN"]
+    multiline_regex = re.compile("(?<!^)\s+(?={})(?!.\s)".format(DD_MULTILINE_LOG_REGEX_PATTERN))
 
 cloudtrail_regex = re.compile(
     "\d+_CloudTrail_\w{2}-\w{4,9}-\d_\d{8}T\d{4}Z.+.json.gz$", re.I
@@ -283,7 +284,7 @@ def s3_handler(event, context, metadata):
     else:
         # Check if using multiline log regex pattern
         if DD_MULTILINE_LOG_REGEX_PATTERN:
-            split_data = re.compile("(?<!^)\s+(?=%s)(?!.\s)" % (DD_MULTILINE_LOG_REGEX_PATTERN,)).split(data)
+            split_data = multiline_regex.split(data)
         else:
             split_data = data.splitlines()
 


### PR DESCRIPTION
### What does this PR do?

Adds multiline log support for s3 logs that are multiline

### Motivation

S3 log buckets that have multiline logs can now be supported similar to how log_processing_rules work in other portions of the Datadog ecosystem. I have seen a few gists/hacks floating around on modifying the Lambda to handle multiline logs, however given the KMS support this lambda offers and that it is regularly updated+maintained, I figured it would make more sense to add an optional configuration for this lambda rather than support  an entirely different multiline log lambda

### Additional Notes

I don't believe it would be possible to handle multiline logs from cloudwatch with this approach, but if I am mistaken, i would be happy to try to generalize this to other sources (such as cloudwatch) if there was consensus that was achievable
