### PR TITLE
Ensure empty tags can be sanitized

### DIFF
--- a/aws/logs_monitoring/enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/enhanced_lambda_metrics.py
@@ -193,6 +193,11 @@ def sanitize_aws_tag_string(tag, remove_colons=False):
     #    as it results in unqueryable data.  See dogweb/#11193
     # 6. Truncate to 200 characters
     # 7. Strip trailing underscores
+
+    if len(tag) == 0:
+        # if tag is empty, nothing to do
+        return tag
+
     if remove_colons:
         tag = tag.replace(":", "_")
     tag = Dedupe(u"_", Sanitize(u"_", tag.lower()))

--- a/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 
-from mock import patch
+from unittest.mock import patch
 
 from enhanced_lambda_metrics import (
     sanitize_aws_tag_string,
@@ -47,6 +47,7 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
         )
         # Convert to lower
         self.assertEqual(sanitize_aws_tag_string("serVerLess"), "serverless")
+        self.assertEqual(sanitize_aws_tag_string(""), "")
 
     def test_parse_lambda_tags_from_arn(self):
         self.assertListEqual(
@@ -71,6 +72,7 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
                             "Tags": [
                                 {"Key": "stage", "Value": "dev"},
                                 {"Key": "team", "Value": "serverless"},
+                                {"Key": "empty", "Value": ""},
                             ],
                         },
                         {
@@ -79,6 +81,7 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
                                 {"Key": "stage", "Value": "prod"},
                                 {"Key": "team", "Value": "serverless"},
                                 {"Key": "datacenter", "Value": "eu"},
+                                {"Key": "empty", "Value": ""},
                             ],
                         },
                     ]
@@ -88,11 +91,13 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
                 "arn:aws:lambda:us-east-1:123497598159:function:my-test-lambda-dev": [
                     "stage:dev",
                     "team:serverless",
+                    "empty",
                 ],
                 "arn:aws:lambda:us-east-1:123497598159:function:my-test-lambda-prod": [
                     "stage:prod",
                     "team:serverless",
                     "datacenter:eu",
+                    "empty",
                 ],
             },
         )


### PR DESCRIPTION
### What does this PR do?

Adds support for lambda tags with empty values, with tests.

### Motivation

We have a few lambdas that have tags with empty values, and that was causing an exception
to be thrown during the sanitization function.  

### Additional Notes

None

### Checklist

- [x] Member of the datadog team has run integration tests
