### PR TITLE
Use unique variable name for Logger instance

### DIFF
--- a/aws/logs_monitoring/enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/enhanced_lambda_metrics.py
@@ -74,7 +74,7 @@ METRIC_ADJUSTMENT_FACTORS = {
 
 resource_tagging_client = boto3.client("resourcegroupstaggingapi")
 
-log = logging.getLogger()
+logger = logging.getLogger()
 
 
 try:
@@ -82,7 +82,7 @@ try:
 
     DD_SUBMIT_ENHANCED_METRICS = True
 except ImportError:
-    log.debug(
+    logger.debug(
         "Could not import from the Datadog Lambda layer so enhanced metrics won't be submitted. "
         "Add the Datadog Lambda layer to this function to submit enhanced metrics."
     )
@@ -104,7 +104,7 @@ class LambdaTagsCache(object):
 
         # If the custom tag fetch env var is not set to true do not fetch
         if not should_fetch_custom_tags():
-            log.debug(
+            logger.debug(
                 "Not fetching custom tags because the env variable DD_FETCH_LAMBDA_TAGS is not set to true"
             )
             return
@@ -199,7 +199,9 @@ class DatadogMetricPoint(object):
         if not timestamp:
             timestamp = time()
 
-        log.debug("Submitting metric {} {} {}".format(self.name, self.value, self.tags))
+        logger.debug(
+            "Submitting metric {} {} {}".format(self.name, self.value, self.tags)
+        )
         lambda_stats.distribution(
             self.name, self.value, timestamp=timestamp, tags=self.tags
         )
@@ -318,12 +320,12 @@ def build_tags_by_arn_cache():
             tags_by_arn_cache.update(page_tags_by_arn)
 
     except ClientError:
-        log.exception(
+        logger.exception(
             "Encountered a ClientError when trying to fetch tags. You may need to give "
             "this Lambda's role the 'tag:GetResources' permission"
         )
 
-    log.debug(
+    logger.debug(
         "Built this tags cache from GetResources API calls: %s", tags_by_arn_cache
     )
 
@@ -349,7 +351,7 @@ def parse_and_submit_enhanced_metrics(logs):
             for enhanced_metric in enhanced_metrics:
                 enhanced_metric.submit_to_dd()
         except Exception:
-            log.exception(
+            logger.exception(
                 "Encountered an error while trying to parse and submit enhanced metrics for log %s",
                 log,
             )

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -53,13 +53,13 @@ from settings import (
 )
 
 
-log = logging.getLogger()
-log.setLevel(logging.getLevelName(os.environ.get("DD_LOG_LEVEL", "INFO").upper()))
+logger = logging.getLogger()
+logger.setLevel(logging.getLevelName(os.environ.get("DD_LOG_LEVEL", "INFO").upper()))
 
 try:
     import requests
 except ImportError:
-    log.error(
+    logger.error(
         "Could not import the 'requests' package, please ensure the Datadog "
         "Lambda Layer is installed. https://dtdg.co/forwarder-layer"
     )
@@ -386,8 +386,8 @@ class DatadogScrubber(object):
 
 def datadog_forwarder(event, context):
     """The actual lambda function entry point"""
-    if log.isEnabledFor(logging.DEBUG):
-        log.debug(f"Received Event:{json.dumps(event)}")
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug(f"Received Event:{json.dumps(event)}")
 
     metrics, logs, trace_payloads = split(enrich(parse(event, context)))
 
@@ -422,10 +422,10 @@ def forward_logs(logs):
             try:
                 client.send(batch)
             except Exception:
-                log.exception(f"Exception while forwarding log batch {batch}")
+                logger.exception(f"Exception while forwarding log batch {batch}")
             else:
-                if log.isEnabledFor(logging.DEBUG):
-                    log.debug(f"Forwarded log batch: {json.dumps(batch)}")
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(f"Forwarded log batch: {json.dumps(batch)}")
 
 
 def parse(event, context):
@@ -633,20 +633,22 @@ def forward_metrics(metrics):
                 metric["m"], metric["v"], timestamp=metric["e"], tags=metric["t"]
             )
         except Exception:
-            log.exception(f"Exception while forwarding metric {json.dumps(metric)}")
+            logger.exception(f"Exception while forwarding metric {json.dumps(metric)}")
         else:
-            if log.isEnabledFor(logging.DEBUG):
-                log.debug(f"Forwarded metric: {json.dumps(metric)}")
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(f"Forwarded metric: {json.dumps(metric)}")
 
 
 def forward_traces(trace_payloads):
     try:
         trace_connection.send_traces(trace_payloads)
     except Exception:
-        log.exception(f"Exception while forwarding traces {json.dumps(trace_payloads)}")
+        logger.exception(
+            f"Exception while forwarding traces {json.dumps(trace_payloads)}"
+        )
     else:
-        if log.isEnabledFor(logging.DEBUG):
-            log.debug(f"Forwarded traces: {json.dumps(trace_payloads)}")
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(f"Forwarded traces: {json.dumps(trace_payloads)}")
 
 
 # Utility functions

--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -11,8 +11,8 @@ import logging
 import re
 
 
-log = logging.getLogger()
-log.setLevel(logging.getLevelName(os.environ.get("DD_LOG_LEVEL", "INFO").upper()))
+logger = logging.getLogger()
+logger.setLevel(logging.getLevelName(os.environ.get("DD_LOG_LEVEL", "INFO").upper()))
 
 
 def get_env_var(envvar, default, boolean=False):
@@ -23,7 +23,7 @@ def get_env_var(envvar, default, boolean=False):
     value = os.getenv(envvar, default=default)
     if boolean:
         value = value.lower() == "true"
-    log.debug(f"{envvar}: {value}")
+    logger.debug(f"{envvar}: {value}")
     return value
 
 
@@ -104,7 +104,7 @@ DD_TAGS = get_env_var("DD_TAGS", "")
 
 ## @param DD_API_URL - Url to use for  validating the the api key.
 DD_API_URL = get_env_var("DD_API_URL", default="https://api.{}".format(DD_SITE))
-log.debug(f"DD_API_URL: {DD_API_URL}")
+logger.debug(f"DD_API_URL: {DD_API_URL}")
 
 ## @param DD_TRACE_INTAKE_URL
 DD_TRACE_INTAKE_URL = get_env_var(
@@ -131,7 +131,7 @@ DD_FORWARD_TRACES = True
 #
 DD_USE_PRIVATE_LINK = get_env_var("DD_USE_PRIVATE_LINK", "false", boolean=True)
 if DD_USE_PRIVATE_LINK:
-    log.debug("Private link enabled, overriding configuration settings")
+    logger.debug("Private link enabled, overriding configuration settings")
     # TCP isn't supported when private link is enabled
     DD_USE_TCP = False
     DD_NO_SSL = False


### PR DESCRIPTION
`log` is used in `for log in logs` loops where its use is more justified.

Signed-off-by: Eugene Glotov <kivagant@gmail.com>

<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

### Motivation

Using the same variable name for different purposes within one file is confusing. Especially when one of the variables is intended for global use.

### Testing Guidelines

The logic has not been touched.

### Additional Notes

nothing

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
