### PR TITLE
fix sanitize tags rule in order to accept hyphens characters

### DIFF
--- a/aws/logs_monitoring/enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/enhanced_lambda_metrics.py
@@ -174,7 +174,7 @@ def should_fetch_custom_tags():
 def sanitize_aws_tag_string(raw_string):
     """Convert characters banned from DD but allowed in AWS tags to underscores
     """
-    return re.sub(r"[\+\-=\.:/@]", "_", raw_string)
+    return re.sub(r"[\+=\.:/@]", "_", raw_string)
 
 
 def get_dd_tag_string_from_aws_dict(aws_key_value_tag_dict):


### PR DESCRIPTION
### What does this PR do?

This PR will just accept tags with hyphen instead of replacing them

### Motivation

Currently, the hyphen character in tags are replaced by an underscore. Which cause many issues on our side, because the ec2 hosts accept the hyphen so there is no more correlation between our lambda logs and our ec2 logs.

The datadog support gave me the following answer 

> Essentially, in the 
enhanced_lambda_metrics.py script we have some logic to convert some illegal characters to underscores and hyphens have been incorrectly added to this rule. Our legal characters are listed in our documentation[1] and hold true for tags from Lambda also with the exception of colons. I have since flagged this with our Product & Engineering team and they are working on fixing this rule as we speak. 

### Checklist

- [ ] Member of the datadog team has run integration tests
