### PR TITLE
Bump version from 3.3.0 to 3.4.0

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -321,7 +321,7 @@ DD_SOURCE = "ddsource"
 DD_CUSTOM_TAGS = "ddtags"
 DD_SERVICE = "service"
 DD_HOST = "host"
-DD_FORWARDER_VERSION = "3.3.0"
+DD_FORWARDER_VERSION = "3.4.0"
 
 
 class RetriableException(Exception):


### PR DESCRIPTION
### What does this PR do?

Bumps version for the changes in https://github.com/DataDog/datadog-serverless-functions/pull/228