### PR TITLE
Update truncation behavior

### DIFF
--- a/aws/logs_monitoring/enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/enhanced_lambda_metrics.py
@@ -230,10 +230,10 @@ def sanitize_aws_tag_string(tag, remove_colons=False):
 
     if remove_colons:
         tag = tag.replace(":", "_")
-    tag = Dedupe(u"_", Sanitize(u"_", tag.lower()))
+    tag = Dedupe("_", Sanitize("_", tag.lower()))
     first_char = tag[0]
-    if first_char == u"_" or u"0" <= first_char <= "9":
-        tag = FixInit(u"", tag)
+    if first_char == "_" or "0" <= first_char <= "9":
+        tag = FixInit("", tag)
     tag = tag.rstrip("_")
     return tag
 

--- a/aws/logs_monitoring/enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/enhanced_lambda_metrics.py
@@ -213,7 +213,7 @@ def sanitize_aws_tag_string(tag, remove_colons=False):
     """
     global Sanitize, Dedupe, FixInit
 
-    # 1. Replaces colons with _
+    # 1. Replace colons with _
     # 2. Convert to all lowercase unicode string
     # 3. Convert bad characters to underscores
     # 4. Dedupe contiguous underscores
@@ -222,8 +222,7 @@ def sanitize_aws_tag_string(tag, remove_colons=False):
     #    FIXME: tag normalization incorrectly supports tags starting
     #    with a ':', but this behavior should be phased out in future
     #    as it results in unqueryable data.  See dogweb/#11193
-    # 6. Truncate to 200 characters
-    # 7. Strip trailing underscores
+    # 6. Strip trailing underscores
 
     if len(tag) == 0:
         # if tag is empty, nothing to do
@@ -235,12 +234,12 @@ def sanitize_aws_tag_string(tag, remove_colons=False):
     first_char = tag[0]
     if first_char == u"_" or u"0" <= first_char <= "9":
         tag = FixInit(u"", tag)
-    tag = tag[0:200].rstrip("_")
+    tag = tag.rstrip("_")
     return tag
 
 
 def get_dd_tag_string_from_aws_dict(aws_key_value_tag_dict):
-    """Converts the AWS dict tag format to the dd key:value string format
+    """Converts the AWS dict tag format to the dd key:value string format and truncates to 200 characters
 
     Args:
         aws_key_value_tag_dict (dict): the dict the GetResources endpoint returns for a tag
@@ -255,7 +254,7 @@ def get_dd_tag_string_from_aws_dict(aws_key_value_tag_dict):
     # Value is optional in DD and AWS
     if not value:
         return key
-    return "{}:{}".format(key, value)
+    return f"{key}:{value}"[0:200]
 
 
 def parse_get_resources_response_for_tags_by_arn(get_resources_page):

--- a/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
@@ -66,7 +66,7 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
         self.assertEqual(get_dd_tag_string_from_aws_dict(test_dict), "region:us-east-1")
 
         # Truncate to 200 characters
-        long_string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+        long_string = "a" * 300
 
         test_dict = {
             "Key": "too-long",

--- a/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
@@ -73,7 +73,9 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
             "Value": long_string,
         }
 
-        self.assertEqual(get_dd_tag_string_from_aws_dict(test_dict), f"too-long:{long_string[0:191]}")
+        self.assertEqual(
+            get_dd_tag_string_from_aws_dict(test_dict), f"too-long:{long_string[0:191]}"
+        )
 
     def test_parse_lambda_tags_from_arn(self):
         self.assertListEqual(

--- a/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
@@ -11,6 +11,7 @@ from enhanced_lambda_metrics import (
     LambdaTagsCache,
     parse_get_resources_response_for_tags_by_arn,
     create_timeout_enhanced_metric,
+    get_dd_tag_string_from_aws_dict,
 )
 
 
@@ -54,6 +55,25 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
         # Convert to lower
         self.assertEqual(sanitize_aws_tag_string("serVerLess"), "serverless")
         self.assertEqual(sanitize_aws_tag_string(""), "")
+
+    def test_get_dd_tag_string_from_aws_dict(self):
+        # Sanitize the key and value, combine them into a string
+        test_dict = {
+            "Key": "region",
+            "Value": "us-east-1",
+        }
+
+        self.assertEqual(get_dd_tag_string_from_aws_dict(test_dict), "region:us-east-1")
+
+        # Truncate to 200 characters
+        long_string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+
+        test_dict = {
+            "Key": "too-long",
+            "Value": long_string,
+        }
+
+        self.assertEqual(get_dd_tag_string_from_aws_dict(test_dict), f"too-long:{long_string[0:191]}")
 
     def test_parse_lambda_tags_from_arn(self):
         self.assertListEqual(


### PR DESCRIPTION
### What does this PR do?

Updates the truncation behavior for tag strings. Instead of truncating the key and the value separately, truncates the combined `key:value` string to 200 characters.

### Motivation

### Testing Guidelines

Updated and added unit tests.

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
