### PR TITLE
Ensure that message is a string before sending enhanced lambda metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ base.zip
 */env
 .vscode
 **/node_modules
+.idea


### PR DESCRIPTION
### What does this PR do?
Fixes a bug when `message` in log is `dict` and not a `string`
### Motivation
We were upgrading our datadog lambda to the newest code and found this problem.  

What inspired you to submit this pull request?
I love fixing bugs :) 

### Checklist

- [ ] Member of the datadog team has run integration tests
