### PR TITLE
Run integration tests with Python 3.8

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -8,15 +8,10 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: ["python3.7", "python3.8"]
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
-        with:
-          python-version: ${{ matrix.python-version }}
-
       - name: Run integration tests
         run: |
-          ./aws/logs_monitoring/tools/integration_test.sh
+          ./aws/logs_monitoring/tools/integration_test.sh ${{ matrix.python-version }}

--- a/aws/logs_monitoring/tools/docker-compose.yml
+++ b/aws/logs_monitoring/tools/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   forwarder:
-    image: datadog-log-forwarder:${PYTHON_RUNTIME:-python3.8}
+    image: datadog-log-forwarder:${PYTHON_RUNTIME:-python3.7}
     command: lambda_function.datadog_forwarder
     environment:
       AWS_ACCOUNT_ID: 0000000000


### PR DESCRIPTION
### What does this PR do?

Previously, integration tests always ran with Python 3.7, even when they were supposed to be running with Python 3.8. This PR gives us the ability to run the integration tests with Python 3.8.

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
