### PR TITLE
Remove duplicate key 'Type'

### DIFF
--- a/aws/logs_monitoring/log-sam-template.yaml
+++ b/aws/logs_monitoring/log-sam-template.yaml
@@ -13,5 +13,3 @@ Resources:
       Layers:
         - !Sub 'arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Python27:3'
         - !Sub 'arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Trace-Forwarder-Python27:1'
-
-    Type: AWS::Serverless::Function


### PR DESCRIPTION
### What does this PR do?

Removes the duplicate key `Type` from the SAM template.

### Motivation

Fixes the following error in the IDE: `Key 'Type' is duplicated`