### PR TITLE
fix NameError: name 'IS_ENHANCED_METRICS_FILE_PRESENT' is not defined

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -35,6 +35,7 @@ except ImportError:
     # of requests is removed in botocore 1.13.x.
     from botocore.vendored import requests
 
+IS_ENHANCED_METRICS_FILE_PRESENT = False
 try:
     from enhanced_lambda_metrics import (
         get_enriched_lambda_log_tags,


### PR DESCRIPTION
### What does this PR do?
Fixes a bug. 
```
[ERROR] NameError: name 'IS_ENHANCED_METRICS_FILE_PRESENT' is not defined
Traceback (most recent call last):
  File "/var/lang/lib/python3.7/imp.py", line 234, in load_module
    return load_source(name, filename, file)
  File "/var/lang/lib/python3.7/imp.py", line 171, in load_source
    module = _load(spec)
  File "<frozen importlib._bootstrap>", line 696, in _load
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/var/task/src/functions/datadog_adapter_handler.py", line 12, in <module>
    from src.handlers import awslogs_handler, s3_handler, cwevent_handler, sns_handler, datadog_handler
  File "/var/task/src/handlers/datadog_handler.py", line 53, in <module>
    log.debug(f"IS_ENHANCED_METRICS_FILE_PRESENT: {IS_ENHANCED_METRICS_FILE_PRESENT}")
```
### Motivation
I was experiencing big number of errors in datadog because of this issue. 