### PR TITLE
Add dms to list of recognized log sources

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -1027,6 +1027,7 @@ def parse_event_source(event, key):
     if "elasticloadbalancing" in key:
         return "elb"
     for source in [
+        "dms",
         "codebuild",
         "lambda",
         "redshift",


### PR DESCRIPTION
### What does this PR do?

This add Database Migration Service (aka dms) to the list of recognized sources.

### Motivation

Currently our DMS log messages are being miscategorized as 'aws' since that's the default category, but we also see them categorized as other services if the name of that service happens to be in the replication instance name.

FWIW, this is what a DMS log event looks like (lightly sanitized to remove private details):

```
{
    'messageType': 'DATA_MESSAGE', 
    'owner': '<aws account id>', 
    'logGroup': 'dms-tasks-<replication instance name>', 
    'logStream': 'dms-task-<replication task id>', 
    'subscriptionFilters': [
        'datadog-log-forwarder'
    ], 
    'logEvents': [
        {
            'id': '<id>', 
            'timestamp': 1582842521000, 
            'message': '2020-02-27T22:28:41 [TARGET_APPLY ]I: <message>'
        }
    ]
}
```