### PR TITLE
Fix inconsistent service tag and metadata

### DIFF
--- a/aws/logs_monitoring/tests/snapshots/cloudwatch_log_coldstart.json~snapshot
+++ b/aws/logs_monitoring/tests/snapshots/cloudwatch_log_coldstart.json~snapshot
@@ -22,7 +22,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:storms-cloudwatch-event,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:storms-cloudwatch-event,region:us-east-1,service:storms-cloudwatch-event",
           "ddsource": "lambda",
           "service": "storms-cloudwatch-event",
           "host": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event"
@@ -44,7 +44,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:storms-cloudwatch-event,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:storms-cloudwatch-event,region:us-east-1,service:storms-cloudwatch-event",
           "ddsource": "lambda",
           "service": "storms-cloudwatch-event",
           "host": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event"
@@ -66,7 +66,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:storms-cloudwatch-event,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:storms-cloudwatch-event,region:us-east-1,service:storms-cloudwatch-event",
           "ddsource": "lambda",
           "service": "storms-cloudwatch-event",
           "host": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event"

--- a/aws/logs_monitoring/tests/snapshots/cloudwatch_log_lambda_invocation.json~snapshot
+++ b/aws/logs_monitoring/tests/snapshots/cloudwatch_log_lambda_invocation.json~snapshot
@@ -22,7 +22,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1,service:hello-dog-node-dev-hello12x",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -44,7 +44,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1,service:hello-dog-node-dev-hello12x",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -66,7 +66,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1,service:hello-dog-node-dev-hello12x",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -88,7 +88,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1,service:hello-dog-node-dev-hello12x",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -110,7 +110,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1,service:hello-dog-node-dev-hello12x",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -132,7 +132,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1,service:hello-dog-node-dev-hello12x",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -154,7 +154,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1,service:hello-dog-node-dev-hello12x",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -176,7 +176,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1,service:hello-dog-node-dev-hello12x",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -198,7 +198,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1,service:hello-dog-node-dev-hello12x",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -220,7 +220,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1,service:hello-dog-node-dev-hello12x",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -242,7 +242,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1,service:hello-dog-node-dev-hello12x",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -264,7 +264,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1,service:hello-dog-node-dev-hello12x",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -286,7 +286,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1,service:hello-dog-node-dev-hello12x",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -308,7 +308,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1,service:hello-dog-node-dev-hello12x",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -330,7 +330,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1,service:hello-dog-node-dev-hello12x",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
@@ -352,7 +352,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1,service:hello-dog-node-dev-hello12x",
           "ddsource": "lambda",
           "service": "hello-dog-node-dev-hello12x",
           "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"

--- a/aws/logs_monitoring/tests/snapshots/cloudwatch_log_timeout.json~snapshot
+++ b/aws/logs_monitoring/tests/snapshots/cloudwatch_log_timeout.json~snapshot
@@ -22,7 +22,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:storms-cloudwatch-event,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:storms-cloudwatch-event,region:us-east-1,service:storms-cloudwatch-event",
           "ddsource": "lambda",
           "service": "storms-cloudwatch-event",
           "host": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event"
@@ -44,7 +44,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:storms-cloudwatch-event,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:storms-cloudwatch-event,region:us-east-1,service:storms-cloudwatch-event",
           "ddsource": "lambda",
           "service": "storms-cloudwatch-event",
           "host": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event"
@@ -66,7 +66,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:storms-cloudwatch-event,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:storms-cloudwatch-event,region:us-east-1,service:storms-cloudwatch-event",
           "ddsource": "lambda",
           "service": "storms-cloudwatch-event",
           "host": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event"
@@ -88,7 +88,7 @@
             "arn": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event"
           },
           "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:storms-cloudwatch-event,region:us-east-1",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,env:none,account_id:0,aws_account:0,functionname:storms-cloudwatch-event,region:us-east-1,service:storms-cloudwatch-event",
           "ddsource": "lambda",
           "service": "storms-cloudwatch-event",
           "host": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event"


### PR DESCRIPTION
### What does this PR do?

If a Lambda function is tagged with a `service` tag, set its value to tags **as well as the `service` metadata field**.

### Motivation

Currently when a Lambda function is tagged with a `service` tag, it's added to the tags, while the `service` metadata field is always set to the function name. The logs management uses the `service` metadata field to determine the actual `service` name https://docs.datadoghq.com/logs/processing/#service-attribute, and this means the user cannot customize the log's service name by tagging the lambda function.

### Testing Guidelines

- [x] When `service` tag present, its value is used for both `service` tag and `service` metadata
- [x] When `service` tag not present, function name is used for both `service` tag and `service` metadata

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
