### PR TITLE
[aws-ints] adding EncryptionContext to our kms decryption

### DIFF
--- a/aws/rds_enhanced_monitoring/lambda_function.py
+++ b/aws/rds_enhanced_monitoring/lambda_function.py
@@ -20,7 +20,10 @@ DD_SITE = os.getenv("DD_SITE", default="datadoghq.com")
 # retrieve datadog options from KMS
 KMS_ENCRYPTED_KEYS = os.environ['kmsEncryptedKeys']
 kms = boto3.client('kms')
-datadog_keys = json.loads(kms.decrypt(CiphertextBlob=base64.b64decode(KMS_ENCRYPTED_KEYS))['Plaintext'])
+datadog_keys = json.loads(kms.decrypt(
+    CiphertextBlob=b64decode(KMS_ENCRYPTED_KEYS),
+    EncryptionContext={'LambdaFunctionName': os.environ['AWS_LAMBDA_FUNCTION_NAME']}
+)['Plaintext'])
 
 print('INFO Lambda function initialized, ready to send metrics')
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
We had a problem with our decryption after AWS started using EncryptionContext for encryption in transit. This has made our current kms decryption non-functional.

### Motivation
A few users have noticed this problem, and the fix below has worked for them.

### Testing Guidelines
We can see this change working on the sandbox admin aws account under this [lambda](https://ap-south-1.console.aws.amazon.com/lambda/home?region=ap-south-1#/functions/serverlessrepo-Datadog-RDS-Enh-rdslambdaddfunction-30G9BP2EUE65?tab=configuration).

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
