### PR TITLE
Update Lambda layer version to the latest

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -124,7 +124,7 @@ DD_SOURCE = "ddsource"
 DD_CUSTOM_TAGS = "ddtags"
 DD_SERVICE = "service"
 DD_HOST = "host"
-DD_FORWARDER_VERSION = "1.4.0"
+DD_FORWARDER_VERSION = "1.4.1"
 
 # Pass custom tags as environment variable, ensure comma separated, no trailing comma in envvar!
 DD_TAGS = os.environ.get("DD_TAGS", "")

--- a/aws/logs_monitoring/log-sam-template.yaml
+++ b/aws/logs_monitoring/log-sam-template.yaml
@@ -11,5 +11,5 @@ Resources:
       Runtime: python2.7
       Timeout: 120
       Layers:
-        - !Sub 'arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Python27:2'
+        - !Sub 'arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Python27:3'
     Type: AWS::Serverless::Function


### PR DESCRIPTION
### What does this PR do?

Update Datadog forwarder SAM template to use the latest Lambda layer version.

### Motivation

Update to the latest lambda layer `v3` for [compact log format](https://github.com/DataDog/datadog-lambda-layer-python/blob/master/CHANGELOG.md#v3--2019-06-18).
