### PR TITLE
Batch traces before making API calls

### DIFF
--- a/.github/workflows/lambdachecks.yml
+++ b/.github/workflows/lambdachecks.yml
@@ -36,5 +36,5 @@ jobs:
         env:
           AWS_DEFAULT_REGION: us-east-1
         run: |
-          pip install boto3
+          pip install boto3 mock
           python -m unittest discover ./aws/logs_monitoring/

--- a/.github/workflows/lambdachecks.yml
+++ b/.github/workflows/lambdachecks.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Run trace forwarder integration tests
         run: |
           ./aws/logs_monitoring/trace_forwarder/scripts/run_tests.sh
-      - name: Run enhanced metric unittest
+      - name: Run unit tests
         env:
           AWS_DEFAULT_REGION: us-east-1
         run: |

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -836,7 +836,7 @@ def batch_trace_payloads(trace_payloads):
         batches = batcher.batch(traces)
         for batch in batches:
             batched_trace_payloads.append(
-                {tags: tags, message: json.dumps({"traces": batch})}
+                {"tags": tags, "message": json.dumps({"traces": batch})}
             )
 
     return batched_trace_payloads

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -563,7 +563,7 @@ def datadog_forwarder(event, context):
         forward_metrics(metrics)
         xray_recorder.end_subsegment()
 
-    if DD_FORWARD_TRACES and len(trace_payloads > 0):
+    if DD_FORWARD_TRACES and len(trace_payloads) > 0:
         xray_recorder.begin_subsegment("forward traces")
         forward_traces(trace_payloads)
         xray_recorder.end_subsegment()

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -473,7 +473,7 @@ class DatadogBatcher(object):
         self._max_items_count = max_items_count
 
     def _sizeof_bytes(self, item):
