### PR TITLE
[Lambda]: Upgrade forwarder version to 2.4.0

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -269,7 +269,7 @@ DD_SOURCE = "ddsource"
 DD_CUSTOM_TAGS = "ddtags"
 DD_SERVICE = "service"
 DD_HOST = "host"
-DD_FORWARDER_VERSION = "2.3.4"
+DD_FORWARDER_VERSION = "2.4.0"
 
 class RetriableException(Exception):
     pass


### PR DESCRIPTION
### What does this PR do?

Upgrade aws log forwarder to 2.4.0 with compression support
