### PR TITLE
Change private link URL

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -232,17 +232,17 @@ The CloudFormation Stack creates following IAM roles:
 
   </details>
 
-## AWS Private Link Support
+## AWS PrivateLink Support
 
-The forwarder can be configured using AWS Private Link to run in a VPC.
+The forwarder can be configured using AWS PrivateLink to run in a VPC.
 
 1. Follow the [setup instructions](https://docs.datadoghq.com/agent/guide/private-link/?tab=logs#create-your-vpc-endpoint) for adding datadog's endpoints to your VPC.
 1. By default, the forwarder's API key will be stored in Secrets Manager. The secrets manager endpoint will need to be added to the VPC. You can follow the instructions [here for adding AWS services to a VPC](https://docs.aws.amazon.com/vpc/latest/userguide/vpce-interface.html#create-interface-endpoint).
 1. When in installing the forwarder via the cloudformation template, enable 'DdUsePrivateLink' and set at least one Subnet Id and Security Group.
 
-### AWS Private Link Limitations
+### AWS PrivateLink Limitations
 
-Currently AWS Private Link can only be configured with datadog organizations on the datadoghq.com site. Trace forwarding is also currently unsupported.
+Currently AWS PrivateLink can only be configured with Datadog organizations in the Datadog US region. Trace forwarding is also currently unsupported.
 
 ## Notes
 

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -13,7 +13,7 @@ import os
 import boto3
 import itertools
 import re
-import six.moves.urllib as urllib  # for for Python 2.7 urllib.unquote_plus
+import six.moves.urllib as urllib  # for Python 2.7 urllib.unquote_plus
 import socket
 import ssl
 import logging
@@ -186,7 +186,7 @@ if DD_USE_PRIVATE_LINK:
     # Traces aren't supported via private link yet
     DD_FORWARD_TRACES = False
     # Override urls to use the private link url
-    DD_URL = "pvtlink.logs.datadoghq.com"
+    DD_URL = "api-pvtlink.logs.datadoghq.com"
     DD_API_URL = "https://pvtlink.api.datadoghq.com"
 
 


### PR DESCRIPTION
### What does this PR do?

Change the `DD_URL` used when forwarding logs via AWS PrivateLink to a new endpoint that correctly supports tags and attributes.

### Motivation

Support tags and attributes in logs when using AWS PrivateLink.

### Testing Guidelines

### Additional Notes

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
