### PR TITLE
Remove code to support Python 2.7

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -3,8 +3,6 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2018 Datadog, Inc.
 
-from __future__ import print_function
-
 import base64
 import gzip
 import json
@@ -14,7 +12,7 @@ from collections import defaultdict
 import boto3
 import itertools
 import re
-import six.moves.urllib as urllib  # for Python 2.7 urllib.unquote_plus
+import urllib
 import socket
 import ssl
 import logging

--- a/aws/logs_monitoring/setup.py
+++ b/aws/logs_monitoring/setup.py
@@ -12,13 +12,11 @@ setup(
     author="Datadog, Inc.",
     author_email="dev@datadoghq.com",
     classifiers=[
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
     ],
     keywords="datadog aws lambda layer",
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4",
+    python_requires=">=3.7, <3.9",
     install_requires=["datadog-lambda==2.16.0"],
     extras_require={
         "dev": ["nose2==0.9.1", "flake8==3.7.9", "requests==2.22.0", "boto3==1.10.33"]


### PR DESCRIPTION
### What does this PR do?

Makes it official that we only support Python 3.7 and 3.8.

### Motivation

We are already using f-strings so Python 2.7 would not work anyway.

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
