### PR TITLE
Jordan.storms/add init duration metric and cold_start tags

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,3 +32,4 @@
 - [ ] This PR's changes are covered by the automated tests
 - [ ] This PR collects user input/sensitive content into Datadog
 - [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
+- [ ] This PR passes the unit tests 

--- a/.github/workflows/lambdachecks.yml
+++ b/.github/workflows/lambdachecks.yml
@@ -32,3 +32,7 @@ jobs:
       - name: Run trace forwarder integration tests
         run: |
           ./aws/logs_monitoring/trace_forwarder/scripts/run_tests.sh
+      - name: Run enhanced metric unittest
+        run: |
+          pip install unittest
+          python -m unittest

--- a/.github/workflows/lambdachecks.yml
+++ b/.github/workflows/lambdachecks.yml
@@ -34,5 +34,4 @@ jobs:
           ./aws/logs_monitoring/trace_forwarder/scripts/run_tests.sh
       - name: Run enhanced metric unittest
         run: |
-          pip install unittest
           python -m unittest

--- a/aws/logs_monitoring/enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/enhanced_lambda_metrics.py
@@ -41,7 +41,7 @@ REPORT_LOG_REGEX = re.compile(
     + r"Memory\s+Size:\s+(?P<{}>\d+)\s+MB\s+".format(MEMORY_ALLOCATED_FIELD_NAME)
     + r"Max\s+Memory\s+Used:\s+(?P<{}>\d+)\s+MB".format(MAX_MEMORY_USED_METRIC_NAME)
 )
-
+# Make separate regex to account for cold start
 REPORT_LOG_REGEX_INIT = re.compile(
     r"REPORT\s+"
     + r"RequestId:\s+(?P<{}>[\w-]+)\s+".format(REQUEST_ID_FIELD_NAME)

--- a/aws/logs_monitoring/enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/enhanced_lambda_metrics.py
@@ -437,20 +437,22 @@ def parse_metrics_from_report_log(report_log_line):
     Returns:
         metrics - DatadogMetricPoint[]
     """
-    metrics = []
-    tags = ["cold_start:false"]
 
     regex_match = REPORT_LOG_REGEX.search(report_log_line)
 
     if not regex_match:
         return []
 
-    # we always want coldstart and memorysize tags
-    tags.append("memorysize:" + regex_match.group(MEMORY_ALLOCATED_FIELD_NAME))
+    metrics = []
+
+    tags = ["memorysize:" + regex_match.group(MEMORY_ALLOCATED_FIELD_NAME)]
+    if regex_match.group(INIT_DURATION_METRIC_NAME):
+        tags.append("cold_start:true")
+    else:
+        tags.append("cold_start:false")
 
     # if cold_start:
     if regex_match.group(INIT_DURATION_METRIC_NAME):
-        tags[0] = "cold_start:true"
         metric_point_value = float(regex_match.group(INIT_DURATION_METRIC_NAME))
         # Multiply by 1/1000 to convert ms to seconds
         metric_point_value *= METRIC_ADJUSTMENT_FACTORS[INIT_DURATION_METRIC_NAME]

--- a/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
@@ -119,25 +119,25 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
             [
                 {
                     "name": "aws.lambda.enhanced.duration",
-                    "tags": ["cold_start:false", "memorysize:128",],
+                    "tags": ["memorysize:128", "cold_start:false",],
                     "value": 0.00062,
                     "timestamp": None,
                 },
                 {
                     "name": "aws.lambda.enhanced.billed_duration",
-                    "tags": ["cold_start:false", "memorysize:128",],
+                    "tags": ["memorysize:128", "cold_start:false",],
                     "value": 0.1000,
                     "timestamp": None,
                 },
                 {
                     "name": "aws.lambda.enhanced.max_memory_used",
-                    "tags": ["cold_start:false", "memorysize:128",],
+                    "tags": ["memorysize:128", "cold_start:false",],
                     "value": 51.0,
                     "timestamp": None,
                 },
                 {
                     "name": "aws.lambda.enhanced.estimated_cost",
-                    "tags": ["cold_start:false", "memorysize:128",],
+                    "tags": ["memorysize:128", "cold_start:false",],
                     "timestamp": None,
                     "value": 4.0833375e-07,
                 },
@@ -150,31 +150,31 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
             [
                 {
                     "name": "aws.lambda.enhanced.init_duration",
-                    "tags": ["cold_start:true", "memorysize:128",],
+                    "tags": ["memorysize:128", "cold_start:true",],
                     "value": 1.234,
                     "timestamp": None,
                 },
                 {
                     "name": "aws.lambda.enhanced.duration",
-                    "tags": ["cold_start:true", "memorysize:128",],
+                    "tags": ["memorysize:128", "cold_start:true",],
                     "value": 0.0008100000000000001,
                     "timestamp": None,
                 },
                 {
                     "name": "aws.lambda.enhanced.billed_duration",
-                    "tags": ["cold_start:true", "memorysize:128",],
+                    "tags": ["memorysize:128", "cold_start:true",],
                     "value": 0.1000,
                     "timestamp": None,
                 },
                 {
                     "name": "aws.lambda.enhanced.max_memory_used",
-                    "tags": ["cold_start:true", "memorysize:128",],
+                    "tags": ["memorysize:128", "cold_start:true",],
                     "value": 90.0,
                     "timestamp": None,
                 },
                 {
                     "name": "aws.lambda.enhanced.estimated_cost",
-                    "tags": ["cold_start:true", "memorysize:128",],
+                    "tags": ["memorysize:128", "cold_start:true",],
                     "timestamp": None,
                     "value": 4.0833375e-07,
                 },
@@ -186,25 +186,25 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
             [
                 {
                     "name": "aws.lambda.enhanced.duration",
-                    "tags": ["cold_start:false", "memorysize:128",],
+                    "tags": ["memorysize:128", "cold_start:false",],
                     "timestamp": None,
                     "value": 1.71187,
                 },
                 {
                     "name": "aws.lambda.enhanced.billed_duration",
-                    "tags": ["cold_start:false", "memorysize:128",],
+                    "tags": ["memorysize:128", "cold_start:false",],
                     "timestamp": None,
                     "value": 1.8,
                 },
                 {
                     "name": "aws.lambda.enhanced.max_memory_used",
-                    "tags": ["cold_start:false", "memorysize:128",],
+                    "tags": ["memorysize:128", "cold_start:false",],
                     "timestamp": None,
                     "value": 98.0,
                 },
                 {
                     "name": "aws.lambda.enhanced.estimated_cost",
-                    "tags": ["cold_start:false", "memorysize:128",],
+                    "tags": ["memorysize:128", "cold_start:false",],
                     "timestamp": None,
                     "value": 3.9500075e-06,
                 },
@@ -249,8 +249,8 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
                 {
                     "name": "aws.lambda.enhanced.duration",
                     "tags": [
-                        "cold_start:false",
                         "memorysize:128",
+                        "cold_start:false",
                         "region:us-east-1",
                         "account_id:172597598159",
                         "aws_account:172597598159",
@@ -262,8 +262,8 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
                 {
                     "name": "aws.lambda.enhanced.billed_duration",
                     "tags": [
-                        "cold_start:false",
                         "memorysize:128",
+                        "cold_start:false",
                         "region:us-east-1",
                         "account_id:172597598159",
                         "aws_account:172597598159",
@@ -275,8 +275,8 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
                 {
                     "name": "aws.lambda.enhanced.max_memory_used",
                     "tags": [
-                        "cold_start:false",
                         "memorysize:128",
+                        "cold_start:false",
                         "region:us-east-1",
                         "account_id:172597598159",
                         "aws_account:172597598159",
@@ -288,8 +288,8 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
                 {
                     "name": "aws.lambda.enhanced.estimated_cost",
                     "tags": [
-                        "cold_start:false",
                         "memorysize:128",
+                        "cold_start:false",
                         "region:us-east-1",
                         "account_id:172597598159",
                         "aws_account:172597598159",
@@ -341,8 +341,8 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
                 {
                     "name": "aws.lambda.enhanced.duration",
                     "tags": [
-                        "cold_start:false",
                         "memorysize:128",
+                        "cold_start:false",
                         "region:us-east-1",
                         "account_id:172597598159",
                         "aws_account:172597598159",
@@ -358,8 +358,8 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
                 {
                     "name": "aws.lambda.enhanced.billed_duration",
                     "tags": [
-                        "cold_start:false",
                         "memorysize:128",
+                        "cold_start:false",
                         "region:us-east-1",
                         "account_id:172597598159",
                         "aws_account:172597598159",
@@ -375,8 +375,8 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
                 {
                     "name": "aws.lambda.enhanced.max_memory_used",
                     "tags": [
-                        "cold_start:false",
                         "memorysize:128",
+                        "cold_start:false",
                         "region:us-east-1",
                         "account_id:172597598159",
                         "aws_account:172597598159",
@@ -392,8 +392,8 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
                 {
                     "name": "aws.lambda.enhanced.estimated_cost",
                     "tags": [
-                        "cold_start:false",
                         "memorysize:128",
+                        "cold_start:false",
                         "region:us-east-1",
                         "account_id:172597598159",
                         "aws_account:172597598159",

--- a/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
@@ -24,6 +24,11 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
         "Duration: 0.62 ms	Billed Duration: 100 ms	Memory Size: 128 MB	Max Memory Used: 51 MB"
     )
 
+    cold_start_report = (
+        "REPORT RequestId: 8edab1f8-7d34-4a8e-a965-15ccbbb78d4c	"
+        "Duration: 0.81 ms	Billed Duration: 100 ms	Memory Size: 128 MB	Max Memory Used: 90 MB	Init Duration: 1234 ms"
+    )
+
     report_with_xray = (
         "REPORT RequestId: 814ba7cb-071e-4181-9a09-fa41db5bccad\tDuration: 1711.87 ms\t"
         "Billed Duration: 1800 ms\tMemory Size: 128 MB\tMax Memory Used: 98 MB\t\n"
@@ -114,56 +119,92 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
             [
                 {
                     "name": "aws.lambda.enhanced.duration",
-                    "tags": [],
+                    "tags": ["cold_start:false", "memorysize:128",],
                     "value": 0.00062,
                     "timestamp": None,
                 },
                 {
                     "name": "aws.lambda.enhanced.billed_duration",
-                    "tags": [],
+                    "tags": ["cold_start:false", "memorysize:128",],
                     "value": 0.1000,
                     "timestamp": None,
                 },
                 {
                     "name": "aws.lambda.enhanced.max_memory_used",
-                    "tags": [],
+                    "tags": ["cold_start:false", "memorysize:128",],
                     "value": 51.0,
                     "timestamp": None,
                 },
                 {
                     "name": "aws.lambda.enhanced.estimated_cost",
-                    "tags": [],
+                    "tags": ["cold_start:false", "memorysize:128",],
                     "timestamp": None,
                     "value": 4.0833375e-07,
                 },
             ],
         )
 
+        parsed_metrics = parse_metrics_from_report_log(self.cold_start_report)
+        self.assertEqual(
+            [metric.__dict__ for metric in parsed_metrics],
+            [
+                {
+                    "name": "aws.lambda.enhanced.init_duration",
+                    "tags": ["cold_start:true", "memorysize:128",],
+                    "value": 1.234,
+                    "timestamp": None,
+                },
+                {
+                    "name": "aws.lambda.enhanced.duration",
+                    "tags": ["cold_start:true", "memorysize:128",],
+                    "value": 0.0008100000000000001,
+                    "timestamp": None,
+                },
+                {
+                    "name": "aws.lambda.enhanced.billed_duration",
+                    "tags": ["cold_start:true", "memorysize:128",],
+                    "value": 0.1000,
+                    "timestamp": None,
+                },
+                {
+                    "name": "aws.lambda.enhanced.max_memory_used",
+                    "tags": ["cold_start:true", "memorysize:128",],
+                    "value": 90.0,
+                    "timestamp": None,
+                },
+                {
+                    "name": "aws.lambda.enhanced.estimated_cost",
+                    "tags": ["cold_start:true", "memorysize:128",],
+                    "timestamp": None,
+                    "value": 4.0833375e-07,
+                },
+            ],
+        )
         parsed_metrics = parse_metrics_from_report_log(self.report_with_xray)
         self.assertListEqual(
             [metric.__dict__ for metric in parsed_metrics],
             [
                 {
                     "name": "aws.lambda.enhanced.duration",
-                    "tags": [],
+                    "tags": ["cold_start:false", "memorysize:128",],
                     "timestamp": None,
                     "value": 1.71187,
                 },
                 {
                     "name": "aws.lambda.enhanced.billed_duration",
-                    "tags": [],
+                    "tags": ["cold_start:false", "memorysize:128",],
                     "timestamp": None,
                     "value": 1.8,
                 },
                 {
                     "name": "aws.lambda.enhanced.max_memory_used",
-                    "tags": [],
+                    "tags": ["cold_start:false", "memorysize:128",],
                     "timestamp": None,
                     "value": 98.0,
                 },
                 {
                     "name": "aws.lambda.enhanced.estimated_cost",
-                    "tags": [],
+                    "tags": ["cold_start:false", "memorysize:128",],
                     "timestamp": None,
                     "value": 3.9500075e-06,
                 },
@@ -208,6 +249,8 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
                 {
                     "name": "aws.lambda.enhanced.duration",
                     "tags": [
+                        "cold_start:false",
+                        "memorysize:128",
                         "region:us-east-1",
                         "account_id:172597598159",
                         "aws_account:172597598159",
@@ -219,6 +262,8 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
                 {
                     "name": "aws.lambda.enhanced.billed_duration",
                     "tags": [
+                        "cold_start:false",
+                        "memorysize:128",
                         "region:us-east-1",
                         "account_id:172597598159",
                         "aws_account:172597598159",
@@ -230,6 +275,8 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
                 {
                     "name": "aws.lambda.enhanced.max_memory_used",
                     "tags": [
+                        "cold_start:false",
+                        "memorysize:128",
                         "region:us-east-1",
                         "account_id:172597598159",
                         "aws_account:172597598159",
@@ -241,6 +288,8 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
                 {
                     "name": "aws.lambda.enhanced.estimated_cost",
                     "tags": [
+                        "cold_start:false",
+                        "memorysize:128",
                         "region:us-east-1",
                         "account_id:172597598159",
                         "aws_account:172597598159",
@@ -292,6 +341,8 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
                 {
                     "name": "aws.lambda.enhanced.duration",
                     "tags": [
+                        "cold_start:false",
+                        "memorysize:128",
                         "region:us-east-1",
                         "account_id:172597598159",
                         "aws_account:172597598159",
@@ -307,6 +358,8 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
                 {
                     "name": "aws.lambda.enhanced.billed_duration",
                     "tags": [
+                        "cold_start:false",
+                        "memorysize:128",
                         "region:us-east-1",
                         "account_id:172597598159",
                         "aws_account:172597598159",
@@ -322,6 +375,8 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
                 {
                     "name": "aws.lambda.enhanced.max_memory_used",
                     "tags": [
+                        "cold_start:false",
+                        "memorysize:128",
                         "region:us-east-1",
                         "account_id:172597598159",
                         "aws_account:172597598159",
@@ -337,6 +392,8 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
                 {
                     "name": "aws.lambda.enhanced.estimated_cost",
                     "tags": [
+                        "cold_start:false",
+                        "memorysize:128",
                         "region:us-east-1",
                         "account_id:172597598159",
                         "aws_account:172597598159",

--- a/aws/logs_monitoring/tools/docker-compose.yml
+++ b/aws/logs_monitoring/tools/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       AWS_ACCOUNT_ID: 0000000000
       DOCKER_LAMBDA_STAY_OPEN: 1
       #DD_FORWARD_LOG: "false"
-      DD_LOG_LEVEL: info
+      DD_LOG_LEVEL: debug
       DD_API_KEY: abcdefghijklmnopqrstuvwxyz012345 # Must be 32 characters exactly
       DD_URL: forwarder-recorder # Used for logs intake
       DD_PORT: 8080 # API port to use

--- a/aws/logs_monitoring/tools/docker-compose.yml
+++ b/aws/logs_monitoring/tools/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       AWS_ACCOUNT_ID: 0000000000
       DOCKER_LAMBDA_STAY_OPEN: 1
       #DD_FORWARD_LOG: "false"
-      DD_LOG_LEVEL: debug
+      DD_LOG_LEVEL: info
       DD_API_KEY: abcdefghijklmnopqrstuvwxyz012345 # Must be 32 characters exactly
       DD_URL: forwarder-recorder # Used for logs intake
       DD_PORT: 8080 # API port to use


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adds an `init duration` enhanced metric for cold starts
Adds a `cold_start` tag for all metrics

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