-        return len(item.encode("UTF-8"))
+        return len(str(item).encode("UTF-8"))
 
     def batch(self, items):
         """
@@ -827,7 +827,7 @@ def batch_trace_payloads(trace_payloads):
     traces_grouped_by_tags = defaultdict(list)
     for trace_payload in trace_payloads:
         tags = trace_payload["tags"]
-        traces = json.parse(trace_payload["message"])["traces"]
+        traces = json.loads(trace_payload["message"])["traces"]
         traces_grouped_by_tags[tags] += traces
 
     batched_trace_payloads = []

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -24,6 +24,10 @@ from datadog_lambda.wrapper import datadog_lambda_wrapper
 from datadog_lambda.metric import lambda_stats
 from datadog import api
 from trace_forwarder.connection import TraceConnection
+from enhanced_lambda_metrics import (
+    get_enriched_lambda_log_tags,
+    parse_and_submit_enhanced_metrics,
+)
 
 from aws_xray_sdk.core import xray_recorder
 from aws_xray_sdk.core import patch_all
@@ -559,7 +563,7 @@ def datadog_forwarder(event, context):
         forward_metrics(metrics)
         xray_recorder.end_subsegment()
 
-    if DD_FORWARD_TRACES and len(traces) > 0:
+    if DD_FORWARD_TRACES and len(trace_payloads > 0):
         xray_recorder.begin_subsegment("forward traces")
         forward_traces(trace_payloads)
         xray_recorder.end_subsegment()
@@ -820,7 +824,7 @@ def batch_trace_payloads(trace_payloads):
     """
     To reduce the number of API calls, batch traces that have the same tags
     """
-    traces_grouped_by_tags = defaultdict(List)
+    traces_grouped_by_tags = defaultdict(list)
     for trace_payload in trace_payloads:
         tags = trace_payload["tags"]
         traces = json.parse(trace_payload["message"])["traces"]

--- a/aws/logs_monitoring/tests/test_lambda_function.py
+++ b/aws/logs_monitoring/tests/test_lambda_function.py
@@ -11,7 +11,7 @@ sys.modules["requests"] = MagicMock()
 from lambda_function import batch_trace_payloads
 
 
-@patch.dict('os.environ', {'DD_API_KEY': '11111111111111111111111111111111'}):
+@patch.dict('os.environ', {'DD_API_KEY': '11111111111111111111111111111111'})
 class TestBatchTracePayloads(unittest.TestCase):
     def test_batch_trace_payloads(self):
         trace_payloads = [

--- a/aws/logs_monitoring/tests/test_lambda_function.py
+++ b/aws/logs_monitoring/tests/test_lambda_function.py
@@ -1,8 +1,9 @@
 import unittest
-from unittest.mock import MagicMock
+from mock import MagicMock
 import sys
 
-sys.modules["datadog_lambda"] = MagicMock()
+sys.modules["datadog_lambda.wrapper"] = MagicMock()
+sys.modules["datadog_lambda.metric"] = MagicMock()
 
 from lambda_function import batch_trace_payloads
 

--- a/aws/logs_monitoring/tests/test_lambda_function.py
+++ b/aws/logs_monitoring/tests/test_lambda_function.py
@@ -11,7 +11,7 @@ sys.modules["requests"] = MagicMock()
 from lambda_function import batch_trace_payloads
 
 
-@patch.dict("os.environ", {"DD_API_KEY": "11111111111111111111111111111111"})
+@patch.dict(os.environ, {"DD_API_KEY": "11111111111111111111111111111111"})
 class TestBatchTracePayloads(unittest.TestCase):
     def test_batch_trace_payloads(self):
         trace_payloads = [

--- a/aws/logs_monitoring/tests/test_lambda_function.py
+++ b/aws/logs_monitoring/tests/test_lambda_function.py
@@ -2,7 +2,6 @@ import unittest
 
 from lambda_function import batch_trace_payloads
 
-
 class TestBatchTracePayloads(unittest.TestCase):
     def test_batch_trace_payloads(self):
         trace_payloads = [
@@ -22,11 +21,11 @@ class TestBatchTracePayloads(unittest.TestCase):
         expected_batched_payloads = [
             {
                 "tags": "tag1:value",
-                "message": '{"traces":[[{"trace_id":"1"}], [[{"trace_id":"2"}, {"trace_id":"3"}]]}\n',
+                "message": '{"traces": [[{"trace_id": "1"}], [{"trace_id": "2"}, {"trace_id": "3"}]]}',
             },
             {
                 "tags": "tag2:value",
-                "message": '{"traces":[[{"trace_id":"4"}], [{"trace_id":"5"}]]}\n',
+                "message": '{"traces": [[{"trace_id": "4"}], [{"trace_id": "5"}]]}',
             },
         ]
 

--- a/aws/logs_monitoring/tests/test_lambda_function.py
+++ b/aws/logs_monitoring/tests/test_lambda_function.py
@@ -4,6 +4,7 @@ import sys
 
 sys.modules["datadog_lambda.wrapper"] = MagicMock()
 sys.modules["datadog_lambda.metric"] = MagicMock()
+sys.modules["datadog"] = MagicMock()
 
 from lambda_function import batch_trace_payloads
 

--- a/aws/logs_monitoring/tests/test_lambda_function.py
+++ b/aws/logs_monitoring/tests/test_lambda_function.py
@@ -5,6 +5,7 @@ import sys
 sys.modules["datadog_lambda.wrapper"] = MagicMock()
 sys.modules["datadog_lambda.metric"] = MagicMock()
 sys.modules["datadog"] = MagicMock()
+sys.modules["requests"] = MagicMock()
 
 from lambda_function import batch_trace_payloads
 

--- a/aws/logs_monitoring/tests/test_lambda_function.py
+++ b/aws/logs_monitoring/tests/test_lambda_function.py
@@ -11,7 +11,7 @@ sys.modules["requests"] = MagicMock()
 from lambda_function import batch_trace_payloads
 
 
-@patch.dict('os.environ', {'DD_API_KEY': '11111111111111111111111111111111'})
+@patch.dict("os.environ", {"DD_API_KEY": "11111111111111111111111111111111"})
 class TestBatchTracePayloads(unittest.TestCase):
     def test_batch_trace_payloads(self):
         trace_payloads = [

--- a/aws/logs_monitoring/tests/test_lambda_function.py
+++ b/aws/logs_monitoring/tests/test_lambda_function.py
@@ -1,6 +1,7 @@
-import unittest
-from mock import MagicMock
+from mock import MagicMock, patch
+import os
 import sys
+import unittest
 
 sys.modules["datadog_lambda.wrapper"] = MagicMock()
 sys.modules["datadog_lambda.metric"] = MagicMock()
@@ -10,6 +11,7 @@ sys.modules["requests"] = MagicMock()
 from lambda_function import batch_trace_payloads
 
 
+@patch.dict('os.environ', {'DD_API_KEY': '11111111111111111111111111111111'}):
 class TestBatchTracePayloads(unittest.TestCase):
     def test_batch_trace_payloads(self):
         trace_payloads = [

--- a/aws/logs_monitoring/tests/test_lambda_function.py
+++ b/aws/logs_monitoring/tests/test_lambda_function.py
@@ -1,0 +1,37 @@
+import unittest
+
+from lambda_function import batch_trace_payloads
+
+
+class TestBatchTracePayloads(unittest.TestCase):
+    def test_batch_trace_payloads(self):
+        trace_payloads = [
+            {"tags": "tag1:value", "message": '{"traces":[[{"trace_id":"1"}]]}\n',},
+            {
+                "tags": "tag1:value",
+                "message": '{"traces":[[{"trace_id":"2"}, {"trace_id":"3"}]]}\n',
+            },
+            {
+                "tags": "tag2:value",
+                "message": '{"traces":[[{"trace_id":"4"}], [{"trace_id":"5"}]]}\n',
+            },
+        ]
+
+        batched_payloads = batch_trace_payloads(trace_payloads)
+
+        expected_batched_payloads = [
+            {
+                "tags": "tag1:value",
+                "message": '{"traces":[[{"trace_id":"1"}], [[{"trace_id":"2"}, {"trace_id":"3"}]]}\n',
+            },
+            {
+                "tags": "tag2:value",
+                "message": '{"traces":[[{"trace_id":"4"}], [{"trace_id":"5"}]]}\n',
+            },
+        ]
+
+        self.assertEqual(batched_payloads, expected_batched_payloads)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/aws/logs_monitoring/tests/test_lambda_function.py
+++ b/aws/logs_monitoring/tests/test_lambda_function.py
@@ -8,9 +8,7 @@ sys.modules["datadog_lambda.metric"] = MagicMock()
 sys.modules["datadog"] = MagicMock()
 sys.modules["requests"] = MagicMock()
 
-env_patch = patch.dict(
-    os.environ, {"DD_API_KEY": "11111111111111111111111111111111"}
-)
+env_patch = patch.dict(os.environ, {"DD_API_KEY": "11111111111111111111111111111111"})
 env_patch.start()
 from lambda_function import batch_trace_payloads
 

--- a/aws/logs_monitoring/tests/test_lambda_function.py
+++ b/aws/logs_monitoring/tests/test_lambda_function.py
@@ -2,6 +2,7 @@ import unittest
 
 from lambda_function import batch_trace_payloads
 
+
 class TestBatchTracePayloads(unittest.TestCase):
     def test_batch_trace_payloads(self):
         trace_payloads = [

--- a/aws/logs_monitoring/tests/test_lambda_function.py
+++ b/aws/logs_monitoring/tests/test_lambda_function.py
@@ -8,9 +8,12 @@ sys.modules["datadog_lambda.metric"] = MagicMock()
 sys.modules["datadog"] = MagicMock()
 sys.modules["requests"] = MagicMock()
 
-env_patch = mock.patch.dict(os.environ, {"DD_API_KEY": "11111111111111111111111111111111"})
+env_patch = mock.patch.dict(
+    os.environ, {"DD_API_KEY": "11111111111111111111111111111111"}
+)
 env_patch.start()
 from lambda_function import batch_trace_payloads
+
 env_patch.stop()
 
 

--- a/aws/logs_monitoring/tests/test_lambda_function.py
+++ b/aws/logs_monitoring/tests/test_lambda_function.py
@@ -8,7 +8,7 @@ sys.modules["datadog_lambda.metric"] = MagicMock()
 sys.modules["datadog"] = MagicMock()
 sys.modules["requests"] = MagicMock()
 
-env_patch = mock.patch.dict(
+env_patch = patch.dict(
     os.environ, {"DD_API_KEY": "11111111111111111111111111111111"}
 )
 env_patch.start()

--- a/aws/logs_monitoring/tests/test_lambda_function.py
+++ b/aws/logs_monitoring/tests/test_lambda_function.py
@@ -1,4 +1,8 @@
 import unittest
+from unittest.mock import MagicMock
+import sys
+
+sys.modules["datadog_lambda"] = MagicMock()
 
 from lambda_function import batch_trace_payloads
 

--- a/aws/logs_monitoring/tests/test_lambda_function.py
+++ b/aws/logs_monitoring/tests/test_lambda_function.py
@@ -8,10 +8,12 @@ sys.modules["datadog_lambda.metric"] = MagicMock()
 sys.modules["datadog"] = MagicMock()
 sys.modules["requests"] = MagicMock()
 
+env_patch = mock.patch.dict(os.environ, {"DD_API_KEY": "11111111111111111111111111111111"})
+env_patch.start()
 from lambda_function import batch_trace_payloads
+env_patch.stop()
 
 
-@patch.dict(os.environ, {"DD_API_KEY": "11111111111111111111111111111111"})
 class TestBatchTracePayloads(unittest.TestCase):
     def test_batch_trace_payloads(self):
         trace_payloads = [

--- a/aws/logs_monitoring/trace_forwarder/cmd/trace/main.go
+++ b/aws/logs_monitoring/trace_forwarder/cmd/trace/main.go
@@ -82,12 +82,11 @@ func combinePayloads(tracePayloads []*pb.TracePayload) *pb.TracePayload {
 	combinedPayload := &pb.TracePayload{
 		HostName: tracePayloads[0].HostName,
 		Env:      tracePayloads[0].Env,
-		Traces:   make([]*pb.APITrace, 0),
+		Traces:   make([]*pb.APITrace, len(tracePayloads)),
 	}
 	for _, tracePayload := range tracePayloads {
 		combinedPayload.Traces = append(combinedPayload.Traces, tracePayload.Traces...)
 	}
-	fmt.Sprintf("aggregated %d traces into single payload", len(combinedPayload.Traces))
 	return combinedPayload
 }
 

--- a/aws/logs_monitoring/trace_forwarder/cmd/trace/main.go
+++ b/aws/logs_monitoring/trace_forwarder/cmd/trace/main.go
@@ -45,13 +45,13 @@ func Configure(rootURL, apiKey string) {
 	edgeConnection = apm.CreateTraceEdgeConnection(localRootURL, localAPIKey)
 }
 
-// ForwardTrace will perform filtering and log forwarding to the trace intake
+// ForwardTraces will perform filtering and log forwarding to the trace intake
 // returns 0 on success, 1 on error
-//export ForwardTrace
+//export ForwardTraces
 func ForwardTraces(content string, tags string) int {
 	tracePayloads, err := apm.ProcessTrace(content, obfuscator, tags)
 	if err != nil {
-		fmt.Printf("Couldn't forward trace: %v", err)
+		fmt.Printf("Couldn't forward traces: %v", err)
 		return 1
 	}
 	hadErr := false

--- a/aws/logs_monitoring/trace_forwarder/cmd/trace/main.go
+++ b/aws/logs_monitoring/trace_forwarder/cmd/trace/main.go
@@ -82,7 +82,7 @@ func combinePayloads(tracePayloads []*pb.TracePayload) *pb.TracePayload {
 	combinedPayload := &pb.TracePayload{
 		HostName: tracePayloads[0].HostName,
 		Env:      tracePayloads[0].Env,
-		Traces:   make([]*pb.APITrace, len(tracePayloads)),
+		Traces:   make([]*pb.APITrace, 0),
 	}
 	for _, tracePayload := range tracePayloads {
 		combinedPayload.Traces = append(combinedPayload.Traces, tracePayload.Traces...)

--- a/aws/logs_monitoring/trace_forwarder/cmd/trace/main.go
+++ b/aws/logs_monitoring/trace_forwarder/cmd/trace/main.go
@@ -48,7 +48,7 @@ func Configure(rootURL, apiKey string) {
 // ForwardTrace will perform filtering and log forwarding to the trace intake
 // returns 0 on success, 1 on error
 //export ForwardTrace
-func ForwardTrace(content string, tags string) int {
+func ForwardTraces(content string, tags string) int {
 	tracePayloads, err := apm.ProcessTrace(content, obfuscator, tags)
 	if err != nil {
 		fmt.Printf("Couldn't forward trace: %v", err)

--- a/aws/logs_monitoring/trace_forwarder/connection.py
+++ b/aws/logs_monitoring/trace_forwarder/connection.py
@@ -23,9 +23,10 @@ class TraceConnection:
         self.lib = cdll.LoadLibrary("{}/bin/trace-intake.so".format(dir))
         self.lib.Configure(make_go_string(root_url), make_go_string(api_key))
 
-    def send_trace(self, trace_str, tags=""):
+    def send_traces(self, traces_str, tags=""):
         had_error = (
-            self.lib.ForwardTrace(make_go_string(trace_str), make_go_string(tags)) != 0
+            self.lib.ForwardTraces(make_go_string(traces_str), make_go_string(tags))
+            != 0
         )
         if had_error:
             raise Exception("Failed to send to trace intake")


### PR DESCRIPTION
### What does this PR do?

Batch traces with like tags before sending them to the Trace Forwarder. Also removes old code that allowed the forwarder to be run without an enhanced metrics file present.


### Motivation

This should reduce the number of API calls we make when forwarding traces, which will hopefully allow the Lambda to run faster, particularly when sending a large number of traces.

### Testing Guidelines

Unit and integration test coverage. Performance testing with X-Ray.

### Additional Notes

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
