### PR TITLE
Add out_of_memory enhanced metric

### DIFF
--- a/aws/logs_monitoring/enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/enhanced_lambda_metrics.py
@@ -331,7 +331,7 @@ def build_tags_by_arn_cache():
 
 
 def parse_and_submit_enhanced_metrics(logs):
-    """Parses enhanced metrics from REPORT logs and submits them to DD with tags
+    """Parses enhanced metrics from logs and submits them to DD with tags
 
     Args:
         logs (dict<str, str | dict | int>[]): the logs parsed from the event in the split method

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -551,13 +551,6 @@ class DatadogScrubber(object):
         return payload
 
 
-def log_has_report_msg(log):
-    msg = log.get("message", "")
-    if isinstance(msg, str):
-        return True
-    return False
-
-
 def datadog_forwarder(event, context):
     """The actual lambda function entry point"""
     if log.isEnabledFor(logging.DEBUG):
@@ -575,8 +568,7 @@ def datadog_forwarder(event, context):
         forward_traces(traces)
 
     if IS_ENHANCED_METRICS_FILE_PRESENT and DD_FORWARD_METRIC:
-        report_logs = filter(log_has_report_msg, logs)
-        parse_and_submit_enhanced_metrics(report_logs)
+        parse_and_submit_enhanced_metrics(logs)
 
 
 if DD_FORWARD_METRIC or DD_FORWARD_TRACES:


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adds `aws.lambda.enhanced.out_of_memory` metric to count "out of memory" errors that appear in the logs.

### Motivation

Will allow customers to keep track of when Lambda functions run out of memory. 

### Testing Guidelines

I added unit test coverage. Before merging, I will also test this in the demo AWS account.

### Additional Notes

The AWS Lambda Ruby runtime seems not to log out of memory errors correctly. Instead, the runtime seems to be unable to sanitize the stacktrace that is generated. Therefore, as of right now, this will not work for Ruby lambdas. I still think this is the right approach, and that the issue is on the AWS side. We should discuss whether/how to bring this issue to Amazon's attention.

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
