### PR TITLE
Update "extractResourceId" function

### DIFF
--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -135,22 +135,31 @@ function extractResourceId(record) {
     metadata = { tags: [], source: '' };
     if (
         record.resourceId === undefined ||
-        typeof record.resourceId !== 'string' ||
-        !record.resourceId.toLowerCase().startsWith('/subscriptions/')
+        typeof record.resourceId !== 'string'
     ) {
         return metadata;
     }
-    var resourceId = record.resourceId.toLowerCase().split('/');
-    if (resourceId.length > 2) {
-        metadata.tags.push('subscription_id:' + resourceId[2]);
+    else if(record.resourceId.toLowerCase().startsWith('/subscriptions/')){
+      var resourceId = record.resourceId.toLowerCase().split('/');
+      if (resourceId.length > 2) {
+          metadata.tags.push('subscription_id:' + resourceId[2]);
+      }
+      if (resourceId.length > 4) {
+          metadata.tags.push('resource_group:' + resourceId[4]);
+      }
+      if (resourceId.length > 6 && resourceId[6]) {
+          metadata.source = resourceId[6].replace('microsoft.', 'azure.');
+      }
+      return metadata;
     }
-    if (resourceId.length > 4) {
-        metadata.tags.push('resource_group:' + resourceId[4]);
+    else if(record.resourceId.toLowerCase().startsWith('/tenants/')){
+      var resourceId = record.resourceId.toLowerCase().split('/');
+      if (resourceId.length > 2 && resourceId[4]) {
+          metadata.tags.push('tenant:' + resourceId[2]);
+          metadata.source = resourceId[4].replace('microsoft.', 'azure.').replace('aadiam', 'active_directory');
+      }
+      return metadata;
     }
-    if (resourceId.length > 6 && resourceId[6]) {
-        metadata.source = resourceId[6].replace('microsoft.', 'azure.');
-    }
-    return metadata;
 }
 
 module.exports.forTests = {

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -154,7 +154,7 @@ function extractResourceId(record) {
     }
     else if(record.resourceId.toLowerCase().startsWith('/tenants/')){
       var resourceId = record.resourceId.toLowerCase().split('/');
-      if (resourceId.length > 2 && resourceId[4]) {
+      if (resourceId.length > 4 && resourceId[4]) {
           metadata.tags.push('tenant:' + resourceId[2]);
           metadata.source = resourceId[4].replace('microsoft.', 'azure.').replace('aadiam', 'activedirectory');
       }

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -156,7 +156,7 @@ function extractResourceId(record) {
       var resourceId = record.resourceId.toLowerCase().split('/');
       if (resourceId.length > 2 && resourceId[4]) {
           metadata.tags.push('tenant:' + resourceId[2]);
-          metadata.source = resourceId[4].replace('microsoft.', 'azure.').replace('aadiam', 'active_directory');
+          metadata.source = resourceId[4].replace('microsoft.', 'azure.').replace('aadiam', 'activedirectory');
       }
       return metadata;
     }


### PR DESCRIPTION

### What does this PR do?
This extends "extractResourceId" function to extract "source" tag from applications that are deployed at Tenant level.

The existing behavior is to discard all resourceId that don't begin with "/subscriptions/" thus it doesn't handle Tenant level resourceId that begin with "/tenants/".

Adds a else if block to handle resourceIds with Tenant level deployemnts(Like Active Directory)

I have kept the source and tag extraction logic similar to what currently exists.

A brief description of the change being made with this pull request.

### Motivation

Currently we don't get the "source" tag for Azure Active Directory thus making it not possible to ship logs integration pipeline and security rules for the integration. 

### Additional Notes

@steveharrington1 for additional context on the Azure integrations side.

### Checklist

- [ ] Member of the datadog team has run integration tests
