### PR TITLE
default assign None to DD_MULTILINE_LOG_REGEX_PATTERN to avoid exception

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -56,6 +56,7 @@ elif "DD_API_KEY" in os.environ:
 DD_API_KEY = DD_API_KEY.strip()
 
 # DD_MULTILINE_REGEX: Datadog Multiline Log Regular Expression Pattern
+DD_MULTILINE_LOG_REGEX_PATTERN = None
 if "DD_MULTILINE_LOG_REGEX_PATTERN" in os.environ:
     DD_MULTILINE_LOG_REGEX_PATTERN = os.environ["DD_MULTILINE_LOG_REGEX_PATTERN"]
     multiline_regex = re.compile("(?<!^)\s+(?={})(?!.\s)".format(DD_MULTILINE_LOG_REGEX_PATTERN))


### PR DESCRIPTION
### What does this PR do?

fixes exception, previously an exception would be thrown  later when referencing `DD_MULTILINE_LOG_REGEX_PATTERN` here: https://github.com/ericmustin/datadog-serverless-functions/blob/fdd4d06f8b0ffb4318e93eec551e9ffb497bb702/aws/logs_monitoring/lambda_function.py#L289` if this variable hadn't been defined  (because env var was not set)

### Motivation

Stop exception, fixes https://github.com/DataDog/datadog-serverless-functions/pull/111

### Additional Notes

@NBParis @ajacquemot  would you mind giving this a look quickly, ty @tj-dd for noting this

Anything else we should know when reviewing?
