### PR TITLE
Allowing "api-gateway" string to configure source

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -979,7 +979,7 @@ def parse_event_source(event, key):
     ]:
         if source in key:
             return source.replace("/aws/", "")
-    if "API-Gateway" in key or "ApiGateway" in key:
+    if "api-gateway" in key.lower() or "apigateway" in key.lower():
         return "apigateway"
     if is_cloudtrail(str(key)) or (
         "logGroup" in event and event["logGroup"] == "CloudTrail"


### PR DESCRIPTION
### What does this PR do?

This PR allows CloudWatch Groups such as "/aws/api-gateway" to be parsed under the "apigateway" source reserved attribute.

I am lower-casing `key` twice which might not be the most efficient implementation. Happy to consider alternatives from the maintainers!

### Motivation

"/aws/api-gateway" is the prefix used for Serverless Framework, and they currently do not allow developers using this framework to modify the prefix.

### Additional Notes

Reference https://help.datadoghq.com/hc/requests/296110 for an ongoing discussion with Datadog support about this.

Reference https://github.com/serverless/serverless/issues/6094 for the Serverless framework discussion.