### PR TITLE
support for secrets manager on logs monitoring

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -65,7 +65,8 @@ There are 3 possibilities to set your Datadog API key:
 
 1. **KMS Encrypted key (recommended)**: Use the `DD_KMS_API_KEY` environment variable to use a KMS encrypted key. Make sure that the Lambda execution role is listed in the KMS Key user in https://console.aws.amazon.com/iam/home#encryptionKeys.
 2. **Environment Variable**: Use the `DD_API_KEY` environment variable for the Lambda function.
-3. **Manual**: Replace `<YOUR_DATADOG_API_KEY>` in the code:
+3. **Secret Manager**: Use the `DD_API_KEY_SECRET_ARN` environment variable for the Lambda function.
+4. **Manual**: Replace `<YOUR_DATADOG_API_KEY>` in the code:
 
   ```python
   ## @param DD_API_KEY - String - required - default: none

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -203,6 +203,9 @@ if "DD_KMS_API_KEY" in os.environ:
         DD_API_KEY = DD_API_KEY.decode("utf-8")
 elif "DD_API_KEY" in os.environ:
     DD_API_KEY = os.environ["DD_API_KEY"]
+elif "DD_API_KEY_SECRET_ARN" in os.environ:
+    RESPONSE = boto3.client("secretsmanager")       
+    DD_API_KEY = RESPONSE.get_secret_value(SecretId=os.environ["DD_API_KEY_SECRET_ARN"]).get('SecretString')
 
 # Strip any trailing and leading whitespace from the API key
 DD_API_KEY = DD_API_KEY.strip()


### PR DESCRIPTION


### What does this PR do?

A condition is added to get Datadog Api Key from secrets manager using environment variable DD_API_KEY_SECRET_ARN.

### Motivation

Lambda layer which needs to be implemented with this lambda function already contains this feature. I was using this code for a project and got stuck for a day because we were using AWS Secrets Manager.  
