### PR TITLE
Update rds_regex in AWS log forwarder to correctly support serverless clusters

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -249,7 +249,7 @@ if "DD_MULTILINE_LOG_REGEX_PATTERN" in os.environ:
         "^{}".format(DD_MULTILINE_LOG_REGEX_PATTERN)
     )
 
-rds_regex = re.compile("/aws/rds/instance/(?P<host>[^/]+)/(?P<name>[^/]+)")
+rds_regex = re.compile("/aws/rds/(instance|cluster)/(?P<host>[^/]+)/(?P<name>[^/]+)")
 
 DD_SOURCE = "ddsource"
 DD_CUSTOM_TAGS = "ddtags"

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -255,7 +255,7 @@ DD_SOURCE = "ddsource"
 DD_CUSTOM_TAGS = "ddtags"
 DD_SERVICE = "service"
 DD_HOST = "host"
-DD_FORWARDER_VERSION = "2.3.3"
+DD_FORWARDER_VERSION = "2.3.4"
 
 class RetriableException(Exception):
     pass


### PR DESCRIPTION
### What does this PR do?

Modifies the rds_regex to properly match the log group names for RDS aurora serverless clusters.
For serverless clusters, the log groups are named as:
/aws/rds/cluster/<cluster_name>/postgresql

And for RDS instances, they are named as:
/aws/rds/instance/<instance_name>/postgresql

### Motivation

After creating some aurora serverless clusters, I noticed that
the "host" property was missing in datadog logs.

### Additional Notes

Not sure if this is the best fix for this issue, but updating the regex seems to have fixed it.
