### PR TITLE
Export lambda function ARN

### DIFF
--- a/aws/logs_monitoring/log-sam-template.yaml
+++ b/aws/logs_monitoring/log-sam-template.yaml
@@ -15,3 +15,9 @@ Resources:
         - !Sub 'arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Trace-Forwarder-Python27:1'
 
     Type: AWS::Serverless::Function
+Outputs:
+  LogFunctionArn:
+    Description: Datadog log AWS Lambda arn
+    Value: !GetAtt loglambdaddfunction.Arn
+    Export:
+      Name: !Sub '${AWS::StackName}-LogFunctionArn'


### PR DESCRIPTION
### What does this PR do?

Export the Lambda Function ARN so it can be referenced in other Cloudformation Stacks. For example, you could reference this function in a serverless framework service using the [serverless-plugin-log-subscription](https://serverless.com/plugins/serverless-plugin-log-subscription/)

### Motivation

Reference the function that has been deployed into each AWS account, using the same name.

