### PR TITLE
Terraform code needs to ignore changes to parameters

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -118,6 +118,9 @@ resource "aws_cloudformation_stack" "datadog-forwarder" {
     DdApiKeySecretArn  = aws_secretsmanager_secret.dd_api_key.arn
     FunctionName       = "datadog-forwarder"
   }
+  lifecycle {
+    ignore_changes = [parameters]
+  }
   template_url = "https://datadog-cloudformation-template.s3.amazonaws.com/aws/forwarder/latest.yaml"
 }
 ```


### PR DESCRIPTION
### What does this PR do?

Prevents Terraform from trying to change the AWS CloudFormation stack object every time `terraform apply` is run.

### Motivation

Because the `DdApiKey` parameter is replaced upon deployment when using Secrets Manager to store the Datadog API key, changes to the value of `parameters` need to be ignored in the resource lifecycle of the `aws_cloudformation_stack` object when deploying via Terraform.

### Checklist

- [ ] Member of the datadog team has run integration tests
