### PR TITLE
changes multi-line aggregation regex to fix bug

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -140,7 +140,7 @@ if "DD_MULTILINE_LOG_REGEX_PATTERN" in os.environ:
     DD_MULTILINE_LOG_REGEX_PATTERN = os.environ["DD_MULTILINE_LOG_REGEX_PATTERN"]
     try:
         multiline_regex = re.compile(
-            "\n+(?={})".format(DD_MULTILINE_LOG_REGEX_PATTERN)
+            "[\n\r\f]+(?={})".format(DD_MULTILINE_LOG_REGEX_PATTERN)
         )
     except Exception:
         raise Exception("could not compile multiline regex with pattern: {}".format(DD_MULTILINE_LOG_REGEX_PATTERN))

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -140,7 +140,7 @@ if "DD_MULTILINE_LOG_REGEX_PATTERN" in os.environ:
     DD_MULTILINE_LOG_REGEX_PATTERN = os.environ["DD_MULTILINE_LOG_REGEX_PATTERN"]
     try:
         multiline_regex = re.compile(
-            "(?<!^)\s+(?={})(?!.\s)".format(DD_MULTILINE_LOG_REGEX_PATTERN)
+            "\n+(?={})".format(DD_MULTILINE_LOG_REGEX_PATTERN)
         )
     except Exception:
         raise Exception("could not compile multiline regex with pattern: {}".format(DD_MULTILINE_LOG_REGEX_PATTERN))


### PR DESCRIPTION
### What does this PR do?

Changes the multi-line aggregation rule regular expression to fix an aggregation bug where logs could be split incorrectly.  The fix forces the split to happen only when the matched pattern occurs after a newline. 

### Motivation

_Bug Fix_: 
Noticed a situation when the multi-line aggregation rule could fail

### Additional Notes

_Bug Description_:
If you have multi-line regex pattern `my_pattern`, and a log like the following:

```
my_pattern [INFO] [98632] my_pattern random text
1234 - 200 /api/healthcheck
```

Then, the following two logs is created

```
my_pattern [INFO] [98632] 
```

```
my_pattern random text
1234 - 200 /api/healthcheck
```

