### PR TITLE
Add codebuild to list of known AWS service sources

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -771,7 +771,7 @@ def forward_metrics(metrics):
 
 def forward_traces(traces):
     for trace in traces:
-        try:   
+        try:
             trace_connection.send_trace(trace)
         except Exception:
             log.exception(f"Exception while forwarding trace {trace}")
@@ -1013,6 +1013,7 @@ def parse_event_source(event, key):
     if "elasticloadbalancing" in key:
         return "elb"
     for source in [
+        "codebuild",
         "lambda",
         "redshift",
         "cloudfront",


### PR DESCRIPTION
This is a fix for #202.  As per the discussion in that thread this does not include `eks`
