### PR TITLE
Add aws_account tag to enhanced metrics and Lambda logs

### DIFF
--- a/aws/logs_monitoring/enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/enhanced_lambda_metrics.py
@@ -341,7 +341,7 @@ def generate_enhanced_lambda_metrics(log, tags_cache):
     return parsed_metrics
 
 
-def parse_lambda_tags_from_arn(arn, aws_account_tag=False):
+def parse_lambda_tags_from_arn(arn):
     """Generate the list of lambda tags based on the data in the arn
 
     Args:

--- a/aws/logs_monitoring/enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/enhanced_lambda_metrics.py
@@ -341,7 +341,7 @@ def generate_enhanced_lambda_metrics(log, tags_cache):
     return parsed_metrics
 
 
-def parse_lambda_tags_from_arn(arn):
+def parse_lambda_tags_from_arn(arn, aws_account_tag=False):
     """Generate the list of lambda tags based on the data in the arn
 
     Args:
@@ -360,6 +360,8 @@ def parse_lambda_tags_from_arn(arn):
     return [
         "region:{}".format(region),
         "account_id:{}".format(account_id),
+        # Include the aws_account tag to match the aws.lambda CloudWatch metrics
+        "aws_account:{}".format(account_id),
         "functionname:{}".format(function_name),
     ]
 
@@ -435,5 +437,4 @@ def get_enriched_lambda_log_tags(log):
     lambda_custom_tags = account_lambda_tags_cache.get(log_function_arn)
     # Combine and dedup tags
     tags = list(set(tags_from_arn + lambda_custom_tags))
-    tags.sort()
     return tags

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -645,7 +645,11 @@ def enrich(events):
 
 
 def add_metadata_to_lambda_log(event):
-    """Mutate log dict to add functionname tag, host, and service from the existing Lambda attribute
+    """Mutate log dict to add tags, host, and service metadata
+
+    * tags for functionname, aws_account, region
+    * host from the Lambda ARN
+    * service from the Lambda name
 
     If the event arg is not a Lambda log then this returns without doing anything
 

--- a/aws/logs_monitoring/tests/snapshots/cloudwatch_log.json~snapshot
+++ b/aws/logs_monitoring/tests/snapshots/cloudwatch_log.json~snapshot
@@ -19,7 +19,7 @@
             "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.2.0",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.3.0",
           "ddsource": "cloudwatch",
           "service": "cloudwatch",
           "host": "testLogGroup"
@@ -38,7 +38,7 @@
             "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.2.0",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.3.0",
           "ddsource": "cloudwatch",
           "service": "cloudwatch",
           "host": "testLogGroup"

--- a/aws/logs_monitoring/tests/snapshots/cloudwatch_log_lambda_invocation.json~snapshot
+++ b/aws/logs_monitoring/tests/snapshots/cloudwatch_log_lambda_invocation.json~snapshot
@@ -22,7 +22,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.2.0,env:none,account_id:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.3.0,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -44,7 +44,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.2.0,env:none,account_id:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.3.0,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -66,7 +66,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.2.0,env:none,account_id:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.3.0,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -88,7 +88,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.2.0,env:none,account_id:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.3.0,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -110,7 +110,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.2.0,env:none,account_id:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.3.0,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -132,7 +132,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.2.0,env:none,account_id:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.3.0,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -154,7 +154,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.2.0,env:none,account_id:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.3.0,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -176,7 +176,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.2.0,env:none,account_id:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.3.0,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -198,7 +198,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.2.0,env:none,account_id:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.3.0,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -220,7 +220,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.2.0,env:none,account_id:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.3.0,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -242,7 +242,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.2.0,env:none,account_id:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.3.0,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -264,7 +264,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.2.0,env:none,account_id:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.3.0,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -286,7 +286,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.2.0,env:none,account_id:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.3.0,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -308,7 +308,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.2.0,env:none,account_id:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.3.0,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -330,7 +330,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.2.0,env:none,account_id:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.3.0,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -352,7 +352,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.2.0,env:none,account_id:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.3.0,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"


### PR DESCRIPTION
### What does this PR do?
Adds the aws_account tag to enhanced metrics and Lambda logs to match how we tag CloudWatch aws.lambda metrics.

The logs and metrics are currently being tagged with account_id only, which causes issues when trying to pivot from the graphs at the top of the serverless detail page to the Lambda's logs - because the metrics are tagged with aws_account and the logs are not, the `View related logs` link returns no results.

### Checklist

- [x] Member of the datadog team has run integration tests
