### PR TITLE
Add mention of undocumented SNS support

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -4,7 +4,7 @@ AWS Lambda function to ship logs from S3 and CloudWatch, custom metrics and trac
 
 ## Features
 
-- Forward CloudWatch, ELB, S3, CloudTrail, VPC and CloudFront logs to Datadog
+- Forward CloudWatch, ELB, S3, CloudTrail, VPC, SNS, and CloudFront logs to Datadog
 - Forward S3 events to Datadog
 - Forward Kinesis data stream events to Datadog, only CloudWatch logs are supported
 - Forward custom metrics from AWS Lambda functions via CloudWatch logs


### PR DESCRIPTION
Had to check the source code to confirm this was supported

https://github.com/DataDog/datadog-serverless-functions/blob/e9180b1bbdd9ccef14d4c498d47d2901c28bbea5/aws/logs_monitoring/lambda_function.py#L624

There is sort of/kind of a reference to this, but it's worded in a very strange way. Logging isn't supported, but it is, by picking an ARN that you "want to use".  I'm assuming what it really means, is select *the* datadog logs forwarder, you set up here<link to cloudformation forwarder documentation>


### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

### Motivation

I want to be able to view triggered SNS topics and payloads in DataDog's "Logs", in contexts that do not make sense under "Events" 

### Additional Notes

Related issue to potentially confusing integration instructions https://github.com/DataDog/documentation/issues/7801

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
