### PR TITLE
Adapt log lambda to latest version of boto3

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -19,7 +19,7 @@ import ssl
 import logging
 from io import BytesIO, BufferedReader
 import time
-from botocore.vendored import requests
+import requests
 
 log = logging.getLogger()
 log.setLevel(logging.getLevelName(os.environ.get("DD_LOG_LEVEL", "INFO").upper()))


### PR DESCRIPTION
### What does this PR do?

Fixes #168

### Motivation

Using the latest version of boto3, log monitoring lambda does not work anymore.

### Additional Notes

This now requires `requests` to be installed, besides `boto3`.