### PR TITLE
[cloud-ints] Updating docs to reflect rds support of python 3

### DIFF
--- a/aws/rds_enhanced_monitoring/README.md
+++ b/aws/rds_enhanced_monitoring/README.md
@@ -169,7 +169,7 @@ Process a RDS enhanced monitoring DATA_MESSAGE, coming from CLOUDWATCH LOGS
 
    - Create a `lambda_execution` role and attach this policy.
 
-   - Create a lambda function: skip the blueprint, name it `functionname`, set the runtime to `Python 2.7`, the handle to `lambda_function.lambda_handler`, and the role to `lambda_execution`.
+   - Create a lambda function: skip the blueprint, name it `functionname`, set the runtime to `Python 3.7`, the handle to `lambda_function.lambda_handler`, and the role to `lambda_execution`.
 
    - Copy the content of `functionname/lambda_function.py` in the code section, and make sure to update the `KMS_ENCRYPTED_KEYS` environment variable with the encrypted key generated in step 1.
 


### PR DESCRIPTION
### What does this PR do?
Changes docs to reflect rds change to support python 3

### Motivation
Needed after [this](https://github.com/DataDog/datadog-serverless-functions/pull/254) change.

