### PR TITLE
Clarify PrivateLink Endpoints in README

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -102,9 +102,10 @@ If you can't install the Forwarder using the provided CloudFormation template, y
 
 You can run the Forwarder in a VPC by using AWS PrivateLink.
 
-1. Follow the [setup instructions](https://docs.datadoghq.com/agent/guide/private-link/?tab=logs#create-your-vpc-endpoint) for adding Datadog's endpoints to your VPC. **Be sure to add endpoints for both the Datadog API and for Logs.** 
-2. By default, the Forwarder's API key is stored in the Secrets Manager. The secrets manager endpoint needs to be added to the VPC. You can follow the instructions [here for adding AWS services to a VPC](https://docs.aws.amazon.com/vpc/latest/userguide/vpce-interface.html#create-interface-endpoint).
-3. When in installing the Forwarder with the CloudFormation template, enable 'DdUsePrivateLink' and set at least one Subnet Id and Security Group.
+1. Follow the [setup instructions](https://docs.datadoghq.com/agent/guide/private-link/?tab=logs#create-your-vpc-endpoint) for adding Datadog's **API** endpoint to your VPC.
+1. Follow the [same procedure](https://docs.datadoghq.com/agent/guide/private-link/?tab=logs#create-your-vpc-endpoint) to add Datadog's **Logs** endpoint to your VPC. 
+1. By default, the Forwarder's API key is stored in the Secrets Manager. The secrets manager endpoint needs to be added to the VPC. You can follow the instructions [here for adding AWS services to a VPC](https://docs.aws.amazon.com/vpc/latest/userguide/vpce-interface.html#create-interface-endpoint).
+1. When in installing the Forwarder with the CloudFormation template, enable 'DdUsePrivateLink' and set at least one Subnet Id and Security Group.
 
 ### AWS PrivateLink Limitations
 

--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -100,15 +100,16 @@ If you can't install the Forwarder using the provided CloudFormation template, y
 
 ## AWS PrivateLink Support
 
-Configure the Forwarder using AWS PrivateLink to run in a VPC.
+You can run the Forwarder in a VPC by using AWS PrivateLink.
 
-1. Follow the [setup instructions](https://docs.datadoghq.com/agent/guide/private-link/?tab=logs#create-your-vpc-endpoint) for adding Datadog's endpoints to your VPC.
+1. Follow the [setup instructions](https://docs.datadoghq.com/agent/guide/private-link/?tab=logs#create-your-vpc-endpoint) for adding Datadog's endpoints to your VPC. **Be sure to add endpoints for both the Datadog API and for Logs.** 
 2. By default, the Forwarder's API key is stored in the Secrets Manager. The secrets manager endpoint needs to be added to the VPC. You can follow the instructions [here for adding AWS services to a VPC](https://docs.aws.amazon.com/vpc/latest/userguide/vpce-interface.html#create-interface-endpoint).
 3. When in installing the Forwarder with the CloudFormation template, enable 'DdUsePrivateLink' and set at least one Subnet Id and Security Group.
 
 ### AWS PrivateLink Limitations
 
-Currently, AWS PrivateLink can only be configured with Datadog organizations in the Datadog US region. Trace forwarding is also unsupported.
+* AWS PrivateLink can only be configured with Datadog organizations in the Datadog US region.
+* Trace forwarding is currently unsupported via AWS PrivateLink.
 
 ## Troubleshooting
 

--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -103,9 +103,9 @@ If you can't install the Forwarder using the provided CloudFormation template, y
 You can run the Forwarder in a VPC by using AWS PrivateLink.
 
 1. Follow the [setup instructions](https://docs.datadoghq.com/agent/guide/private-link/?tab=logs#create-your-vpc-endpoint) for adding Datadog's **API** endpoint to your VPC.
-1. Follow the [same procedure](https://docs.datadoghq.com/agent/guide/private-link/?tab=logs#create-your-vpc-endpoint) to add Datadog's **Logs** endpoint to your VPC. 
-1. By default, the Forwarder's API key is stored in the Secrets Manager. The secrets manager endpoint needs to be added to the VPC. You can follow the instructions [here for adding AWS services to a VPC](https://docs.aws.amazon.com/vpc/latest/userguide/vpce-interface.html#create-interface-endpoint).
-1. When installing the Forwarder with the CloudFormation template, enable 'DdUsePrivateLink' and set at least one Subnet Id and Security Group.
+2. Follow the [same procedure](https://docs.datadoghq.com/agent/guide/private-link/?tab=logs#create-your-vpc-endpoint) to add Datadog's **Logs** endpoint to your VPC. 
+3. By default, the Forwarder's API key is stored in the Secrets Manager. The secrets manager endpoint needs to be added to the VPC. You can follow the instructions [here for adding AWS services to a VPC](https://docs.aws.amazon.com/vpc/latest/userguide/vpce-interface.html#create-interface-endpoint).
+4. When installing the Forwarder with the CloudFormation template, enable 'DdUsePrivateLink' and set at least one Subnet Id and Security Group.
 
 ### AWS PrivateLink Limitations
 

--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -105,7 +105,7 @@ You can run the Forwarder in a VPC by using AWS PrivateLink.
 1. Follow the [setup instructions](https://docs.datadoghq.com/agent/guide/private-link/?tab=logs#create-your-vpc-endpoint) for adding Datadog's **API** endpoint to your VPC.
 1. Follow the [same procedure](https://docs.datadoghq.com/agent/guide/private-link/?tab=logs#create-your-vpc-endpoint) to add Datadog's **Logs** endpoint to your VPC. 
 1. By default, the Forwarder's API key is stored in the Secrets Manager. The secrets manager endpoint needs to be added to the VPC. You can follow the instructions [here for adding AWS services to a VPC](https://docs.aws.amazon.com/vpc/latest/userguide/vpce-interface.html#create-interface-endpoint).
-1. When in installing the Forwarder with the CloudFormation template, enable 'DdUsePrivateLink' and set at least one Subnet Id and Security Group.
+1. When installing the Forwarder with the CloudFormation template, enable 'DdUsePrivateLink' and set at least one Subnet Id and Security Group.
 
 ### AWS PrivateLink Limitations
 


### PR DESCRIPTION
Several customers have been confused by the need to set up PrivateLink endpoints for both the API and the logs intake. This also threw me off when I set up the Forwarder in a VPC.

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
