### PR TITLE
Enable supplying DdApiKeySecret directly

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -100,11 +100,21 @@ variable "dd_api_key" {
   description = "Datadog API key"
 }
 
+resource "aws_secretsmanager_secret" "dd_api_key" {
+  name        = "datadog_api_key"
+  description = "Datadog API Key"
+}
+
+resource "aws_secretsmanager_secret_version" "dd_api_key" {
+  secret_id     = aws_secretsmanager_secret.dd_api_key.id
+  secret_string = var.dd_api_key
+}
+
 resource "aws_cloudformation_stack" "datadog-forwarder" {
   name         = "datadog-forwarder"
   capabilities = ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
   parameters   = {
-    DdApiKey        = var.dd_api_key
+    DdApiKeySecret  = aws_secretsmanager_secret.dd_api_key.arn
     FunctionName    = "datadog-forwarder"
   }
   template_url = "https://datadog-cloudformation-template.s3.amazonaws.com/aws/forwarder/latest.yaml"

--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -114,8 +114,9 @@ resource "aws_cloudformation_stack" "datadog-forwarder" {
   name         = "datadog-forwarder"
   capabilities = ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
   parameters   = {
-    DdApiKeySecret  = aws_secretsmanager_secret.dd_api_key.arn
-    FunctionName    = "datadog-forwarder"
+    DdApiKey           = "value_will_be_overwritten_by_DdApiKeySecretArn"
+    DdApiKeySecretArn  = aws_secretsmanager_secret.dd_api_key.arn
+    FunctionName       = "datadog-forwarder"
   }
   template_url = "https://datadog-cloudformation-template.s3.amazonaws.com/aws/forwarder/latest.yaml"
 }

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -8,10 +8,14 @@ Mappings:
 Parameters:
   DdApiKey:
     Type: String
+    Default: ""
     NoEcho: true
-    AllowedPattern: .+
-    ConstraintDescription: DdApiKey is required
-    Description: The Datadog API key, which can be found from the APIs page (/account/settings#api). It will be stored in AWS Secrets Manager securely.
+    Description: The Datadog API key, which can be found from the APIs page (/account/settings#api). It will be stored in AWS Secrets Manager securely. Either this or DdApiKeySecret must be set.
+  DdApiKeySecret:
+    Type: String
+    AllowedPattern: "arn:aws:secretsmanager:.*"
+    Default: "arn:aws:secretsmanager:DEFAULT"
+    Description: The ARN where Datadog API key can be found. Either this or DdApiKey must be set.
   DdSite:
     Type: String
     Default: datadoghq.com
@@ -142,6 +146,11 @@ Parameters:
     Default: ""
     Description: ARN for the Permissions Boundary Policy
 Conditions:
+  SetDdApiKeySecretFromApiKey:
+    Fn::Not:
+      - Fn::Equals:
+         - Ref: DdApiKey
+         - ""
   SetFunctionName:
     Fn::Not:
       - Fn::Equals:
@@ -273,7 +282,10 @@ Resources:
         Variables:
           DD_ENHANCED_METRICS: "false"
           DD_API_KEY_SECRET_ARN:
-            Ref: DdApiKeySecret
+            Fn::If:
+              - SetDdApiKeySecretFromApiKey
+              - Ref: DdApiKeySecretFromApiKey
+              - Ref: DdApiKeySecret
           DD_SITE:
             Ref: DdSite
           DD_TAGS:
@@ -379,7 +391,10 @@ Resources:
               Action:
                 - secretsmanager:GetSecretValue
               Resource:
-                Ref: DdApiKeySecret
+                Fn::If:
+                  - SetDdApiKeySecretFromApiKey
+                  - Ref: DdApiKeySecretFromApiKey
+                  - Ref: DdApiKeySecret
             - !If
               - SetDdFetchLambdaTags
               - Effect: Allow
@@ -408,8 +423,9 @@ Resources:
         Fn::Sub: /aws/lambda/${Forwarder}
       RetentionInDays:
         Ref: LogRetentionInDays
-  DdApiKeySecret:
+  DdApiKeySecretFromApiKey:
     Type: AWS::SecretsManager::Secret
+    Condition: SetDdApiKeySecretFromApiKey
     Properties:
       Description: Datadog API Key
       SecretString:

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -8,14 +8,14 @@ Mappings:
 Parameters:
   DdApiKey:
     Type: String
-    Default: ""
     NoEcho: true
-    Description: The Datadog API key, which can be found from the APIs page (/account/settings#api). It will be stored in AWS Secrets Manager securely. Either this or DdApiKeySecret must be set.
-  DdApiKeySecret:
+    AllowedPattern: .+
+    Description: The Datadog API key, which can be found from the APIs page (/account/settings#api). It will be stored in AWS Secrets Manager securely. If DdApiKeySecretArn is also set, this value will not be used. This value must still be set, however.
+  DdApiKeySecretArn:
     Type: String
     AllowedPattern: "arn:aws:secretsmanager:.*"
     Default: "arn:aws:secretsmanager:DEFAULT"
-    Description: The ARN where Datadog API key can be found. Either this or DdApiKey must be set.
+    Description: The ARN of the secret storing the Datadog API key, if you already have it stored in Secrets Manager. You still need to set a dummy value for "DdApiKey" to satisfy the requirement, though that value won't be used.
   DdSite:
     Type: String
     Default: datadoghq.com
@@ -146,11 +146,10 @@ Parameters:
     Default: ""
     Description: ARN for the Permissions Boundary Policy
 Conditions:
-  SetDdApiKeySecretFromApiKey:
-    Fn::Not:
-      - Fn::Equals:
-         - Ref: DdApiKey
-         - ""
+  CreateDdApiKeySecret:
+    Fn::Equals:
+       - Ref: DdApiKeySecretArn
+       - "arn:aws:secretsmanager:DEFAULT"
   SetFunctionName:
     Fn::Not:
       - Fn::Equals:
@@ -283,9 +282,9 @@ Resources:
           DD_ENHANCED_METRICS: "false"
           DD_API_KEY_SECRET_ARN:
             Fn::If:
-              - SetDdApiKeySecretFromApiKey
-              - Ref: DdApiKeySecretFromApiKey
+              - CreateDdApiKeySecret
               - Ref: DdApiKeySecret
+              - Ref: DdApiKeySecretArn
           DD_SITE:
             Ref: DdSite
           DD_TAGS:
@@ -392,9 +391,9 @@ Resources:
                 - secretsmanager:GetSecretValue
               Resource:
                 Fn::If:
-                  - SetDdApiKeySecretFromApiKey
-                  - Ref: DdApiKeySecretFromApiKey
+                  - CreateDdApiKeySecret
                   - Ref: DdApiKeySecret
+                  - Ref: DdApiKeySecretArn
             - !If
               - SetDdFetchLambdaTags
               - Effect: Allow
@@ -423,9 +422,9 @@ Resources:
         Fn::Sub: /aws/lambda/${Forwarder}
       RetentionInDays:
         Ref: LogRetentionInDays
-  DdApiKeySecretFromApiKey:
+  DdApiKeySecret:
     Type: AWS::SecretsManager::Secret
-    Condition: SetDdApiKeySecretFromApiKey
+    Condition: CreateDdApiKeySecret
     Properties:
       Description: Datadog API Key
       SecretString:
@@ -613,6 +612,7 @@ Metadata:
         Parameters:
           - SourceZipUrl
           - PermissionsBoundaryArn
+          - DdApiKeySecretArn
     ParameterLabels:
       DdApiKey:
         default: "DdApiKey *"


### PR DESCRIPTION
### What does this PR do?

Works around indefinite reapply changes when using terraform to deploy
cloudformation with NoEcho parameters
(https://github.com/terraform-providers/terraform-provider-aws/issues/55)

### Motivation

Using terraform with DdApiKey (and NoEcho) results in always requiring reapplication of the API key parameter.

### Checklist

- [x] Member of the datadog team has run integration tests
