### PR TITLE
Feature/aws reduce s3 handler mem usage

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -494,9 +494,6 @@ def filter_logs(logs):
     Applies log filtering rules.
     If no filtering rules exist, return all the logs.
     """
-    if INCLUDE_AT_MATCH is None and EXCLUDE_AT_MATCH is None:
-        # convert to strings
-        return logs
     # Test each log for exclusion and inclusion, if the criteria exist
     for log in logs:
         try:

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -497,8 +497,6 @@ def filter_logs(logs):
     if INCLUDE_AT_MATCH is None and EXCLUDE_AT_MATCH is None:
         # convert to strings
         return logs
-    # Add logs that should be sent to logs_to_send
-    logs_to_send = []
     # Test each log for exclusion and inclusion, if the criteria exist
     for log in logs:
         try:
@@ -510,11 +508,9 @@ def filter_logs(logs):
                 # if no include match is found, do not add log to logs_to_send
                 if not re.search(include_regex, log):
                     continue
-            logs_to_send.append(log)
+            yield log
         except ScrubbingException:
             raise Exception("could not filter the payload")
-    return logs_to_send
-
 
 def forward_metrics(metrics):
     """

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -535,16 +535,14 @@ def forward_metrics(metrics):
 
 
 def normalize_events(events, metadata):
-    normalized = []
     for event in events:
         if isinstance(event, dict):
-            normalized.append(merge_dicts(event, metadata))
+            yield merge_dicts(event, metadata)
         elif isinstance(event, str):
-            normalized.append(merge_dicts({"message": event}, metadata))
+            yield merge_dicts({"message": event}, metadata)
         else:
             # drop this log
             continue
-    return normalized
 
 
 def parse_event_type(event):

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -315,12 +315,12 @@ class DatadogBatcher(object):
 
     def batch(self, logs):
         """
-        Returns an array of batches.
+        Generates batches of logs.
+
         Each batch contains at most max_size_count logs and
         is not strictly greater than max_size_bytes.
         All logs strictly greater than max_log_size_bytes are dropped.
         """
-        batches = []
         batch = []
         size_bytes = 0
         size_count = 0
@@ -330,7 +330,7 @@ class DatadogBatcher(object):
                 size_count >= self._max_size_count
                 or size_bytes + log_size_bytes > self._max_size_bytes
             ):
-                batches.append(batch)
+                yield batch
                 batch = []
                 size_bytes = 0
                 size_count = 0
@@ -340,8 +340,10 @@ class DatadogBatcher(object):
                 size_bytes += log_size_bytes
                 size_count += 1
         if size_count > 0:
-            batches.append(batch)
-        return batches
+            # yield the final batch, which wasn't quite full...
+            # We keep as a yield here, since "return <foo>" is illegal in python 2.x.
+            # The docs for this lambda state 2.7 support...
+            yield batch
 
 
 class ScrubbingRule(object):

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -576,7 +576,7 @@ def s3_handler(event, context, metadata):
     }
 
     # Build a structured message out of the s3 event data.
-    def reformat_record(record):
+    def build_message(record):
         # We can be fed either strings, or event dictionaries here.
         # Checking against dict type here, to avoid the python 2 vs 3 thing
         # with checking for basestring, str, bytes...  
@@ -611,14 +611,14 @@ def s3_handler(event, context, metadata):
             else:
                 # Send decompressed lines to Datadog. Stream iter is line-by-line already.
                 for line in decompress_stream:
-                    yield reformat_record(line)
+                    yield build_message(line)
                 return
 
     if is_cloudtrail(str(key)):
         cloud_trail = json.loads(data)
         for event in cloud_trail["Records"]:
             # Create structured object and send it
-            yield reformat_record(event)
+            yield build_message(event)
     else:
         # Check if using multiline log regex pattern
         # and determine whether line or pattern separated logs
@@ -631,7 +631,7 @@ def s3_handler(event, context, metadata):
         # Send lines to Datadog
         for line in split_data:
             # Create structured object and send it
-            yield reformat_record(line)
+            yield build_message(line)
 
 
 # Handle CloudWatch logs from Kinesis


### PR DESCRIPTION
### What does this PR do?

Reduce the memory consumption by the aws lambda function, mainly when processing gzipped logs.

### Motivation

When reading `.gz` logs, to send back to datadog, multiple in-memory copies of the decompressed data are being made.  This is ok in most cases, but when the compressed files are already large (eg. 100MB+), the lambda function tended to bomb out with Out of Memory exceptions.

Previously, the `s3_handler` would:

1. Read the entire contents of the gzipped file into memory from s3 (not too much choice here...),
2. Open a `gzip.GzipFile` iterator to walk each decompressed line of the file,
3. Immediately join all the lines ("all lines" list, unneeded copy 1) into one big `data` string (unneeded copy 2),
4. For the case of just "Send lines to Datadog", the `data` string is again split back in to a list of lines (unneeded copy 3).

This change tries to eliminate the copies created in steps 3 & 4.

In our local test case, memory usage against a 100MB gzip logfile dropped from approx 3GB (and crashing...) down to 300MB (and completing...).

For the other cases catered for in this handler (`is_cloudtrail` and has a `DD_MULTILINE_LOG_REGEX_PATTERN`), the behaviour remains the same as before.

For the `is_cloudtrail` case, it expects `data` to be a big blob of json to be parsed.
Whereas the multi-line regex check expects many lines in `data`.  So both of these have been left alone for now.

### Additional Notes

`normalize_logs` and `DatadogBatcher.batch` were consuming the log generators they were given and returning full lists (extra copies of all the log data).  Also altered these to be generator functions.  