### PR TITLE
Set DD_ENHANCED_METRICS to false on the Forwarder

### DIFF
--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -259,6 +259,7 @@ Resources:
         dd_forwarder_version: !FindInMap [Constants, DdForwarder, Version]
       Environment:
         Variables:
+          DD_ENHANCED_METRICS: false
           DD_API_KEY_SECRET_ARN:
             Ref: DdApiKeySecret
           DD_SITE:


### PR DESCRIPTION
### What does this PR do?

Set DD_ENHANCED_METRICS to false on the Forwarder to avoid unnecessarily generate enhanced metrics for the forwarder Lambda function.