### PR TITLE
Added EXCLUDE_SERVICES environment variable to exclude services/lambda from sending logs to DataDog

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -172,6 +172,9 @@ Use the `EXCLUDE_AT_MATCH` OR `INCLUDE_AT_MATCH` environment variables to filter
 - If a log matches both the inclusion and exclusion criteria, it is excluded.
 - Filtering rules are applied to the full JSON-formatted log, including any metadata that is automatically added by the function.
 
+Use `EXCLUDE_SERVICES` to exclude and not send logs that match a particular lambda
+- To use `EXCLUDE_SERVICES`, add it as an environment variable and set to a list of comma separated strings of service or lambda names you which to exclude.
+
 ### 9. (optional) Multiline Log support for s3
 
 If there are multiline logs in s3, set `DD_MULTILINE_LOG_REGEX_PATTERN` environment variable to the specified regex pattern to detect for a new log line.

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -835,6 +835,13 @@ def awslogs_handler(event, context, metadata):
                 if not env_tag_exists:
                     metadata[DD_CUSTOM_TAGS] += ",env:none"
 
+    # Check for excluded services
+    EXCLUDED_SERVICES = os.getenv("EXCLUDE_SERVICES", default=None)
+    # Convert to list and strip whitespaces
+    EXCLUDED_SERVICES = [x.strip() for x in EXCLUDED_SERVICES.split(',')]
+    # Check if service matches excluded services and returns if match, else continues
+    if (metadata[DD_SERVICE] is not None) and metadata[DD_SERVICE] in EXCLUDED_SERVICES:
+        return
     # Create and send structured logs to Datadog
     for log in logs["logEvents"]:
         yield merge_dicts(log, aws_attributes)


### PR DESCRIPTION
Added EXCLUDE_SERVICES environment variable to allow the exclusion of service from log collection. This can help when you have certain processes you don't need forwarded to DataDog.