### PR TITLE
Only add env:none tag to logs if no env tag is set

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -250,7 +250,7 @@ DD_SOURCE = "ddsource"
 DD_CUSTOM_TAGS = "ddtags"
 DD_SERVICE = "service"
 DD_HOST = "host"
-DD_FORWARDER_VERSION = "2.3.0"
+DD_FORWARDER_VERSION = "2.3.1"
 
 class RetriableException(Exception):
     pass

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -822,7 +822,11 @@ def awslogs_handler(event, context, metadata):
                 # Default `env` to `none` and `service` to the function name,
                 # for correlation with the APM env and service.
                 metadata[DD_SERVICE] = function_name
-                metadata[DD_CUSTOM_TAGS] += ",env:none"
+
+                env_tag_exists = metadata[DD_CUSTOM_TAGS].startswith('env:') or ',env:' in metadata[DD_CUSTOM_TAGS]
+                # If there is no env specified, default to env:none
+                if not env_tag_exists:
+                    metadata[DD_CUSTOM_TAGS] += ",env:none"
 
     # Create and send structured logs to Datadog
     for log in logs["logEvents"]:


### PR DESCRIPTION
### What does this PR do?

We had a customer reach out that the env:none tag was being applied to their logs even when they supplied their own env: in the `DD_TAGS` environment variable. This PR checks whether an env: tag exists in the custom tags and only adds env:none if there is no env tag already set.

I tested this using demo Lambdas and it's stopped adding the env:none tag when log forwarders have an env set in DD_TAGS.

