### PR TITLE
update sns handler to handle s3 events when s3 events arrive vs sns

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -984,6 +984,7 @@ def cwevent_handler(event, metadata):
 
 # Handle Sns events
 def sns_handler(event, context, metadata):
+    data = event
     # test if sns payload contains an s3 event
     try:
         event = json.loads(event['Records'][0]['Sns']['Message'])
@@ -994,7 +995,6 @@ def sns_handler(event, context, metadata):
     except json.decoder.JSONDecodeError:
         pass
 
-    data = event
     # Set the source on the log
     metadata[DD_SOURCE] = parse_event_source(event, "sns")
 

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -996,7 +996,7 @@ def sns_handler(event, context, metadata):
         pass
 
     # Set the source on the log
-    metadata[DD_SOURCE] = parse_event_source(event, "sns")
+    metadata[DD_SOURCE] = parse_event_source(data, "sns")
 
     for ev in data["Records"]:
         # Create structured object and send it


### PR DESCRIPTION
### What does this PR do?

This small update allows the function to handle S3 events when they come via SNS. E.g. you have S3 events going to SNS instead of Lambda directly because you need to have multiple Lambda subscribers for the S3 event.

### Motivation

https://github.com/DataDog/datadog-serverless-functions/issues/114

### Additional Notes

Anything else we should know when reviewing?
This works for me, it could fail is someone was sending an event through SNS that looked a lot like an S3 object or if they wanted to just log the S3 Event itself.