### PR TITLE
Adds ability to set DD_API_KEY in AWS secrets manager

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -112,7 +112,12 @@ exclude_regex = compileRegex("EXCLUDE_AT_MATCH", EXCLUDE_AT_MATCH)
 
 # DD_API_KEY: Datadog API Key
 DD_API_KEY = "<your_api_key>"
-if "DD_KMS_API_KEY" in os.environ:
+if "DD_API_KEY_SECRET_ARN" in os.environ:
+    SECRET_ARN = os.environ["DD_API_KEY_SECRET_ARN"]
+    DD_API_KEY = boto3.client("secretsmanager").get_secret_value(
+        SecretId=SECRET_ARN
+    )["SecretString"]
+elif "DD_KMS_API_KEY" in os.environ:
     ENCRYPTED = os.environ["DD_KMS_API_KEY"]
     DD_API_KEY = boto3.client("kms").decrypt(
         CiphertextBlob=base64.b64decode(ENCRYPTED)


### PR DESCRIPTION
### What does this PR do?

This allows a new method to set the datadog API key. This would allow you to place the DD_API_KEY as a string within AWS secrets manager and avoid the need to set an environment variable directly and also avoid the need for KMS keys directly. Secrets manager secrets allow more granular permissions control than these other options.
