### PR TITLE
Use us-west-2 for installation test

### DIFF
--- a/aws/logs_monitoring/tools/installation_test.sh
+++ b/aws/logs_monitoring/tools/installation_test.sh
@@ -8,6 +8,9 @@
 # Tests installation and deployment process of forwarder, and that CloudFormation template works.
 set -e
 
+# Deploy the stack to a less commonly used region to avoid any problems with limits
+AWS_REGION="us-west-2"
+
 # Move into the root directory, so this script can be called from any directory
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd $DIR/..
@@ -43,12 +46,12 @@ echo "Setting params ${PARAM_LIST}"
 STACK_NAME="datadog-forwarder-integration-stack-${RUN_ID}"
 echo "Creating stack ${STACK_NAME}"
 aws cloudformation create-stack --stack-name $STACK_NAME --template-url $TEMPLATE_URL --capabilities "CAPABILITY_AUTO_EXPAND" "CAPABILITY_IAM" --on-failure "DELETE" \
-    --parameters=$PARAM_LIST 
+    --parameters=$PARAM_LIST --region $AWS_REGION
 
 echo "Waiting for stack to complete creation ${STACK_NAME}"
-aws cloudformation wait stack-create-complete --stack-name $STACK_NAME
+aws cloudformation wait stack-create-complete --stack-name $STACK_NAME --region $AWS_REGION
 
 echo "Completed stack creation"
 
 echo "Cleaning up stack"
-aws cloudformation delete-stack --stack-name $STACK_NAME 
+aws cloudformation delete-stack --stack-name $STACK_NAME  --region $AWS_REGION


### PR DESCRIPTION
### What does this PR do?

Updates the installation_test script to deploy the forwarder to the less-used us-west-2 rather than the default us-east-1 in order to avoid limits in us-east-1.

### Motivation

Was running into a limit in us-east-1.

### Testing Guidelines

Ran the test script and everything works as expected

```
Creating stack datadog-forwarder-integration-stack-NXtsXefm8Z
{
    "StackId": "arn:aws:cloudformation:us-west-2:123457279990:stack/datadog-forwarder-integration-stack-xxxxxx/xxxxxx"
}
Waiting for stack to complete creation datadog-forwarder-integration-stack-xxxxxx
Completed stack creation
Cleaning up stack
```

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
