### PR TITLE
Fix enhanced metric tag conversion

### DIFF
--- a/aws/logs_monitoring/enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/enhanced_lambda_metrics.py
@@ -188,7 +188,7 @@ def convert_camel_case_to_underscore(string):
     return AllCapRe.sub(r"\1_\2", string).lower()
 
 
-def sanitize_aws_tag_string(tag):
+def sanitize_aws_tag_string(tag, remove_colons=False):
     """Convert characters banned from DD but allowed in AWS tags to underscores
     """
     global Sanitize, Dedupe, FixInit
@@ -206,7 +206,8 @@ def sanitize_aws_tag_string(tag):
     # 7. Truncate to 200 characters
     # 8. Strip trailing underscores
     tag = convert_camel_case_to_underscore(tag)
-    tag = tag.replace(":", "_")
+    if remove_colons:
+        tag = tag.replace(":", "_")
     tag = Dedupe(u"_", Sanitize(u"_", tag.lower()))
     first_char = tag[0]
     if first_char == u"_" or u"0" <= first_char <= "9":
@@ -226,7 +227,7 @@ def get_dd_tag_string_from_aws_dict(aws_key_value_tag_dict):
         key:value colon-separated string built from the dict
             ex: "creator:swf"
     """
-    key = sanitize_aws_tag_string(aws_key_value_tag_dict["Key"])
+    key = sanitize_aws_tag_string(aws_key_value_tag_dict["Key"], remove_colons=True)
     value = sanitize_aws_tag_string(aws_key_value_tag_dict.get("Value"))
     # Value is optional in DD and AWS
     if not value:

--- a/aws/logs_monitoring/enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/enhanced_lambda_metrics.py
@@ -193,16 +193,18 @@ def sanitize_aws_tag_string(tag):
     """
     global Sanitize, Dedupe, FixInit
 
-    # 1. Convert to all lowercase unicode string
-    # 2. Convert bad characters to underscores
-    # 3. Dedupe contiguous underscores
-    # 4. Remove initial underscores/digits such that the string
+    # 1. Convert camel case to underscores
+    # 2. Replaces colons with _
+    # 3. Convert to all lowercase unicode string
+    # 4. Convert bad characters to underscores
+    # 5. Dedupe contiguous underscores
+    # 6. Remove initial underscores/digits such that the string
     #    starts with an alpha char
     #    FIXME: tag normalization incorrectly supports tags starting
     #    with a ':', but this behavior should be phased out in future
     #    as it results in unqueryable data.  See dogweb/#11193
-    # 5. Truncate to 200 characters
-    # 6. Strip trailing underscores
+    # 7. Truncate to 200 characters
+    # 8. Strip trailing underscores
     tag = convert_camel_case_to_underscore(tag)
     tag = tag.replace(":", "_")
     tag = Dedupe(u"_", Sanitize(u"_", tag.lower()))

--- a/aws/logs_monitoring/tests/snapshots/cloudwatch_log.json~snapshot
+++ b/aws/logs_monitoring/tests/snapshots/cloudwatch_log.json~snapshot
@@ -19,7 +19,7 @@
             "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.4.0",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x",
           "ddsource": "cloudwatch",
           "service": "cloudwatch",
           "host": "testLogGroup"
@@ -38,7 +38,7 @@
             "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.4.0",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x",
           "ddsource": "cloudwatch",
           "service": "cloudwatch",
           "host": "testLogGroup"

--- a/aws/logs_monitoring/tests/snapshots/cloudwatch_log_lambda_invocation.json~snapshot
+++ b/aws/logs_monitoring/tests/snapshots/cloudwatch_log_lambda_invocation.json~snapshot
@@ -22,7 +22,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.4.0,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -44,7 +44,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.4.0,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -66,7 +66,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.4.0,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -88,7 +88,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.4.0,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -110,7 +110,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.4.0,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -132,7 +132,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.4.0,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -154,7 +154,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.4.0,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -176,7 +176,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.4.0,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -198,7 +198,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.4.0,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -220,7 +220,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.4.0,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -242,7 +242,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.4.0,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -264,7 +264,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.4.0,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -286,7 +286,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.4.0,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -308,7 +308,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.4.0,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -330,7 +330,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.4.0,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -352,7 +352,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:3.4.0,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"

--- a/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
@@ -41,7 +41,7 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
         self.assertEqual(sanitize_aws_tag_string("serverl___ess"), "serverl_ess")
         # Keep colons when remove_colons=False
         self.assertEqual(sanitize_aws_tag_string("serv:erless:"), "serv:erless:")
-        # Substiture colon when remove_colons=True
+        # Substitute colon when remove_colons=True
         self.assertEqual(
             sanitize_aws_tag_string("serv:erless:", remove_colons=True), "serv_erless"
         )

