### PR TITLE
Add Lambda tags to logs, traces and all metrics

### DIFF
--- a/aws/logs_monitoring/enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/enhanced_lambda_metrics.py
@@ -420,3 +420,14 @@ def calculate_estimated_cost(billed_duration_ms, memory_allocated):
     gb_seconds = (billed_duration_ms / 1000.0) * (memory_allocated / 1024.0)
 
     return BASE_LAMBDA_INVOCATION_PRICE + gb_seconds * LAMBDA_PRICE_PER_GB_SECOND
+
+def get_enriched_lambda_log_tags(log):
+    '''
+    Retrieves extra tags from lambda, either read from the function arn, or by fetching lambda tags from the function itself.
+    '''
+    log_function_arn = log.get("lambda", {}).get("arn")
+    if not log_function_arn:
+        return []
+    tags_from_arn = parse_lambda_tags_from_arn(log_function_arn)
+    lambda_custom_tags = account_lambda_tags_cache.get(log_function_arn)
+    return tags_from_arn + lambda_custom_tags 

--- a/aws/logs_monitoring/enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/enhanced_lambda_metrics.py
@@ -422,9 +422,11 @@ def calculate_estimated_cost(billed_duration_ms, memory_allocated):
     return BASE_LAMBDA_INVOCATION_PRICE + gb_seconds * LAMBDA_PRICE_PER_GB_SECOND
 
 def get_enriched_lambda_log_tags(log):
-    '''
-    Retrieves extra tags from lambda, either read from the function arn, or by fetching lambda tags from the function itself.
-    '''
+    """ Retrieves extra tags from lambda, either read from the function arn, or by fetching lambda tags from the function itself.
+
+    Args:
+        log (dict<str, str | dict | int>): a log parsed from the event in the split method
+    """
     log_function_arn = log.get("lambda", {}).get("arn")
     if not log_function_arn:
         return []

--- a/aws/logs_monitoring/enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/enhanced_lambda_metrics.py
@@ -430,4 +430,4 @@ def get_enriched_lambda_log_tags(log):
         return []
     tags_from_arn = parse_lambda_tags_from_arn(log_function_arn)
     lambda_custom_tags = account_lambda_tags_cache.get(log_function_arn)
-    return tags_from_arn + lambda_custom_tags 
+    return list(set(tags_from_arn + lambda_custom_tags))

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -37,16 +37,16 @@ except ImportError:
 
 try:
     from enhanced_lambda_metrics import get_enriched_lambda_log_tags,parse_and_submit_enhanced_metrics
-    DD_ENHANCED_LAMBDA_METRICS = True
+    IS_ENHANCED_METRICS_FILE_PRESENT = True
 except ImportError:
-    DD_ENHANCED_LAMBDA_METRICS = False
+    IS_ENHANCED_METRICS_FILE_PRESENT = False
     log.warn(
         "Could not import from enhanced_lambda_metrics so enhanced metrics "
         "will not be submitted. Ensure you've included the enhanced_lambda_metrics "
         "file in your Lambda project."
     )
 finally:
-    log.debug(f"DD_ENHANCED_LAMBDA_METRICS: {DD_ENHANCED_LAMBDA_METRICS}")
+    log.debug(f"IS_ENHANCED_METRICS_FILE_PRESENT: {IS_ENHANCED_METRICS_FILE_PRESENT}")
 
 
 try:
@@ -556,7 +556,7 @@ def datadog_forwarder(event, context):
     if DD_FORWARD_TRACES and len(traces) > 0:
         forward_traces(traces)
 
-    if DD_ENHANCED_LAMBDA_METRICS:
+    if IS_ENHANCED_METRICS_FILE_PRESENT:
         report_logs = filter(
             lambda log: log.get("message", "").startswith("REPORT"), logs
         )
@@ -656,7 +656,7 @@ def add_metadata_to_lambda_log(event):
 
 
     # Add any enhanced tags from metadata
-    if DD_ENHANCED_LAMBDA_METRICS:
+    if IS_ENHANCED_METRICS_FILE_PRESENT:
         tags += get_enriched_lambda_log_tags(event)
     
     # Dedup tags, so we don't end up with functionname twice

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -665,7 +665,6 @@ def add_metadata_to_lambda_log(event):
     event[DD_CUSTOM_TAGS] = ",".join([event[DD_CUSTOM_TAGS]] + tags)
 
 
-
 def generate_metadata(context):
     metadata = {
         "ddsourcecategory": "aws",
@@ -787,7 +786,6 @@ def forward_metrics(metrics):
 def forward_traces(traces):
     for trace in traces:
         try:
-            log.debug("Trace tags are" + trace["tags"])
             trace_connection.send_trace(trace["message"], trace["tags"])
         except Exception:
             log.exception(f"Exception while forwarding trace {trace}")

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -650,12 +650,20 @@ def add_metadata_to_lambda_log(event):
     function_name = lambda_log_arn.split(':')[6]
 
     event[DD_HOST] = lambda_log_arn
-    event[DD_CUSTOM_TAGS] = "{},functionname:{}".format(event[DD_CUSTOM_TAGS], function_name)
     event[DD_SERVICE] = function_name
+
+    tags = ['functionname:{}'.format(function_name)]
+
 
     # Add any enhanced tags from metadata
     if DD_ENHANCED_LAMBDA_METRICS:
-        event[DD_CUSTOM_TAGS] += ','+','.join(get_enriched_lambda_log_tags(event))
+        tags += get_enriched_lambda_log_tags(event)
+    
+    # Dedup tags, so we don't end up with functionname twice
+    tags = list(set(tags))
+
+    event[DD_CUSTOM_TAGS] = ",".join([event[DD_CUSTOM_TAGS]] + tags)
+
 
 
 def generate_metadata(context):

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -52,7 +52,7 @@ Parameters:
     AllowedValues:
       - true
       - false
-    Description: Let the forwarder fetch Lambda tags using GetResources API calls and apply them to the aws.lambda.enhanced.* metrics parsed from the REPORT log. If set to true, permission tag:GetResources will be automatically added to the Lambda execution IAM role. The tags are cached in memory so that they'll only be fetched when the function cold starts or when the TTL (1 hour) expires. The forwarder increments the aws.lambda.enhanced.get_resources_api_calls metric for each API call made.
+    Description: Let the forwarder fetch Lambda tags using GetResources API calls and apply them to logs, metrics and traces. If set to true, permission tag:GetResources will be automatically added to the Lambda execution IAM role. The tags are cached in memory so that they'll only be fetched when the function cold starts or when the TTL (1 hour) expires. The forwarder increments the aws.lambda.enhanced.get_resources_api_calls metric for each API call made.
   DdUseTcp:
     Type: String
     Default: false

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -248,7 +248,7 @@ Resources:
             - { DdForwarderVersion: !FindInMap [Constants, DdForwarder, Version] }
       Layers:
       - Fn::Sub: arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Python37:11
-      - Fn::Sub: arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Trace-Forwarder-Python37:4
+      - Fn::Sub: arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Trace-Forwarder-Python37:5
       Tags:
         dd_forwarder_version: !FindInMap [Constants, DdForwarder, Version]
       Environment:


### PR DESCRIPTION
### What does this PR do?

When DD_FETCH_LAMBDA_TAGS is true and the forwarder has tags:GetResource permissions, enrich logs/traces/metrics with those tags. Previously only enhanced metrics were enriched.
