### PR TITLE
use SSLcontext.wrap_socket() instead of ssl.wrap_socket()

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -211,7 +211,7 @@ class DatadogTCPClient(object):
 
     def _connect(self):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock = ssl.wrap_socket(sock)
+        sock = ssl.create_default_context().wrap_socket(sock, server_hostname=self.host)
         sock.connect((self.host, self.port))
         self._sock = sock
 


### PR DESCRIPTION
### What does this PR do?

use SSLContext.wrap_socket() instead of ssl.wrap_socket  Since Python 3.2 and 2.7.9, it is recommended to use the SSLContext.wrap_socket() instead of wrap_socket(). The top-level function is limited and creates an insecure  client socket without server name indication or hostname matching.

### Motivation

For users that use the Datadog Lambda function behind a transparent proxy that uses SNI, it is recommended to use the newer library. 

### Additional Notes

Anything else we should know when reviewing?
