### PR TITLE
[aws/logs_monitoring] Update readme with kinesis support + small clean ups

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -6,6 +6,7 @@ AWS lambda function to ship ELB, S3, CloudTrail, VPC, CloudFront and CloudWatch 
 # Features
 
 - Use AWS Lambda to re-route triggered S3 events to Datadog
+- Use AWS Lambda to re-route triggered Kinesis data stream events to Datadog, only the Cloudwatch logs are supported
 - Cloudwatch, ELB, S3, CloudTrail, VPC and CloudFont logs can be forwarded
 - SSL Security
 - JSON events providing details about S3 documents forwarded

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -119,7 +119,7 @@ class DatadogClient(object):
             try:
                 self._client.send(logs)
                 return
-            except RetriableException as e:
+            except RetriableException:
                 time.sleep(backoff)
                 if backoff < self._max_backoff:
                     backoff *= 2
@@ -167,9 +167,9 @@ class DatadogTCPClient(object):
                 )
             )
             self._sock.sendall(frame.encode("UTF-8"))
-        except ScrubbingException as e:
+        except ScrubbingException:
             raise Exception("could not scrub the payload")
-        except Exception as e:
+        except Exception:
             # most likely a network error, reset the connection
             self._reset()
             raise RetriableException()
@@ -213,9 +213,9 @@ class DatadogHTTPClient(object):
                 data=self._scrubber.scrub(json.dumps(logs)),
                 timeout=self._timeout,
             )
-        except ScrubbingException as e:
+        except ScrubbingException:
             raise Exception("could not scrub the payload")
-        except Exception as e:
+        except Exception:
             # most likely a network error
             raise RetriableException()
         if resp.status_code >= 500:
@@ -305,7 +305,7 @@ class DatadogScrubber(object):
         for rule in self._rules:
             try:
                 payload = rule.regex.sub(rule.placeholder, payload)
-            except Exception as e:
+            except Exception:
                 raise ScrubbingException()
         return payload
 

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -415,7 +415,7 @@ def parse_event_type(event):
             return "s3"
         elif "Sns" in event["Records"][0]:
             return "sns"
-        elif "eventSource" in event["Records"][0] and event["Records"][0]["eventSource"] == "aws:kinesis":
+        elif "kinesis" in event["Records"][0]:
             return "kinesis"
 
     elif "awslogs" in event:


### PR DESCRIPTION
### What does this PR do?

Update the aws/logs_monitoring readme to advertise the support of kinesis data stream.

Clean up:
* unused variables
* kinesis event detection: use the presence of the `kinesis` field in records, see https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html