### PR TITLE
Bump to v3.6.0, remove camel case parsing rules

### DIFF
--- a/aws/logs_monitoring/enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/enhanced_lambda_metrics.py
@@ -175,17 +175,6 @@ _other_chars = r"\w:\-\.\/"
 Sanitize = re.compile(r"[^%s]" % _other_chars, re.UNICODE).sub
 Dedupe = re.compile(r"_+", re.UNICODE).sub
 FixInit = re.compile(r"^[_\d]*", re.UNICODE).sub
-FirstCapRe = re.compile("(.)([A-Z][a-z]+)")
-AllCapRe = re.compile("([a-z0-9])([A-Z])")
-
-
-def convert_camel_case_to_underscore(string):
-    """
-    Convert from CamelCase to camel_case
-    """
-    global FirstCapRe, AllCapRe
-    string = FirstCapRe.sub(r"\1_\2", string)
-    return AllCapRe.sub(r"\1_\2", string).lower()
 
 
 def sanitize_aws_tag_string(tag, remove_colons=False):
@@ -193,19 +182,17 @@ def sanitize_aws_tag_string(tag, remove_colons=False):
     """
     global Sanitize, Dedupe, FixInit
 
-    # 1. Convert camel case to underscores
-    # 2. Replaces colons with _
-    # 3. Convert to all lowercase unicode string
-    # 4. Convert bad characters to underscores
-    # 5. Dedupe contiguous underscores
-    # 6. Remove initial underscores/digits such that the string
+    # 1. Replaces colons with _
+    # 2. Convert to all lowercase unicode string
+    # 3. Convert bad characters to underscores
+    # 4. Dedupe contiguous underscores
+    # 5. Remove initial underscores/digits such that the string
     #    starts with an alpha char
     #    FIXME: tag normalization incorrectly supports tags starting
     #    with a ':', but this behavior should be phased out in future
     #    as it results in unqueryable data.  See dogweb/#11193
-    # 7. Truncate to 200 characters
-    # 8. Strip trailing underscores
-    tag = convert_camel_case_to_underscore(tag)
+    # 6. Truncate to 200 characters
+    # 7. Strip trailing underscores
     if remove_colons:
         tag = tag.replace(":", "_")
     tag = Dedupe(u"_", Sanitize(u"_", tag.lower()))

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -321,7 +321,7 @@ DD_SOURCE = "ddsource"
 DD_CUSTOM_TAGS = "ddtags"
 DD_SERVICE = "service"
 DD_HOST = "host"
-DD_FORWARDER_VERSION = "3.5.0"
+DD_FORWARDER_VERSION = "3.6.0"
 
 
 class RetriableException(Exception):

--- a/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
@@ -34,9 +34,9 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
     def test_sanitize_tag_string(self):
         self.assertEqual(sanitize_aws_tag_string("serverless"), "serverless")
         # Don't replace : \ / . in middle of string
-        self.assertEqual(sanitize_aws_tag_string("ser-/.ver_less"), "ser-/.ver_less")  #
+        self.assertEqual(sanitize_aws_tag_string("ser-/.ver_less"), "ser-/.ver_less")
         # Remove invalid characters
-        self.assertEqual(sanitize_aws_tag_string("s+e@rv_erl_ess"), "s_e_rv_erl_ess")  #
+        self.assertEqual(sanitize_aws_tag_string("s+e@rv_erl_ess"), "s_e_rv_erl_ess")
         # Dedup underscores
         self.assertEqual(sanitize_aws_tag_string("serverl___ess"), "serverl_ess")
         # Keep colons when remove_colons=False

--- a/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
@@ -34,9 +34,9 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
     def test_sanitize_tag_string(self):
         self.assertEqual(sanitize_aws_tag_string("serverless"), "serverless")
         # Don't replace : \ / . in middle of string
-        self.assertEqual(sanitize_aws_tag_string("ser-/.ver_less"), "ser-/.ver_less")
+        self.assertEqual(sanitize_aws_tag_string("ser-/.ver_less"), "ser-/.ver_less")  #
         # Remove invalid characters
-        self.assertEqual(sanitize_aws_tag_string("s+e@rv_erl_ess"), "s_e_rv_erl_ess")
+        self.assertEqual(sanitize_aws_tag_string("s+e@rv_erl_ess"), "s_e_rv_erl_ess")  #
         # Dedup underscores
         self.assertEqual(sanitize_aws_tag_string("serverl___ess"), "serverl_ess")
         # Keep colons when remove_colons=False
@@ -45,8 +45,8 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
         self.assertEqual(
             sanitize_aws_tag_string("serv:erless:", remove_colons=True), "serv_erless"
         )
-        # Convert camel case
-        self.assertEqual(sanitize_aws_tag_string("serVerLess"), "ser_ver_less")
+        # Convert to lower
+        self.assertEqual(sanitize_aws_tag_string("serVerLess"), "serverless")
 
     def test_parse_lambda_tags_from_arn(self):
         self.assertListEqual(


### PR DESCRIPTION
### What does this PR do?

From testing, it looks like our internal tag converters don't convert from camel case into snake case, so this PR updates that behavior.

Also bumping to 3.6.0 to prep for release.