### PR TITLE
Bump version to 2.2.0 for enhanced lambda metrics

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -201,7 +201,7 @@ DD_SOURCE = "ddsource"
 DD_CUSTOM_TAGS = "ddtags"
 DD_SERVICE = "service"
 DD_HOST = "host"
-DD_FORWARDER_VERSION = "2.1.0"
+DD_FORWARDER_VERSION = "2.2.0"
 
 class RetriableException(Exception):
     pass


### PR DESCRIPTION
### What does this PR do?

Updating the version to 2.2.0 for enhanced Lambda metrics - https://github.com/DataDog/datadog-serverless-functions/pull/159

### Motivation

To avoid a conflict of version numbers

### Additional Notes

Anything else we should know when reviewing?
