### PR TITLE
[azure event hub forwarder] Convert strings to json logs

### DIFF
--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2019 Datadog, Inc.
+// Copyright 2020 Datadog, Inc.
 
 var tls = require('tls');
 

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -79,10 +79,10 @@ function handleLogs(sender, logs, context) {
             logs.forEach(sender(addTagsToStringLog));
             break;
         case JSON_ARRAY:
-            handleJSONArrayLogs(sender, logs, JSON_ARRAY);
+            handleJSONArrayLogs(sender, context, logs, JSON_ARRAY);
             break;
         case JSON_STRING_ARRAY:
-            handleJSONArrayLogs(sender, logs, JSON_STRING_ARRAY);
+            handleJSONArrayLogs(sender, context, logs, JSON_STRING_ARRAY);
             break;
         case INVALID:
         default:
@@ -91,7 +91,7 @@ function handleLogs(sender, logs, context) {
     }
 }
 
-function handleJSONArrayLogs(sender, logs, logsType) {
+function handleJSONArrayLogs(sender, context, logs, logsType) {
     logs.forEach(message => {
         if (logsType == JSON_STRING_ARRAY) {
             try {

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -10,14 +10,15 @@ const VERSION = '0.1.1';
 const STRING = 'string'; // example: 'some message'
 const STRING_ARRAY = 'string-array'; // example: ['one message', 'two message', ...]
 const JSON_OBJECT = 'json-object'; // example: {"key": "value"}
-const JSON_RECORDS = 'json-records'; // example: [{"records": [{}, {}, ...]}, {"records": [{}, {}, ...]}, ...]
-const JSON_ARRAY = 'json-array'; // example: [{"key": "value"}, {"key": "value"}, ...]
+const JSON_ARRAY = 'json-array'; // example: [{"key": "value"}, {"key": "value"}, ...] or [{"records": [{}, {}, ...]}, {"records": [{}, {}, ...]}, ...]
+const JSON_STRING = 'json-string'; // example: '{"key": "value"}'
+const JSON_STRING_ARRAY = 'json-string-array'; // example: ['{"records": [{}, {}]}'] or ['{"key": "value"}']
 const INVALID = 'invalid';
 
 const DD_API_KEY = process.env.DD_API_KEY || '<DATADOG_API_KEY>';
 const DD_SITE = process.env.DD_SITE || 'datadoghq.com';
 const DD_URL = process.env.DD_URL || 'functions-intake.logs.' + DD_SITE;
-const DD_PORT = process.env.DD_PORT || (DD_SITE === 'datadoghq.eu') ? 443 : 10516
+const DD_PORT = process.env.DD_PORT || DD_SITE === 'datadoghq.eu' ? 443 : 10516;
 const DD_TAGS = process.env.DD_TAGS || ''; // Replace '' by your comma-separated list of tags
 const DD_SERVICE = process.env.DD_SERVICE || 'azure';
 const DD_SOURCE = process.env.DD_SOURCE || 'azure';
@@ -67,19 +68,21 @@ function handleLogs(sender, logs, context) {
         case STRING:
             sender(addTagsToStringLog)(logs);
             break;
+        case JSON_STRING:
+            logs = JSON.parse(logs);
+            sender(addTagsToJsonLog)(logs);
+            break;
         case JSON_OBJECT:
             sender(addTagsToJsonLog)(logs);
             break;
         case STRING_ARRAY:
             logs.forEach(sender(addTagsToStringLog));
             break;
-        case JSON_RECORDS:
-            logs.forEach(message => {
-                message.records.forEach(sender(addTagsToJsonLog));
-            });
-            break;
         case JSON_ARRAY:
-            logs.forEach(sender(addTagsToJsonLog));
+            handleJSONArrayLogs(sender, logs, JSON_ARRAY);
+            break;
+        case JSON_STRING_ARRAY:
+            handleJSONArrayLogs(sender, logs, JSON_STRING_ARRAY);
             break;
         case INVALID:
         default:
@@ -88,8 +91,30 @@ function handleLogs(sender, logs, context) {
     }
 }
 
+function handleJSONArrayLogs(sender, logs, logsType) {
+    logs.forEach(message => {
+        if (logsType == JSON_STRING_ARRAY) {
+            try {
+                message = JSON.parse(message);
+            } catch (err) {
+                context.log.warn('log is malformed json, sending as string');
+                sender(addTagsToStringLog)(message);
+                return;
+            }
+        }
+        if (message.records != undefined) {
+            message.records.forEach(sender(addTagsToJsonLog));
+        } else {
+            sender(addTagsToJsonLog)(message);
+        }
+    });
+}
+
 function getLogFormat(logs) {
     if (typeof logs === 'string') {
+        if (isJsonString(logs)) {
+            return JSON_STRING;
+        }
         return STRING;
     }
     if (!Array.isArray(logs) && typeof logs === 'object' && logs !== null) {
@@ -99,16 +124,25 @@ function getLogFormat(logs) {
         return INVALID;
     }
     if (typeof logs[0] === 'object') {
-        if (logs[0].records !== undefined) {
-            return JSON_RECORDS;
-        } else {
-            return JSON_ARRAY;
-        }
+        return JSON_ARRAY;
     }
     if (typeof logs[0] === 'string') {
-        return STRING_ARRAY;
+        if (isJsonString(logs[0])) {
+            return JSON_STRING_ARRAY;
+        } else {
+            return STRING_ARRAY;
+        }
     }
     return INVALID;
+}
+
+function isJsonString(record) {
+    try {
+        JSON.parse(record);
+        return true;
+    } catch (err) {
+        return false;
+    }
 }
 
 function addTagsToJsonLog(record, context) {
@@ -138,39 +172,46 @@ function extractResourceId(record) {
         typeof record.resourceId !== 'string'
     ) {
         return metadata;
-    }
-    else if(record.resourceId.toLowerCase().startsWith('/subscriptions/')){
-      var resourceId = record.resourceId.toLowerCase().split('/');
-      if (resourceId.length > 2) {
-          metadata.tags.push('subscription_id:' + resourceId[2]);
-      }
-      if (resourceId.length > 4) {
-          metadata.tags.push('resource_group:' + resourceId[4]);
-      }
-      if (resourceId.length > 6 && resourceId[6]) {
-          metadata.source = resourceId[6].replace('microsoft.', 'azure.');
-      }
-      return metadata;
-    }
-    else if(record.resourceId.toLowerCase().startsWith('/tenants/')){
-      var resourceId = record.resourceId.toLowerCase().split('/');
-      if (resourceId.length > 4 && resourceId[4]) {
-          metadata.tags.push('tenant:' + resourceId[2]);
-          metadata.source = resourceId[4].replace('microsoft.', 'azure.').replace('aadiam', 'activedirectory');
-      }
-      return metadata;
+    } else if (record.resourceId.toLowerCase().startsWith('/subscriptions/')) {
+        var resourceId = record.resourceId.toLowerCase().split('/');
+        if (resourceId.length > 2) {
+            metadata.tags.push('subscription_id:' + resourceId[2]);
+        }
+        if (resourceId.length > 4) {
+            metadata.tags.push('resource_group:' + resourceId[4]);
+        }
+        if (resourceId.length > 6 && resourceId[6]) {
+            metadata.source = resourceId[6].replace('microsoft.', 'azure.');
+        }
+        return metadata;
+    } else if (record.resourceId.toLowerCase().startsWith('/tenants/')) {
+        var resourceId = record.resourceId.toLowerCase().split('/');
+        if (resourceId.length > 4 && resourceId[4]) {
+            metadata.tags.push('tenant:' + resourceId[2]);
+            metadata.source = resourceId[4]
+                .replace('microsoft.', 'azure.')
+                .replace('aadiam', 'activedirectory');
+        }
+        return metadata;
+    } else {
+        return metadata;
     }
 }
 
 module.exports.forTests = {
     getLogFormat,
     extractResourceId,
+    handleLogs,
+    isJsonString,
+    addTagsToStringLog,
+    addTagsToJsonLog,
     constants: {
         STRING,
         STRING_ARRAY,
         JSON_OBJECT,
-        JSON_RECORDS,
         JSON_ARRAY,
+        JSON_STRING,
+        JSON_STRING_ARRAY,
         INVALID
     }
 };

--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -4,6 +4,51 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@sinonjs/commons": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.0.tgz",
+      "integrity": "sha512-wEj54PfsZ5jGSwMX68G8ZXFawcSglQSXqCftWX3ec8MDUzQdHgcKvw97awHbY0efQEL5iKUOAmmVtoYgmrSG4Q==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
+      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^5.0.2"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.0.3.tgz",
+      "integrity": "sha512-QucHkc2uMJ0pFGjJUDP3F9dq5dx8QIaqISl9QgwLOh6P9yv877uONPGXh/OH/0zmM3tW1JjuJltAZV2l7zU+uQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "ansi-colors": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
@@ -363,6 +408,12 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -379,6 +430,12 @@
         "esprima": "^4.0.0"
       }
     },
+    "just-extend": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
+      "integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==",
+      "dev": true
+    },
     "locate-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -393,6 +450,12 @@
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "log-symbols": {
@@ -464,6 +527,19 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "dev": true
+    },
+    "nise": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.4.tgz",
+      "integrity": "sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
     },
     "node-environment-flags": {
       "version": "1.0.5",
@@ -554,6 +630,15 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      }
+    },
     "prettier": {
       "version": "1.16.4",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.4.tgz",
@@ -583,6 +668,44 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
+    },
+    "sinon": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.2.tgz",
+      "integrity": "sha512-0uF8Q/QHkizNUmbK3LRFqx5cpTttEVXudywY9Uwzy8bTfZUhljZ7ARzSxnRHWYWtVTeh4Cw+tTb3iU21FQVO9A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.2",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/formatio": "^5.0.1",
+        "@sinonjs/samsam": "^5.0.3",
+        "diff": "^4.0.2",
+        "nise": "^4.0.1",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -665,6 +788,12 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "which": {
       "version": "1.3.1",

--- a/azure/package.json
+++ b/azure/package.json
@@ -23,6 +23,7 @@
     "dependencies": {},
     "devDependencies": {
         "mocha": "^6.2.3",
-        "prettier": "^1.16.4"
+        "prettier": "^1.16.4",
+        "sinon": "^9.0.2"
     }
 }

--- a/azure/test/client.test.js
+++ b/azure/test/client.test.js
@@ -16,10 +16,6 @@ describe('Azure Log Monitoring', function() {
       eventHubMessages = ['', 'foobar'];
       assert.equal(constants.STRING_ARRAY, client.getLogFormat(eventHubMessages));
     });
-//    it('should return json with records', function() {
-//      eventHubMessages = [{'records': [{}, {}]}, {'records': [{}, {}]}];
-//      assert.equal(constants.JSON_RECORDS, client.getLogFormat(eventHubMessages));
-//    });
     it('should return json object', function() {
       eventHubMessages = {'key': 'value', 'otherkey':'othervalue'};
       assert.equal(constants.JSON_OBJECT, client.getLogFormat(eventHubMessages));
@@ -105,7 +101,7 @@ describe('Azure Log Monitoring', function() {
     if (isJson == true) {
       sinon.assert.calledWith(handleJsonLogsSpy, expected)
     } else {
-          sinon.assert.calledWith(handleStringLogsSpy, expected)
+      sinon.assert.calledWith(handleStringLogsSpy, expected)
 
     }
   }
@@ -166,6 +162,5 @@ describe('Azure Log Monitoring', function() {
       assert.equal(client.getLogFormat(record), constants.JSON_STRING_ARRAY)
       testHandleLogs(record, expected, true)
     });
-
   })
 });

--- a/azure/test/client.test.js
+++ b/azure/test/client.test.js
@@ -81,6 +81,8 @@ describe('Azure Log Monitoring', function() {
     contextSpy = sinon.spy()
     contextSpy.log = sinon.spy()
     contextSpy.log.error = function(x) {} // do nothing
+    contextSpy.log.warn = function(x) {} // do nothing
+
     return contextSpy
   }
 
@@ -161,6 +163,13 @@ describe('Azure Log Monitoring', function() {
       expected = {"time": "xyz"}
       assert.equal(client.getLogFormat(record), constants.JSON_STRING_ARRAY)
       testHandleLogs(record, expected, true)
+    });
+
+    it('should handle json-string-array with malformed string', function() {
+      record = ['{"time": "xyz"}', '{"time": "xy']
+      expected = '{"time": "xy'
+      assert.equal(client.getLogFormat(record), constants.JSON_STRING_ARRAY)
+      testHandleLogs(record, expected, false)
     });
   })
 });


### PR DESCRIPTION
### What does this PR do?
Updates the azure event hub forwarder to handle string logs and convert them to json if possible. Also updates unit tests, and adds `sinon` to the requirements so we can use spies to mock certain behavior. Fixes a few things and ran the linter on the code.

### Motivation
https://datadoghq.atlassian.net/jira/software/projects/AGAI/boards/207?selectedIssue=AGAI-414

### Testing Guidelines

Copied this code into the azure portal for a function I created, set the type to string and confirmed logs come into the test org I'm using correctly. Also ran unittests to confirm the correct format of the logs are passed to the right method


Before: 
![image](https://user-images.githubusercontent.com/1701147/86629971-2a135400-bf9a-11ea-90e1-437f88263b1a.png)

After:
![image](https://user-images.githubusercontent.com/1701147/86629944-1ff15580-bf9a-11ea-9f8b-242dff5e3d8f.png)


### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
