### PR TITLE
Don't duplicate functionname tag when triggered by Kinesis

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -551,6 +551,8 @@ def enrich(events):
     for event in events:
         add_metadata_to_lambda_log(event)
 
+    return events
+
 
 def add_metadata_to_lambda_log(event):
     """Mutate log dict to add functionname tag, host, and service from the existing Lambda attribute


### PR DESCRIPTION
### What does this PR do?

Fixes a bug that would happen when the log forwarder was triggered by Kinesis with CloudWatch logs from multiple Lambda functions and all of the logs would get a `functionname:` tag for each of the functions in the Kinesis event batch. 

This PR makes it so that the logs are tagged with only the functionname of the specific function that created the log line.

