### PR TITLE
[Lambda]: Add DD_SKIP_SSL_VALIDATION option to disable hostname validation for HTTP forwarding

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -181,3 +181,8 @@ If there are multiline logs in s3, set `DD_MULTILINE_LOG_REGEX_PATTERN` environm
 ### 10. (optional) Disable log forwarding
 
 The datadog forwarder **ALWAYS** forwards logs by default. If you do NOT use the Datadog log management product, you **MUST** set environment variable `DD_FORWARD_LOG` to `False`, to avoid sending logs to Datadog. The forwarder will then only forward other observability data, such as metrics.
+
+### 11. (optional) Disable SSL validation
+
+If you need to ignore SSL certificate validation when forwarding logs using HTTPS, you can set the environment variable `DD_SKIP_SSL_VALIDATION` to `True`.
+This will still encrypt the traffic between the forwarder and the endpoint provided with `DD_URL` but will not check if the destination SSL certificate is valid. 

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -255,7 +255,7 @@ DD_SOURCE = "ddsource"
 DD_CUSTOM_TAGS = "ddtags"
 DD_SERVICE = "service"
 DD_HOST = "host"
-DD_FORWARDER_VERSION = "2.3.1"
+DD_FORWARDER_VERSION = "2.3.2"
 
 class RetriableException(Exception):
     pass

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -255,7 +255,7 @@ DD_SOURCE = "ddsource"
 DD_CUSTOM_TAGS = "ddtags"
 DD_SERVICE = "service"
 DD_HOST = "host"
-DD_FORWARDER_VERSION = "2.3.0"
+DD_FORWARDER_VERSION = "2.3.1"
 
 class RetriableException(Exception):
     pass


### PR DESCRIPTION
### What does this PR do?

Provide the DD_SKIP_SSL_VALIDATION option to skip hostname validation for the lambda forwarder.

Requests documentation: https://requests.kennethreitz.org//en/latest/user/advanced/#ssl-cert-verification

### Motivation

This option is provided for specific scenarios such as private link where we can't yet guarantee to provide an endpoint under the logs.datadoghq.com domain

