### PR TITLE
raises an exception if multiline regex is invalid

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -109,13 +109,16 @@ if not validation_res.ok:
     raise Exception("The API key is not valid.")
 
 
-# DD_MULTILINE_REGEX: Datadog Multiline Log Regular Expression Pattern
+# DD_MULTILINE_LOG_REGEX_PATTERN: Datadog Multiline Log Regular Expression Pattern
 DD_MULTILINE_LOG_REGEX_PATTERN = None
 if "DD_MULTILINE_LOG_REGEX_PATTERN" in os.environ:
     DD_MULTILINE_LOG_REGEX_PATTERN = os.environ["DD_MULTILINE_LOG_REGEX_PATTERN"]
-    multiline_regex = re.compile(
-        "(?<!^)\s+(?={})(?!.\s)".format(DD_MULTILINE_LOG_REGEX_PATTERN)
-    )
+    try:
+        multiline_regex = re.compile(
+            "(?<!^)\s+(?={})(?!.\s)".format(DD_MULTILINE_LOG_REGEX_PATTERN)
+        )
+    except Exception:
+        raise Exception("could not compile multiline regex with pattern: {}".format(DD_MULTILINE_LOG_REGEX_PATTERN))
     multiline_regex_start_pattern = re.compile(
         "^{}".format(DD_MULTILINE_LOG_REGEX_PATTERN)
     )


### PR DESCRIPTION
### What does this PR do?

Raises an exception if the regex passed in with the DD_MULTILINE_LOG_REGEX_PATTERN env var is invalid

### Motivation

Add helpful feedback for users trying to configure multiline aggregation that helps identify what the problem is more than the previous message `module initialization error: unexpected end of pattern`

### Additional Notes

Anything else we should know when reviewing?
