### PR TITLE
[PROD] Update RDS func to deal with empty name tag

### DIFF
--- a/aws/rds_enhanced_monitoring/lambda_function.py
+++ b/aws/rds_enhanced_monitoring/lambda_function.py
@@ -97,7 +97,11 @@ def _process_rds_enhanced_monitoring_message(ts, message, account, region):
         fs_tag = []
         for tag_key in ["name", "mountPoint"]:
             if tag_key in fs_stats:
-                fs_tag.append("%s:%s" % (tag_key, fs_stats.pop(tag_key)))
+                tag_value = fs_stats.pop(tag_key)
+                if tag_value == '':
+                    continue
+                else: 
+                    fs_tag.append("%s:%s" % (tag_key, tag_value))
         for key, value in fs_stats.iteritems():
             stats.gauge(
                 'aws.rds.filesystem.%s' % key, value,


### PR DESCRIPTION
Currently filesystem metrics -> aws.rds.filesystem.* metrics are being tagged with an empty 'name:' tag. 
This happens because we are trying to parse the name key's value from the "fileSys" section of the log event, but it has an empty values as seen here: https://a.cl.ly/v1um7p1z which results in an empty tag like this: https://a.cl.ly/WnuEgNNn
I think my change will not add the `name` tag if it has an empty value.

### What does this PR do?

Change the function to collect fileSys metrics to deal with an empty `name:` tag issue. 

### Motivation

Customer reached out to us about this, we have an issue on the support board.

### Additional Notes

Anything else we should know when reviewing?
