### PR TITLE
Update SAM template to use Python 3.8 for Lambda

### DIFF
--- a/aws/logs_monitoring/template.yml
+++ b/aws/logs_monitoring/template.yml
@@ -8,10 +8,8 @@ Resources:
       Description: Pushes logs and metrics from AWS to Datadog.
       Handler: lambda_function.lambda_handler
       MemorySize: 1024
-      Runtime: python2.7
+      Runtime: python3.8
       Timeout: 120
       Layers:
-        - !Sub 'arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Python27:3'
-        - !Sub 'arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Trace-Forwarder-Python27:1'
-
-    Type: AWS::Serverless::Function
+        - !Sub 'arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Python38:11'
+        - !Sub 'arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Trace-Forwarder-Python38:3'


### PR DESCRIPTION
AWS announced that Python 2.7 support for AWS Lambda is deprecated,
therefore this updates the used AWS Lambda runtime for the DataDog
forwarder from Python 2.7 to Python 3.8.

This commit also renames the SAM template from `log-sam-template.yaml`
to `template.yml`, as the latter one is the default template name when
running AWS SAM CLI commands.