--- a/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
@@ -39,8 +39,12 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
         self.assertEqual(sanitize_aws_tag_string("s+e@rv_erl_ess"), "s_e_rv_erl_ess")
         # Dedup underscores
         self.assertEqual(sanitize_aws_tag_string("serverl___ess"), "serverl_ess")
-        # Tag value cannot have a colon
-        self.assertEqual(sanitize_aws_tag_string("serv:erless:"), "serv_erless")
+        # Keep colons when remove_colons=False
+        self.assertEqual(sanitize_aws_tag_string("serv:erless:"), "serv:erless:")
+        # Substiture colon when remove_colons=True
+        self.assertEqual(
+            sanitize_aws_tag_string("serv:erless:", remove_colons=True), "serv_erless"
+        )
         # Convert camel case
         self.assertEqual(sanitize_aws_tag_string("serVerLess"), "ser_ver_less")
 

--- a/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
@@ -44,6 +44,7 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
             [
                 "region:us-east-1",
                 "account_id:1234597598159",
+                "aws_account:1234597598159",
                 "functionname:swf-hello-test",
             ],
         )
@@ -192,6 +193,7 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
                     "tags": [
                         "region:us-east-1",
                         "account_id:172597598159",
+                        "aws_account:172597598159",
                         "functionname:post-coupon-prod-us",
                     ],
                     "timestamp": 10000,
@@ -202,6 +204,7 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
                     "tags": [
                         "region:us-east-1",
                         "account_id:172597598159",
+                        "aws_account:172597598159",
                         "functionname:post-coupon-prod-us",
                     ],
                     "timestamp": 10000,
@@ -212,6 +215,7 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
                     "tags": [
                         "region:us-east-1",
                         "account_id:172597598159",
+                        "aws_account:172597598159",
                         "functionname:post-coupon-prod-us",
                     ],
                     "timestamp": 10000,
@@ -222,6 +226,7 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
                     "tags": [
                         "region:us-east-1",
                         "account_id:172597598159",
+                        "aws_account:172597598159",
                         "functionname:post-coupon-prod-us",
                     ],
                     "timestamp": 10000,
@@ -272,6 +277,7 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
                     "tags": [
                         "region:us-east-1",
                         "account_id:172597598159",
+                        "aws_account:172597598159",
                         "functionname:post-coupon-prod-us",
                         "team:metrics",
                         "monitor:datadog",
@@ -286,6 +292,7 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
                     "tags": [
                         "region:us-east-1",
                         "account_id:172597598159",
+                        "aws_account:172597598159",
                         "functionname:post-coupon-prod-us",
                         "team:metrics",
                         "monitor:datadog",
@@ -300,6 +307,7 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
                     "tags": [
                         "region:us-east-1",
                         "account_id:172597598159",
+                        "aws_account:172597598159",
                         "functionname:post-coupon-prod-us",
                         "team:metrics",
                         "monitor:datadog",
@@ -314,6 +322,7 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
                     "tags": [
                         "region:us-east-1",
                         "account_id:172597598159",
+                        "aws_account:172597598159",
                         "functionname:post-coupon-prod-us",
                         "team:metrics",
                         "monitor:datadog",

--- a/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
@@ -33,8 +33,16 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
 
     def test_sanitize_tag_string(self):
         self.assertEqual(sanitize_aws_tag_string("serverless"), "serverless")
-        self.assertEqual(sanitize_aws_tag_string("ser:ver_less"), "ser_ver_less")
-        self.assertEqual(sanitize_aws_tag_string("s-erv:erl_ess"), "s_erv_erl_ess")
+        # Don't replace : \ / . in middle of string
+        self.assertEqual(sanitize_aws_tag_string("ser-/.ver_less"), "ser-/.ver_less")
+        # Remove invalid characters
+        self.assertEqual(sanitize_aws_tag_string("s+e@rv_erl_ess"), "s_e_rv_erl_ess")
+        # Dedup underscores
+        self.assertEqual(sanitize_aws_tag_string("serverl___ess"), "serverl_ess")
+        # Tag value cannot have a colon
+        self.assertEqual(sanitize_aws_tag_string("serv:erless:"), "serv_erless")
+        # Convert camel case
+        self.assertEqual(sanitize_aws_tag_string("serVerLess"), "ser_ver_less")
 
     def test_parse_lambda_tags_from_arn(self):
         self.assertListEqual(


### PR DESCRIPTION
### What does this PR do?

Modify tag parsing rules to match Datadog's internal integrations
1. Convert camel case to underscores
2. Replaces colons with _
3. Convert to all lowercase unicode string
4. Convert bad characters to underscores
5. Dedupe contiguous underscores
6. Remove initial underscores/digits such that the string
7. Truncate to 200 characters
8. Strip trailing underscores

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Checklist

- [ ] Member of the datadog team has run integration tests
