### PR TITLE
Darcy.rayner/fix metrics api key whitespace

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -234,6 +234,11 @@ elif "DD_API_KEY" in os.environ:
 DD_API_KEY = DD_API_KEY.strip()
 os.environ["DD_API_KEY"] = DD_API_KEY
 
+# Force the layer to use the exact same API key as the forwarder
+if DD_FORWARD_METRIC:
+    from datadog import api
+    api._api_key = DD_API_KEY
+
 # DD_API_KEY must be set
 if DD_API_KEY == "<YOUR_DATADOG_API_KEY>" or DD_API_KEY == "":
     raise Exception(

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -232,6 +232,7 @@ elif "DD_API_KEY" in os.environ:
 
 # Strip any trailing and leading whitespace from the API key
 DD_API_KEY = DD_API_KEY.strip()
+os.environ["DD_API_KEY"] = DD_API_KEY
 
 # DD_API_KEY must be set
 if DD_API_KEY == "<YOUR_DATADOG_API_KEY>" or DD_API_KEY == "":

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -248,7 +248,7 @@ Resources:
             - { DdForwarderVersion: !FindInMap [Constants, DdForwarder, Version] }
       Layers:
       - Fn::Sub: arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Python37:11
-      - Fn::Sub: arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Trace-Forwarder-Python37:3
+      - Fn::Sub: arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Trace-Forwarder-Python37:4
       Tags:
         dd_forwarder_version: !FindInMap [Constants, DdForwarder, Version]
       Environment:


### PR DESCRIPTION
### What does this PR do?

Fixes issue with metric submission, where API key determined by forwarder is not identical to API key determined by layer. This was resulting is situations where log/trace forwarding worked, but metric submission was failing, (eg, in the case where there was whitespace at the start/beginning of the API key).
