### PR TITLE
Use latest cfn-lint

### DIFF
--- a/.github/workflows/cfn-lint.yml
+++ b/.github/workflows/cfn-lint.yml
@@ -11,6 +11,6 @@ jobs:
       uses: actions/checkout@v2
 
     - name: cfn-lint
-      uses: docker://scottbrenner/cfn-lint-action:latest
+      uses: scottbrenner/cfn-lint-action@master
       with:
         args: "aws/logs_monitoring/template.yaml"


### PR DESCRIPTION
### What does this PR do?

Similar to https://github.com/DataDog/cloudformation-template/pull/7, use the latest cfn-lint.

### Checklist

- [x] Member of the datadog team has run integration tests
