### PR TITLE
Update enhanced lambda timed out metric name for consistency

### DIFF
--- a/aws/logs_monitoring/enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/enhanced_lambda_metrics.py
@@ -28,7 +28,7 @@ BILLED_DURATION_METRIC_NAME = "billed_duration"
 MEMORY_ALLOCATED_FIELD_NAME = "memorysize"
 MAX_MEMORY_USED_METRIC_NAME = "max_memory_used"
 INIT_DURATION_METRIC_NAME = "init_duration"
-TIMED_OUT_DURATION_METRIC_NAME = "timed_out"
+TIMED_OUT_DURATION_METRIC_NAME = "timeout"
 
 # Create named groups for each metric and tag so that we can
 # access the values from the search result by name

--- a/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
@@ -527,7 +527,7 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
             [metric.__dict__ for metric in generated_metrics],
             [
                 {
-                    "name": "aws.lambda.enhanced.timed_out",
+                    "name": "aws.lambda.enhanced.timeout",
                     "tags": [
                         "region:us-east-1",
                         "account_id:0",


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Changes `aws.enhanced.lambda.timed_out` to `aws.enhance.lambda.timeout` to maintain  naming consistency.

### Motivation

We already submit a metric `aws.lambda.timeout`

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
