### PR TITLE
Refactor parse_event_source to prevent mis-identification of sources

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -65,7 +65,7 @@ def get_env_var(envvar, default, boolean=False):
 ############# PARAMETERS ############
 #####################################
 
-## @param DD_API_KEY - String - conditional - default: none:
+## @param DD_API_KEY - String - conditional - default: none
 ## The Datadog API key associated with your Datadog Account
 ## It can be found here:
 ##

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -65,7 +65,7 @@ def get_env_var(envvar, default, boolean=False):
 ############# PARAMETERS ############
 #####################################
 
-## @param DD_API_KEY - String - conditional - default: none
+## @param DD_API_KEY - String - conditional - default: none:
 ## The Datadog API key associated with your Datadog Account
 ## It can be found here:
 ##
@@ -305,6 +305,26 @@ DD_CUSTOM_TAGS = "ddtags"
 DD_SERVICE = "service"
 DD_HOST = "host"
 DD_FORWARDER_VERSION = "3.15.0"
+
+
+# Used to identify and assign sources to logs
+LOG_SOURCE_SUBSTRINGS = [
+    "codebuild",
+    "lambda",
+    "redshift",
+    "cloudfront",
+    "kinesis",
+    "mariadb",
+    "mysql",
+    "apigateway",
+    "route53",
+    "docdb",
+    "fargate",
+    "dms",
+    "vpc",
+    "sns",
+    "waf",
+]
 
 
 class RetriableException(Exception):
@@ -999,7 +1019,7 @@ def cwevent_handler(event, metadata):
 def sns_handler(event, metadata):
     data = event
     # Set the source on the log
-    metadata[DD_SOURCE] = parse_event_source(event, "sns")
+    metadata[DD_SOURCE] = "sns"
 
     for ev in data["Records"]:
         # Create structured object and send it
@@ -1037,36 +1057,40 @@ def is_cloudtrail(key):
 
 
 def parse_event_source(event, key):
-    if "elasticloadbalancing" in key:
+    """Parse out the source that will be assigned to the log in Datadog
+
+    TODO Refactor to do a more thorough parsing that will guarantee correct source identification
+
+    Args:
+        event (dict): The AWS-formatted log event that the forwarder was triggered with
+        key (string): The S3 object key if the event is from S3 or the CW Log Group if the event is from CW Logs
+    """
+    lowercase_key = str(key).lower()
+
+    if "elasticloadbalancing" in lowercase_key:
         return "elb"
-    for source in [
-        "dms",
-        "codebuild",
-        "lambda",
-        "redshift",
-        "cloudfront",
-        "kinesis",
-        "/aws/rds",
-        "mariadb",
-        "mysql",
-        "apigateway",
-        "route53",
-        "vpc",
-        "sns",
-        "waf",
-        "docdb",
-        "fargate",
-    ]:
-        if source in key:
-            return source.replace("/aws/", "")
-    if "api-gateway" in key.lower() or "apigateway" in key.lower():
+
+    if "api-gateway" in lowercase_key:
         return "apigateway"
+
     if is_cloudtrail(str(key)) or (
         "logGroup" in event and event["logGroup"] == "CloudTrail"
     ):
         return "cloudtrail"
+
+    if "/aws/rds" in lowercase_key:
+        return "rds"
+
+    # Use the source substrings to find if the key matches any known services
+    for source in LOG_SOURCE_SUBSTRINGS:
+        if source in lowercase_key:
+            return source
+
+    # If the source AWS service cannot be parsed from the key, return the service
+    # that contains the logs as the source, "cloudwatch" or "s3"
     if "awslogs" in event:
         return "cloudwatch"
+
     if "Records" in event and len(event["Records"]) > 0:
         if "s3" in event["Records"][0]:
             return "s3"

