### PR TITLE
[Lambda]: Use default context for SSL

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -366,7 +366,7 @@ class DatadogTCPClient(object):
     def _connect(self):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         if self._use_ssl:
-            sock = ssl.wrap_socket(sock)
+            sock = ssl.create_default_context().wrap_socket(sock, server_hostname=self.host)
         sock.connect((self.host, self.port))
         self._sock = sock
 
@@ -658,7 +658,7 @@ def add_metadata_to_lambda_log(event):
     # Add any enhanced tags from metadata
     if IS_ENHANCED_METRICS_FILE_PRESENT:
         tags += get_enriched_lambda_log_tags(event)
-    
+
     # Dedup tags, so we don't end up with functionname twice
     tags = list(set(tags))
 


### PR DESCRIPTION
### What does this PR do?

Get the contribution from https://github.com/DataDog/datadog-serverless-functions/pull/147/files in

### Motivation

Use the recommended SSLContext.wrap_socket()
