### PR TITLE
Decode DD_API_KEY into UTF-8 

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -108,6 +108,7 @@ if "DD_KMS_API_KEY" in os.environ:
     DD_API_KEY = boto3.client("kms").decrypt(
         CiphertextBlob=base64.b64decode(ENCRYPTED)
     )["Plaintext"]
+    DD_API_KEY = DD_API_KEY.decode("utf-8")
 elif "DD_API_KEY" in os.environ:
     DD_API_KEY = os.environ["DD_API_KEY"]
 

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -108,7 +108,8 @@ if "DD_KMS_API_KEY" in os.environ:
     DD_API_KEY = boto3.client("kms").decrypt(
         CiphertextBlob=base64.b64decode(ENCRYPTED)
     )["Plaintext"]
-    DD_API_KEY = DD_API_KEY.decode("utf-8")
+    if type(DD_API_KEY) is bytes:
+        DD_API_KEY = DD_API_KEY.decode("utf-8")
 elif "DD_API_KEY" in os.environ:
     DD_API_KEY = os.environ["DD_API_KEY"]
 


### PR DESCRIPTION
### What does this PR do?

Seems like python3 fails when using DD_KMS_API_KEY as DD_API_KEY is type bytes. This decodes this into utf-8 if the key is of type bytes.