### PR TITLE
Updates parse_service_arn to allow S3 bucket prefix on elb logs

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -758,10 +758,11 @@ def parse_service_arn(source, key, bucket, context):
         # 3. We extract the id of the loadbalancer
         # 4. We build the arn
         idsplit = key.split("/")
-        # If AWSLogs isn't the first element of idsplit, there is a prefix 
+        # If there is a prefix on the S3 bucket, idsplit[1] will be "AWSLogs"
         # Remove the prefix before splitting they key
-        if idsplit[0] != "AWSLogs":
-            keysplit = "/".join(idsplit[1:]).split("_")
+        if len(idsplit) > 1 and idsplit[1] == "AWSLogs":
+            idsplit = idsplit[1:]
+            keysplit = "/".join(idsplit).split("_")
         # If no prefix, split the key
         else:
             keysplit = key.split("_")        

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -757,8 +757,14 @@ def parse_service_arn(source, key, bucket, context):
         # 2. We extract the loadbalancer name and replace the "." by "/" to match the ARN format
         # 3. We extract the id of the loadbalancer
         # 4. We build the arn
-        keysplit = key.split("_")
         idsplit = key.split("/")
+        # If AWSLogs isn't the first element of idsplit, there is a prefix 
+        # Remove the prefix before splitting they key
+        if idsplit[0] != "AWSLogs":
+            keysplit = "/".join(idsplit[1:]).split("_")
+        # If no prefix, split the key
+        else:
+            keysplit = key.split("_")        
         if len(keysplit) > 3:
             region = keysplit[2].lower()
             name = keysplit[3]


### PR DESCRIPTION
### What does this PR do?

Updates the `parse_service_arn` function to accommodate an optional S3 bucket prefix on `source:elb` logs.  

### Motivation

Support ticket.  If the S3 bucket storing elasticloadbalancing logs has a prefix, the host attribute was not constructed properly.

### Additional Notes

The file names of the access logs use the following format ([AWS doc](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html)):

`bucket[/prefix]/AWSLogs/aws-account-id/elasticloadbalancing/region/yyyy/mm/dd/aws-account-id_elasticloadbalancing_region_load-balancer-id_end-time_ip-address_random-string.log.gz
`

where the prefix is optional.

Bucket prefixes can contain underscores.  The logic was updated to handle buckets with prefixes that may or may not include underscores.

Tested with a prefix with underscores, with a prefix without underscores, and without a prefix. 
