### PR TITLE
Ensure the forwarder can be installed to GovCloud

### DIFF
--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -13,7 +13,7 @@ Parameters:
     Description: The Datadog API key, which can be found from the APIs page (/account/settings#api). It will be stored in AWS Secrets Manager securely. If DdApiKeySecretArn is also set, this value will not be used. This value must still be set, however.
   DdApiKeySecretArn:
     Type: String
-    AllowedPattern: "arn:aws:secretsmanager:.*"
+    AllowedPattern: "arn:.*:secretsmanager:.*"
     Default: "arn:aws:secretsmanager:DEFAULT"
     Description: The ARN of the secret storing the Datadog API key, if you already have it stored in Secrets Manager. You still need to set a dummy value for "DdApiKey" to satisfy the requirement, though that value won't be used.
   DdSite:
@@ -161,6 +161,10 @@ Parameters:
     Default: ""
     Description: ARN for the Permissions Boundary Policy
 Conditions:
+  IsAWSChina:
+    Fn::Equals:
+      - Ref: AWS::Partition
+      - "aws-cn"
   CreateDdApiKeySecret:
     Fn::Equals:
       - Ref: DdApiKeySecretArn
@@ -412,7 +416,7 @@ Resources:
             - Effect: Allow
               Action:
                 - s3:GetObject
-              Resource: "arn:aws:s3:::*"
+              Resource: "*"
             - Effect: Allow
               Action:
                 - secretsmanager:GetSecretValue
@@ -442,14 +446,22 @@ Resources:
     Properties:
       FunctionName: !Ref "Forwarder"
       Action: lambda:InvokeFunction
-      Principal: !Sub "logs.${AWS::Region}.amazonaws.com"
+      Principal:
+        Fn::If:
+          - IsAWSChina
+          - !Sub "logs.${AWS::Region}.amazonaws.com.cn"
+          - !Sub "logs.${AWS::Region}.amazonaws.com"
       SourceAccount: !Ref "AWS::AccountId"
   S3Permission:
     Type: AWS::Lambda::Permission
     Properties:
       FunctionName: !Ref "Forwarder"
       Action: lambda:InvokeFunction
-      Principal: "s3.amazonaws.com"
+      Principal:
+        Fn::If:
+          - IsAWSChina
+          - "s3.amazonaws.com.cn"
+          - "s3.amazonaws.com"
       SourceAccount: !Ref "AWS::AccountId"
   LogGroup:
     Type: AWS::Logs::LogGroup
@@ -467,6 +479,16 @@ Resources:
         Ref: DdApiKey
   ForwarderZipsBucket:
     Type: AWS::S3::Bucket
+    Properties:
+      BucketEncryption:
+          ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
   ForwarderZip:
     Type: Custom::ForwarderZip
     Properties:
@@ -582,7 +604,7 @@ Resources:
                 Resource:
                   - Fn::Join:
                       - ""
-                      - - "arn:aws:s3:::"
+                      - - "arn:*:s3:::"
                         - !Select [1, !Split ["s3://", !Ref SourceZipUrl]]
               - Ref: AWS::NoValue
       Environment:


### PR DESCRIPTION
### What does this PR do?

Ensure the forwarder can be installed to US Gov (and China) AWS accounts.

- Encrypt the s3 bucket temporarily storing forwarder source code
- Block public access on the s3 bucket temporarily storing forwarder source code
- Update ARNs to use a wildcard for the AWS partition segment
- Update service principles with the `.cn` suffix for China

### Motivation

Ensure the forwarder can be installed to US Gov (and China) AWS accounts.

### Testing Guidelines

- [x] No regression to installation in the regular AWS partition
- [x] Forwarder can be installed in a real US Gov AWS account

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
