### PR TITLE
Make DdSite a text field instead of dropdown

### DIFF
--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -14,10 +14,7 @@ Parameters:
   DdSite:
     Type: String
     Default: datadoghq.com
-    AllowedValues:
-      - datadoghq.com
-      - datadoghq.eu
-    Description: Define your Datadog Site to send data to -- select datadoghq.com for the Datadog US site or datadoghq.eu for the Datadog EU site.
+    Description: Define your Datadog Site to send data to. For the Datadog EU site, set to datadoghq.eu
   FunctionName:
     Type: String
     Default: DatadogForwarder


### PR DESCRIPTION
### What does this PR do?

Make `DdSite` a text input field instead of a dropdown, so it's possible to set a custom value for special use cases.
