### PR TITLE
Updated CloudWatch deploy permissions

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -166,6 +166,8 @@ To deploy the CloudFormation Stack with the default options, you need to have th
     "secretsmanager:TagResource",
     "s3:CreateBucket",
     "s3:GetObject",
+    "s3:PutEncryptionConfiguration",
+    "s3:PutBucketPublicAccessBlock",
     "iam:CreateRole",
     "iam:GetRole",
     "iam:PassRole",


### PR DESCRIPTION
Adds two new permissions to the suggested IAM policy, without which the AWS CloudFormations deployment fails with:
- ForwarderZipsBucket, CREATE_FAILED, API: s3:SetBucketEncryption Access Denied
- ForwarderZipsBucket, CREATE_FAILED, API: s3:PutPublicAccessBlock Access Denied

<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

The current AWS IAM Policy on the README is insufficient for a successful deployment of CloudFormation Log Forwarder. This PR adds in the additional new permissions, based on troubleshooting CloudWatch deployment failures.

### Motivation

Hit this while doing a Guided Eval for a client.

### Testing Guidelines

Tested on AWS sandbox using a user that exclusively has the original IAM Policy, as well as the IAM Policy updated on this PR.

### Additional Notes

DD employee, reach out to me if further details are required.

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
