### PR TITLE
[Don't merge] Add default concurrency limit to SAM template

### DIFF
--- a/aws/logs_monitoring/log-sam-template.yaml
+++ b/aws/logs_monitoring/log-sam-template.yaml
@@ -10,6 +10,7 @@ Resources:
       MemorySize: 1024
       Runtime: python2.7
       Timeout: 120
+      ReservedConcurrentExecutions: 100
       Layers:
         - !Sub 'arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Python27:3'
         - !Sub 'arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Trace-Forwarder-Python27:1'


### PR DESCRIPTION
### What does this PR do?

Adds a default concurrency limit to the SAM configuration used for doing one-click setup of the Lambda log forwarder.

### Motivation

We recommend this in our public docs and is supported in SAM https://github.com/awslabs/serverless-application-model/releases/tag/1.4.0

This prevents the log forwarder from consuming too much account-wide concurrency.

### Additional Notes

I have not tested this yet.
