### PR TITLE
Add note for lambda layer now being required

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -1,3 +1,5 @@
+**IMPORTANT NOTE: When upgrading, please ensure your forwarder Lambda function has [the latest Datadog Lambda Layer installed](https://github.com/DataDog/datadog-serverless-functions/tree/master/aws/logs_monitoring#3-add-the-datadog-lambda-layer).**
+
 # Datadog Forwarder
 
 AWS Lambda function to ship logs and metrics from ELB, S3, CloudTrail, VPC, CloudFront, and CloudWatch logs to Datadog
@@ -40,6 +42,13 @@ The [Datadog Lambda Layer]((https://github.com/DataDog/datadog-lambda-layer-pyth
 ```
 arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<PYTHON_RUNTIME>:<VERSION>
 ```
+
+For example:
+
+```
+arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python37:8
+```
+
 
 ### 4. Set your Parameters
 

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -1,3 +1,8 @@
+# IMPORTANT NOTE: When upgrading, please ensure your forwarder Lambda function
+# has the latest Datadog Lambda Layer installed.
+# https://github.com/DataDog/datadog-serverless-functions/tree/master/aws/logs_monitoring#3-add-the-datadog-lambda-layer
+
+
 # Unless explicitly stated otherwise all files in this repository are licensed
 # under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).


### PR DESCRIPTION
### What does this PR do?

Note that the Datadog Lambda Layer is required for the latest version of the forwarder to operate after https://github.com/DataDog/datadog-serverless-functions/pull/170 being merged.