### PR TITLE
Add Encryption Context to KMS Decryption

### DIFF
--- a/aws/rds_enhanced_monitoring/lambda_function.py
+++ b/aws/rds_enhanced_monitoring/lambda_function.py
@@ -20,7 +20,10 @@ DD_SITE = os.getenv("DD_SITE", default="datadoghq.com")
 # retrieve datadog options from KMS
 KMS_ENCRYPTED_KEYS = os.environ['kmsEncryptedKeys']
 kms = boto3.client('kms')
-datadog_keys = json.loads(kms.decrypt(CiphertextBlob=base64.b64decode(KMS_ENCRYPTED_KEYS))['Plaintext'])
+encryption_context = {'LambdaFunctionName': os.environ['AWS_LAMBDA_FUNCTION_NAME']}
+datadog_keys = json.loads(kms.decrypt(CiphertextBlob=base64.b64decode(KMS_ENCRYPTED_KEYS),
+                                      EncryptionContext=encryption_context)
+                          ['Plaintext'])
 
 print('INFO Lambda function initialized, ready to send metrics')
 


### PR DESCRIPTION
### What does this PR do?

This PR is a bug fix.

It adds the [Encryption Context](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context) to the KMS `decrypt` call that retrieves the Datadog API key from the environment variables for the Lambda function.

### Motivation

Lambda encrypts environment variables using a specified customer-managed key. During setup for the RDS Enhanced Metrics application for Datadog, the ID of that key is specified. That key is used to encrypt the Datadog API key that is stored as an environment variable.

When this is done via the AWS console, [as instructed in the Datadog documentation](https://docs.datadoghq.com/integrations/amazon_rds/#create-your-lambda-function), the console uses an Encryption Context using the name of the function:

```
{'LambdaFunctionName': os.environ['AWS_LAMBDA_FUNCTION_NAME']}
```

Therefore, in order to be able to properly decrypt the Datadog API keys in an encrypted environment variable, the Lambda function must decrypt the value using the same encryption context. In fact, the AWS Console now provides the following snippet that describes this:

```
import boto3
import os

from base64 import b64decode

ENCRYPTED = os.environ['kmsEncryptedKeys']
# Decrypt code should run once and variables stored outside of the function
# handler so that these are decrypted once per container
DECRYPTED = boto3.client('kms').decrypt(
    CiphertextBlob=b64decode(ENCRYPTED),
    EncryptionContext={'LambdaFunctionName': os.environ['AWS_LAMBDA_FUNCTION_NAME']}
)['Plaintext']

def lambda_handler(event, context):
    # TODO handle the event here
    pass
```

This PR changes the decryption to provide the encryption context.

### Testing Guidelines

Due to the lack of tests for this function, this change was tested in a heavily-used production application. Without this change, the function will fail with the following error:

```
An error occurred (InvalidCiphertextException) when calling the Decrypt operation:
```
### Types of changes

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [X] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
