### PR TITLE
Update timed_out to timeouts and replace value with a count value

### DIFF
--- a/aws/logs_monitoring/enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/enhanced_lambda_metrics.py
@@ -28,7 +28,7 @@ BILLED_DURATION_METRIC_NAME = "billed_duration"
 MEMORY_ALLOCATED_FIELD_NAME = "memorysize"
 MAX_MEMORY_USED_METRIC_NAME = "max_memory_used"
 INIT_DURATION_METRIC_NAME = "init_duration"
-TIMED_OUT_DURATION_METRIC_NAME = "timeouts"
+TIMED_OUT_METRIC_NAME = "timeouts"
 
 # Create named groups for each metric and tag so that we can
 # access the values from the search result by name
@@ -45,9 +45,7 @@ REPORT_LOG_REGEX = re.compile(
 )
 
 TIMED_OUT_REGEX = re.compile(
-    r"Task\stimed\sout\safter\s+(?P<{}>[\d\.]+)\s+seconds".format(
-        TIMED_OUT_DURATION_METRIC_NAME
-    )
+    r"Task\stimed\sout\safter\s+(?P<{}>[\d\.]+)\s+seconds".format(TIMED_OUT_METRIC_NAME)
 )
 
 METRICS_TO_PARSE_FROM_REPORT = [
@@ -546,9 +544,6 @@ def create_timeout_enhanced_metric(report_log_line):
         return []
 
     dd_metric = DatadogMetricPoint(
-        "{}.{}".format(
-            ENHANCED_METRICS_NAMESPACE_PREFIX, TIMED_OUT_DURATION_METRIC_NAME
-        ),
-        1.0,
+        "{}.{}".format(ENHANCED_METRICS_NAMESPACE_PREFIX, TIMED_OUT_METRIC_NAME), 1.0,
     )
     return [dd_metric]

--- a/aws/logs_monitoring/enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/enhanced_lambda_metrics.py
@@ -28,7 +28,7 @@ BILLED_DURATION_METRIC_NAME = "billed_duration"
 MEMORY_ALLOCATED_FIELD_NAME = "memorysize"
 MAX_MEMORY_USED_METRIC_NAME = "max_memory_used"
 INIT_DURATION_METRIC_NAME = "init_duration"
-TIMED_OUT_DURATION_METRIC_NAME = "timed_out"
+TIMED_OUT_DURATION_METRIC_NAME = "timeout"
 
 # Create named groups for each metric and tag so that we can
 # access the values from the search result by name

--- a/aws/logs_monitoring/enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/enhanced_lambda_metrics.py
@@ -28,7 +28,7 @@ BILLED_DURATION_METRIC_NAME = "billed_duration"
 MEMORY_ALLOCATED_FIELD_NAME = "memorysize"
 MAX_MEMORY_USED_METRIC_NAME = "max_memory_used"
 INIT_DURATION_METRIC_NAME = "init_duration"
-TIMED_OUT_METRIC_NAME = "timeouts"
+TIMEOUTS_METRIC_NAME = "timeouts"
 
 # Create named groups for each metric and tag so that we can
 # access the values from the search result by name
@@ -45,7 +45,7 @@ REPORT_LOG_REGEX = re.compile(
 )
 
 TIMED_OUT_REGEX = re.compile(
-    r"Task\stimed\sout\safter\s+(?P<{}>[\d\.]+)\s+seconds".format(TIMED_OUT_METRIC_NAME)
+    r"Task\stimed\sout\safter\s+(?P<{}>[\d\.]+)\s+seconds".format(TIMEOUTS_METRIC_NAME)
 )
 
 METRICS_TO_PARSE_FROM_REPORT = [
@@ -544,6 +544,6 @@ def create_timeout_enhanced_metric(report_log_line):
         return []
 
     dd_metric = DatadogMetricPoint(
-        "{}.{}".format(ENHANCED_METRICS_NAMESPACE_PREFIX, TIMED_OUT_METRIC_NAME), 1.0,
+        "{}.{}".format(ENHANCED_METRICS_NAMESPACE_PREFIX, TIMEOUTS_METRIC_NAME), 1.0,
     )
     return [dd_metric]

--- a/aws/logs_monitoring/enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/enhanced_lambda_metrics.py
@@ -28,7 +28,7 @@ BILLED_DURATION_METRIC_NAME = "billed_duration"
 MEMORY_ALLOCATED_FIELD_NAME = "memorysize"
 MAX_MEMORY_USED_METRIC_NAME = "max_memory_used"
 INIT_DURATION_METRIC_NAME = "init_duration"
-TIMED_OUT_DURATION_METRIC_NAME = "timeout"
+TIMED_OUT_DURATION_METRIC_NAME = "timeouts"
 
 # Create named groups for each metric and tag so that we can
 # access the values from the search result by name
@@ -530,7 +530,7 @@ def get_enriched_lambda_log_tags(log_event):
 
 
 def create_timeout_enhanced_metric(report_log_line):
-    """Parses and returns timed out metric from lambda log
+    """Parses and returns a value of 1 if a timeout occured for the function
 
     Args:
         report_log_line (str): The timed out task log
@@ -549,6 +549,6 @@ def create_timeout_enhanced_metric(report_log_line):
         "{}.{}".format(
             ENHANCED_METRICS_NAMESPACE_PREFIX, TIMED_OUT_DURATION_METRIC_NAME
         ),
-        float(regex_match.group(TIMED_OUT_DURATION_METRIC_NAME)),
+        1.0,
     )
     return [dd_metric]

--- a/aws/logs_monitoring/enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/enhanced_lambda_metrics.py
@@ -530,7 +530,7 @@ def get_enriched_lambda_log_tags(log_event):
 
 
 def create_timeout_enhanced_metric(report_log_line):
-    """Parses and returns a value of 1 if a timeout occured for the function
+    """Parses and returns a value of 1 if a timeout occurred for the function
 
     Args:
         report_log_line (str): The timed out task log

--- a/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
@@ -527,7 +527,7 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
             [metric.__dict__ for metric in generated_metrics],
             [
                 {
-                    "name": "aws.lambda.enhanced.timed_out",
+                    "name": "aws.lambda.enhanced.timeout",
                     "tags": [
                         "region:us-east-1",
                         "account_id:0",

--- a/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
@@ -527,7 +527,7 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
             [metric.__dict__ for metric in generated_metrics],
             [
                 {
-                    "name": "aws.lambda.enhanced.timeout",
+                    "name": "aws.lambda.enhanced.timeouts",
                     "tags": [
                         "region:us-east-1",
                         "account_id:0",
@@ -539,7 +539,7 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
                         "creator:swf",
                     ],
                     "timestamp": 1591714946151,
-                    "value": 3.0,
+                    "value": 1.0,
                 }
             ],
         )


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Updates the name of `aws.enhanced.lambda.timed_out` to `aws.enhanced.lambda.timeouts`
Changes the value of the metric to count time out function occurrences.

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
