### PR TITLE
Changes logic for assigning rds as log source

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -911,14 +911,14 @@ def parse_event_source(event, key):
         "apigateway",
         "route53",
         "vpc",
-        "rds",
+        "/aws/rds",
         "sns",
         "waf",
         "docdb",
         "fargate",
     ]:
         if source in key:
-            return source
+            return source.replace("/aws/", "")
     if "API-Gateway" in key or "ApiGateway" in key:
         return "apigateway"
     if is_cloudtrail(str(key)) or (


### PR DESCRIPTION
### What does this PR do?

Changes the logic for assigning "rds" as a log source to prevent incorrect assignments for cases where the string "rds" is present in a log group name (e.g. "words"), but the log is not an rds log.

### Motivation

Support Case

### Additional Notes

Other short service strings like "vpc", "sns", and "waf" could have similar issues.  