### PR TITLE
[Lambda]: Add a NO SSL option to disable SSL for TCP and support proxy for HTTP

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -87,7 +87,7 @@ Set the environment variable `DD_SITE` to `datadoghq.eu` and logs are automatica
 
 ### Send logs through a proxy
 
-For TCP, ensure that you disable SSL between the lambda and your proxy by setting `DD_NO_SSL` to `true`
+Ensure that you disable SSL between the lambda and your proxy by setting `DD_NO_SSL` to `true`
  
 Two environment variables can be used to forward logs through a proxy:
 

--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -87,6 +87,8 @@ Set the environment variable `DD_SITE` to `datadoghq.eu` and logs are automatica
 
 ### Send logs through a proxy
 
+For TCP, ensure that you disable SSL between the lambda and your proxy by setting `DD_NO_SSL` to `true`
+ 
 Two environment variables can be used to forward logs through a proxy:
 
 - `DD_URL`: Define the proxy endpoint to forward the logs to

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -65,7 +65,7 @@ DD_FORWARD_LOG = get_bool_env_var("DD_FORWARD_LOG", "true")
 
 ## @param DD_USE_TCP - boolean - optional -default: false
 ## Change this value to `true` to send your logs and metrics using the HTTP network client
-## By default, it use the TCP client.
+## By default, it uses the HTTP client.
 #
 DD_USE_TCP = get_bool_env_var("DD_USE_TCP", "false")
 

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -61,7 +61,7 @@ DD_API_KEY = "<YOUR_DATADOG_API_KEY>"
 ## Set this variable to `False` to disable log forwarding.
 ## E.g., when you only want to forward metrics from logs.
 #
-DD_FORWARD_LOG = get_bool_env_var("DD_FORWARD_LOG", "false")
+DD_FORWARD_LOG = get_bool_env_var("DD_FORWARD_LOG", "true")
 
 ## @param DD_USE_TCP - boolean - optional -default: false
 ## Change this value to `true` to send your logs and metrics using the HTTP network client


### PR DESCRIPTION
### What does this PR do?

- Add a NO_SSL option to the lambda forwarder for TCP proxying
- Support custom host/port for proxy

### Motivation

Enhance proxy support for the logs lambda forwarder