--- a/aws/logs_monitoring/tests/test_parse_event_source.py
+++ b/aws/logs_monitoring/tests/test_parse_event_source.py
@@ -1,0 +1,50 @@
+from mock import MagicMock, patch
+import os
+import sys
+import unittest
+
+sys.modules["trace_forwarder.connection"] = MagicMock()
+sys.modules["datadog_lambda.wrapper"] = MagicMock()
+sys.modules["datadog_lambda.metric"] = MagicMock()
+sys.modules["datadog"] = MagicMock()
+sys.modules["requests"] = MagicMock()
+
+env_patch = patch.dict(os.environ, {"DD_API_KEY": "11111111111111111111111111111111"})
+env_patch.start()
+from lambda_function import parse_event_source
+
+env_patch.stop()
+
+
+class TestParseEventSource(unittest.TestCase):
+    def test_aws_source_if_none_found(self):
+        self.assertEqual(parse_event_source({}, "asdfalsfhalskjdfhalsjdf"), "aws")
+
+    def test_cloudwatch_source_if_none_found(self):
+        self.assertEqual(parse_event_source({"awslogs": "logs"}, ""), "cloudwatch")
+
+    def test_s3_source_if_none_found(self):
+        self.assertEqual(parse_event_source({"Records": ["logs-from-s3"]}, ""), "s3")
+
+    def test_cloudtrail_event(self):
+        self.assertEqual(
+            parse_event_source(
+                {},
+                "cloud-trail/AWSLogs/123456779121/CloudTrail/us-west-3/2018/01/07/123456779121_CloudTrail_eu-west-3_20180707T1735Z_abcdefghi0MCRL2O.json.gz",
+            ),
+            "cloudtrail",
+        )
+
+    def test_cloudtrail_event_with_service_substrings(self):
+        # Assert that source "cloudtrail" is parsed even though substrings "waf" and "sns" are present in the key
+        self.assertEqual(
+            parse_event_source(
+                {},
+                "cloud-trail/AWSLogs/123456779121/CloudTrail/us-west-3/2018/01/07/123456779121_CloudTrail_eu-west-3_20180707T1735Z_xywafKsnsXMBrdsMCRL2O.json.gz",
+            ),
+            "cloudtrail",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/aws/logs_monitoring/tests/test_parse_event_source.py
+++ b/aws/logs_monitoring/tests/test_parse_event_source.py
@@ -20,12 +20,6 @@ class TestParseEventSource(unittest.TestCase):
     def test_aws_source_if_none_found(self):
         self.assertEqual(parse_event_source({}, "asdfalsfhalskjdfhalsjdf"), "aws")
 
-    def test_cloudwatch_source_if_none_found(self):
-        self.assertEqual(parse_event_source({"awslogs": "logs"}, ""), "cloudwatch")
-
-    def test_s3_source_if_none_found(self):
-        self.assertEqual(parse_event_source({"Records": ["logs-from-s3"]}, ""), "s3")
-
     def test_cloudtrail_event(self):
         self.assertEqual(
             parse_event_source(
@@ -44,6 +38,15 @@ class TestParseEventSource(unittest.TestCase):
             ),
             "cloudtrail",
         )
+
+    def test_rds_event(self):
+        self.assertEqual(parse_event_source({}, "/aws/rds/my-rds-resource"), "rds")
+
+    def test_cloudwatch_source_if_none_found(self):
+        self.assertEqual(parse_event_source({"awslogs": "logs"}, ""), "cloudwatch")
+
+    def test_s3_source_if_none_found(self):
+        self.assertEqual(parse_event_source({"Records": ["logs-from-s3"]}, ""), "s3")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What does this PR do?
Refactors the logic in parse_event_source to prevent bugs where the event's key (s3 bucket or CW log group) has a substring of an AWS service (for example, `waf` or `sns`), causing the function to mis-identify the log's source as the substring service.

Also adds some comments and unit tests for the function.

### Motivation
Received customer ticket SLES-225

### Testing Guidelines
Added unit tests, ran integration tests

### Additional Notes


### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
