### PR TITLE
Trace Forwarding

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -145,7 +145,6 @@ if not validation_res.ok:
 trace_connection = None
 if DD_FORWARD_TRACES:
     trace_connection = TraceConnection("https://trace.agent.{}".format(DD_SITE), DD_API_KEY)
-trace_regex = re.compile(r"^\s*{\s*\"traces\"\s*\:\s*\[")
 
 # DD_MULTILINE_LOG_REGEX_PATTERN: Datadog Multiline Log Regular Expression Pattern
 DD_MULTILINE_LOG_REGEX_PATTERN = None
@@ -387,7 +386,6 @@ class DatadogScrubber(object):
 
 def datadog_forwarder(event, context):
     """The actual lambda function entry point"""
-    global trace_connection
     events = parse(event, context)
     metrics, logs, traces = split(events)
     if DD_FORWARD_LOG:
@@ -480,9 +478,11 @@ def generate_metadata(context):
 def extract_trace(event):
     """Extract traces from an event if possible"""
     try:
+        print(event)
         message = event["message"]
-        if not trace_regex.match(message):
-            return
+        obj = json.loads(event['message'])
+        if not "traces" in obj or not isinstance(obj["traces"], list):
+            return None
         return message
     except Exception:
         return None

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -511,9 +511,9 @@ def split(events):
     for event in events:
         metric = extract_metric(event)
         new_trace = extract_traces(event)
-        if metric:
+        if metric and DD_FORWARD_METRIC:
             metrics.append(metric)
-        elif new_trace:
+        elif new_trace and DD_FORWARD_TRACES:
             traces = traces + [new_trace]
         else:
             logs.append(json.dumps(event))

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -478,7 +478,6 @@ def generate_metadata(context):
 def extract_trace(event):
     """Extract traces from an event if possible"""
     try:
-        print(event)
         message = event["message"]
         obj = json.loads(event['message'])
         if not "traces" in obj or not isinstance(obj["traces"], list):

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -510,11 +510,11 @@ def split(events):
     metrics, logs, traces = [], [], []
     for event in events:
         metric = extract_metric(event)
-        spans = extract_traces(event)
+        new_trace = extract_traces(event)
         if metric:
             metrics.append(metric)
-        elif spans:
-            traces = traces + spans
+        elif new_trace:
+            traces = traces + [new_trace]
         else:
             logs.append(json.dumps(event))
     return metrics, logs, traces

--- a/aws/logs_monitoring/log-sam-template.yaml
+++ b/aws/logs_monitoring/log-sam-template.yaml
@@ -12,4 +12,6 @@ Resources:
       Timeout: 120
       Layers:
         - !Sub 'arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Python27:3'
+        - !Sub 'arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Trace-Forwarder-Python27:1'
+
     Type: AWS::Serverless::Function


### PR DESCRIPTION
### What does this PR do?
Adds experimental trace forwarding support to the log forwarder. More info can be found in the [RFC here](https://github.com/DataDog/architecture/pull/462). Also has an optional dependency on a [new lambda layer](https://github.com/DataDog/datadog-trace-forwarder) which supports trace forwarding + trace obfuscation.

### Motivation

Supporting DataDog tracing in Lambda environments.
