### PR TITLE
Fallback to botocore vendored requests

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -24,10 +24,21 @@ import ssl
 import logging
 from io import BytesIO, BufferedReader
 import time
-import requests
 
 log = logging.getLogger()
 log.setLevel(logging.getLevelName(os.environ.get("DD_LOG_LEVEL", "INFO").upper()))
+
+try:
+    import requests
+except ImportError:
+    log.error(
+        "Could not import the 'requests' package, please ensure the Datadog "
+        "Lambda Layer is installed. https://dtdg.co/forwarder-layer"
+    )
+    # Fallback to the botocore vendored version of requests, while ensuring
+    # customers have the Datadog Lambda Layer installed. The vendored version
+    # of requests is removed in botocore 1.13.x.
+    from botocore.vendored import requests
 
 try:
     from enhanced_lambda_metrics import parse_and_submit_enhanced_metrics


### PR DESCRIPTION
### What does this PR do?

Fallback to the botocore vendored version of requests, while ensuring customers have the Datadog Lambda Layer installed (required after https://github.com/DataDog/datadog-serverless-functions/pull/170 being merged). 

The vendored version of requests is removed in botocore 1.13.x, so the fallback will only work until AWS updates the Lambda Python runtime with the latest boto3 and botocore.