### PR TITLE
Forward metrics from Lambda logs

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -1,7 +1,6 @@
-# Datadog-lambda
+# Datadog Log Forwarder
 
-
-AWS lambda function to ship ELB, S3, CloudTrail, VPC, CloudFront and CloudWatch logs to Datadog
+AWS Lambda function to ship logs and metrics from ELB, S3, CloudTrail, VPC, CloudFront and CloudWatch logs to Datadog
 
 # Features
 
@@ -12,6 +11,7 @@ AWS lambda function to ship ELB, S3, CloudTrail, VPC, CloudFront and CloudWatch 
 - JSON events providing details about S3 documents forwarded
 - Structured meta-information can be attached to the events
 - Multiline Log Support (S3 Only)
+- Forward custom metrics from Lambda logs
 
 # Quick Start
 
@@ -101,3 +101,17 @@ For S3 logs, there may be some latency between the time a first S3 log file is p
 If there are multiline logs in s3, set `DD_MULTILINE_LOG_REGEX_PATTERN` environment variable to the specified regex pattern to detect for a new log line.
 
 - Example: for multiline logs beginning with pattern `11/10/2014`: `DD_MULTILINE_LOG_REGEX_PATTERN="\d{2}\/\d{2}\/\d{4}"`
+
+## 7. (optional) Forward Metrics from Lambda Logs
+
+If your Lambda function powers a performance-critical task (e.g., a consumer-facing API), you can avoid the added latencies of metric-submitting API calls, by writing custom metrics to CloudWatch Logs using the appropriate Datadog Lambda Layer (e.g., [Lambda Layer for Python](https://github.com/DataDog/datadog-lambda-layer-python)). The log forwarder will automatically detect log entries that contain metrics and forward them to Datadog metric intake.
+
+The [Datadog Lambda Layer for Python 2.7]((https://github.com/DataDog/datadog-lambda-layer-python)) **MUST** be added to the log forwarder Lambda function, to enable metric forwarding. Use the Lambda layer ARN below, and replace `us-east-1` with the actual AWS region where your log forwarder operates.
+
+```
+arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python27:2
+```
+
+**IMPORTANT**
+
+The log forwarder forwards logs by default. If you do NOT use the Datadog log management product, you **MUST** set environment variable `DD_FORWARD_LOG` to `False`, to avoid sending logs to Datadog. The log forwarder will then only forward metrics.

--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -1,4 +1,4 @@
-# Datadog Log Forwarder
+# Datadog Forwarder
 
 AWS Lambda function to ship logs and metrics from ELB, S3, CloudTrail, VPC, CloudFront and CloudWatch logs to Datadog
 
@@ -11,7 +11,7 @@ AWS Lambda function to ship logs and metrics from ELB, S3, CloudTrail, VPC, Clou
 - JSON events providing details about S3 documents forwarded
 - Structured meta-information can be attached to the events
 - Multiline Log Support (S3 Only)
-- Forward custom metrics from Lambda logs
+- Forward custom metrics from logs
 
 # Quick Start
 
@@ -102,16 +102,16 @@ If there are multiline logs in s3, set `DD_MULTILINE_LOG_REGEX_PATTERN` environm
 
 - Example: for multiline logs beginning with pattern `11/10/2014`: `DD_MULTILINE_LOG_REGEX_PATTERN="\d{2}\/\d{2}\/\d{4}"`
 
-## 7. (optional) Forward Metrics from Lambda Logs
+## 7. (optional) Forward Metrics from Logs
 
-If your Lambda function powers a performance-critical task (e.g., a consumer-facing API), you can avoid the added latencies of metric-submitting API calls, by writing custom metrics to CloudWatch Logs using the appropriate Datadog Lambda Layer (e.g., [Lambda Layer for Python](https://github.com/DataDog/datadog-lambda-layer-python)). The log forwarder will automatically detect log entries that contain metrics and forward them to Datadog metric intake.
+For example, if you have a Lambda function that powers a performance-critical task (e.g., a consumer-facing API), you can avoid the added latencies of submitting metric via API calls, by writing custom metrics to CloudWatch Logs using the appropriate Datadog Lambda Layer (e.g., [Lambda Layer for Python](https://github.com/DataDog/datadog-lambda-layer-python)). The log forwarder will automatically detect log entries that contain metrics and forward them to Datadog metric intake.
 
 The [Datadog Lambda Layer for Python 2.7]((https://github.com/DataDog/datadog-lambda-layer-python)) **MUST** be added to the log forwarder Lambda function, to enable metric forwarding. Use the Lambda layer ARN below, and replace `us-east-1` with the actual AWS region where your log forwarder operates.
 
 ```
-arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python27:2
+arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python27:3
 ```
 
 **IMPORTANT**
 
-The log forwarder forwards logs by default. If you do NOT use the Datadog log management product, you **MUST** set environment variable `DD_FORWARD_LOG` to `False`, to avoid sending logs to Datadog. The log forwarder will then only forward metrics.
+The log forwarder **ALWAYS** forwards logs by default. If you do NOT use the Datadog log management product, you **MUST** set environment variable `DD_FORWARD_LOG` to `False`, to avoid sending logs to Datadog. The log forwarder will then only forward metrics.

--- a/aws/logs_monitoring/log-sam-template.yaml
+++ b/aws/logs_monitoring/log-sam-template.yaml
@@ -1,13 +1,15 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
-Description: Pushes logs from S3 and CloudWatch Logs to Datadog.
+Description: Pushes logs and metrics from AWS to Datadog.
 Resources:
   loglambdaddfunction:
     Type: 'AWS::Serverless::Function'
     Properties:
-      Description: Pushes logs from S3 and CloudWatch Logs to Datadog.
+      Description: Pushes logs and metrics from AWS to Datadog.
       Handler: lambda_function.lambda_handler
-      MemorySize: 128
+      MemorySize: 1024
       Runtime: python2.7
-      Timeout: 10
+      Timeout: 120
+      Layers:
+        - !Sub 'arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Python27:2'
     Type: AWS::Serverless::Function


### PR DESCRIPTION
### What does this PR do?

This PR enables the log forwarder to detect metrics in Lambda CloudWatch log groups and forward the metrics through a background thread using Datadog Lambda Layer.

This is the related PR (https://github.com/DataDog/datadog-lambda-layer-python/pull/4) that enables Lambda layer to write metrics to logs.

### Motivation

Forwarding monitoring data from CloudWatch logs to Datadog is the only viable and the AWS-recommended way to collect monitoring data without a performance penalty on customers' Lambda functions.

Need to add this functionality to the existing log forwarder, instead of creating a separate Lambda function, because each CloudWatch log group only support one Lambda subscription and customers often need to forward both logs and metrics.

### Additional Notes

This change is backward-compatible, and existing users can safely upgrade by copy & paste. 