### PR TITLE
Expose serverless application parameters (DD_API_KEY, DD_SITE)

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -74,7 +74,7 @@ def get_bool_env_var(envvar, default):
 ##   * Datadog US Site: https://app.datadoghq.com/account/settings#api
 ##   * Datadog EU Site: https://app.datadoghq.eu/account/settings#api
 #
-DD_API_KEY = "<YOUR_DATADOG_API_KEY>"
+DD_API_KEY = os.getenv("DD_API_KEY", default="<YOUR_DATADOG_API_KEY>")
 
 ## @param DD_FORWARD_LOG - boolean - optional - default: true
 ## Set this variable to `False` to disable log forwarding.

--- a/aws/logs_monitoring/log-sam-template.yaml
+++ b/aws/logs_monitoring/log-sam-template.yaml
@@ -1,6 +1,16 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: Pushes logs and metrics from AWS to Datadog.
+Parameters:
+  DatadogApiKey:
+    Type: 'String'
+    NoEcho: true
+    MinLength: 32
+    MaxLength: 32
+    AllowedPattern: ^[a-fA-F0-9]*$
+  DatadogSite:
+    Type: 'String'
+    Default: 'datadoghq.com'
 Resources:
   loglambdaddfunction:
     Type: 'AWS::Serverless::Function'
@@ -13,5 +23,9 @@ Resources:
       Layers:
         - !Sub 'arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Python27:3'
         - !Sub 'arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Trace-Forwarder-Python27:1'
+      Environment:
+        Variables:
+          DD_API_KEY: !Ref 'DatadogApiKey'
+          DD_SITE: !Ref 'DatadogSite'
 
     Type: AWS::Serverless::Function


### PR DESCRIPTION
### What does this PR do?

Exposes the following parameters for the serverless application:
* `DatadogApiKey` (for environment variable: `DD_API_KEY`)
* `DatadogSite` (for environment variable: `DD_SITE`)

### Motivation

Exposing the API key and site as parameters for the serverless application allows others to use the app without modifications to the Python code.

### Additional Notes

If you like the idea, additional parameters (for example custom tags) could be exposed similarly.