### PR TITLE
Translate binary data type to be human readable

### DIFF
--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -102,6 +102,10 @@ function handleJSONArrayLogs(sender, context, logs, logsType) {
                 return;
             }
         }
+        // If the message is a buffer object, the data type has been set to binary.
+        if (Buffer.isBuffer(message)) {
+            message = JSON.parse(message.toString());
+        }
         if (message.records != undefined) {
             message.records.forEach(sender(addTagsToJsonLog));
         } else {

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -11,6 +11,7 @@ const STRING = 'string'; // example: 'some message'
 const STRING_ARRAY = 'string-array'; // example: ['one message', 'two message', ...]
 const JSON_OBJECT = 'json-object'; // example: {"key": "value"}
 const JSON_ARRAY = 'json-array'; // example: [{"key": "value"}, {"key": "value"}, ...] or [{"records": [{}, {}, ...]}, {"records": [{}, {}, ...]}, ...]
+const BUFFER_ARRAY = 'buffer-array'; // example: <Buffer 7b 22 72 65 63 6f 72 64 73 22 3a 20 5b 7b 20 22 74 69 6d 65 22 3a 20 22 74 65 73 74 69 6e 67 22 7d 5d 7d>
 const JSON_STRING = 'json-string'; // example: '{"key": "value"}'
 const JSON_STRING_ARRAY = 'json-string-array'; // example: ['{"records": [{}, {}]}'] or ['{"key": "value"}']
 const INVALID = 'invalid';
@@ -81,6 +82,9 @@ function handleLogs(sender, logs, context) {
         case JSON_ARRAY:
             handleJSONArrayLogs(sender, context, logs, JSON_ARRAY);
             break;
+        case BUFFER_ARRAY:
+            handleJSONArrayLogs(sender, context, logs, BUFFER_ARRAY);
+            break;
         case JSON_STRING_ARRAY:
             handleJSONArrayLogs(sender, context, logs, JSON_STRING_ARRAY);
             break;
@@ -103,7 +107,7 @@ function handleJSONArrayLogs(sender, context, logs, logsType) {
             }
         }
         // If the message is a buffer object, the data type has been set to binary.
-        if (Buffer.isBuffer(message)) {
+        if (logsType == BUFFER_ARRAY) {
             message = JSON.parse(message.toString());
         }
         if (message.records != undefined) {
@@ -126,6 +130,9 @@ function getLogFormat(logs) {
     }
     if (!Array.isArray(logs)) {
         return INVALID;
+    }
+    if (Buffer.isBuffer(logs[0])) {
+        return BUFFER_ARRAY;
     }
     if (typeof logs[0] === 'object') {
         return JSON_ARRAY;
@@ -214,6 +221,7 @@ module.exports.forTests = {
         STRING_ARRAY,
         JSON_OBJECT,
         JSON_ARRAY,
+        BUFFER_ARRAY,
         JSON_STRING,
         JSON_STRING_ARRAY,
         INVALID

--- a/azure/test/client.test.js
+++ b/azure/test/client.test.js
@@ -154,6 +154,13 @@ describe('Azure Log Monitoring', function() {
       testHandleLogs(record, expected, true)
     });
 
+    it('should handle byte array properly', function() {
+      record = [Buffer.from('{"records": [{ "test": "testing"}]}')];
+      expected = [{"test": "testing"}]
+      assert.equal(client.getLogFormat(record), constants.JSON_ARRAY)
+      testHandleLogs(record, expected, true)
+    });
+
     it('should handle json-string-array properly records', function() {
       record = ['{"records": [{ "time": "xyz"}, {"time": "abc"}]}']
       expected = [{"time": "xyz"}]

--- a/azure/test/client.test.js
+++ b/azure/test/client.test.js
@@ -157,7 +157,7 @@ describe('Azure Log Monitoring', function() {
     it('should handle byte array properly', function() {
       record = [Buffer.from('{"records": [{ "test": "testing"}]}')];
       expected = [{"test": "testing"}]
-      assert.equal(client.getLogFormat(record), constants.JSON_ARRAY)
+      assert.equal(client.getLogFormat(record), constants.BUFFER_ARRAY)
       testHandleLogs(record, expected, true)
     });
 


### PR DESCRIPTION
### What does this PR do?

We’d like to allow customers to be able to send logs as binary format to the datadog forwarder. We should handle the binary type (example of where it is set is here: https://a.cl.ly/E0uzNmg0)

Here is what this type of log would look like in DD prior to this change: https://a.cl.ly/yAub7zbb

Here is the same logs after the change: https://a.cl.ly/z8uZEoPv

### Motivation

https://datadoghq.atlassian.net/jira/software/projects/AGAI/boards/207?selectedIssue=AGAI-417

### Testing Guidelines

Tested in the Azure portal and locally with unit tests.

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
