### PR TITLE
Refresh tags when new lambda arn is encountered

### DIFF
--- a/aws/logs_monitoring/enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/enhanced_lambda_metrics.py
@@ -197,7 +197,7 @@ FixInit = re.compile(r"^[_\d]*", re.UNICODE).sub
 def sanitize_aws_tag_string(tag, remove_colons=False):
     """Convert characters banned from DD but allowed in AWS tags to underscores
     """
-    global Sanitize, Dedupe, FixInit1677
+    global Sanitize, Dedupe, FixInit
 
     # 1. Replaces colons with _
     # 2. Convert to all lowercase unicode string


### PR DESCRIPTION
### What does this PR do?

Refreshes tags in the tag cache when a new lambda arn is encountered

### Motivation

Some issues were being encountered with new lambdas taking a while to have there tags attached

### Additional Notes

Anything else we should know when reviewing?

### Checklist

- [x] Member of the datadog team has run integration tests
