### PR TITLE
Fixes #207 by allowing CloudWatch Logs & S3 to invoke the Forwarder

### DIFF
--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -382,6 +382,20 @@ Resources:
                   - tag:GetResources
                 Resource: "*"
               - Ref: AWS::NoValue
+  CloudWatchLogsPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref "Forwarder"
+      Action: lambda:InvokeFunction
+      Principal: !Sub "logs.${AWS::Region}.amazonaws.com"
+      SourceAccount: !Ref "AWS::AccountId"
+  S3Permission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref "Forwarder"
+      Action: lambda:InvokeFunction
+      Principal: "s3.amazonaws.com"
+      SourceAccount: !Ref "AWS::AccountId"
   LogGroup:
     Type: AWS::Logs::LogGroup
     Properties:


### PR DESCRIPTION
### What does this PR do?

fixes #207 

### Motivation

We cannot add a separate (or update an existing) `SubscriptionFilter` in order to forward logs from API Gateway etc. to trigger the `Forwarder` lambda using a CloudWatch Log Group.

Error message in the AWS Console:
```
Could not execute the lambda function. Make sure you have given CloudWatch Logs permission to execute your function.
```

### Additional Notes

This PR allows CloudWatch Logs and S3 to trigger the `Forwarder` lambda.

### Checklist

- [x] Member of the datadog team has run integration tests
