### PR TITLE
checks if blobContent isBuffer and if so, converts it to string

### DIFF
--- a/azure/blobs_logs_monitoring/index.js
+++ b/azure/blobs_logs_monitoring/index.js
@@ -44,6 +44,8 @@ module.exports = function(context, blobContent) {
     var logs;
     if (typeof blobContent === 'string') {
         logs = blobContent.trim().split('\n');
+    } else if (Buffer.isBuffer(blobContent)) {
+        logs = blobContent.toString('utf8').trim().split('\n');
     } else {
         logs = JSON.stringify(blobContent).trim().split('\n');
     }


### PR DESCRIPTION
### What does this PR do?

Checks if blobContent isBuffer and converts to string if so

### Motivation

Support Issue.  Logs were coming in as blocks of ascii character codes instead of text because `JSON.stringify(blobContent)` does not properly convert to string if blobContent `isBuffer`. 

### Additional Notes

Anything else we should know when reviewing?
