### PR TITLE
Enable Trace Forwarding via AWS PrivateLink

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -100,7 +100,7 @@ If you can't install the Forwarder using the provided CloudFormation template, y
 
 ## AWS PrivateLink Support
 
-You can run the Forwarder in a VPC by using AWS PrivateLink to connect to Datadog.
+You can run the Forwarder in a VPC by using AWS PrivateLink to connect to Datadog. Note that AWS PrivateLink can only be configured with Datadog organizations in the Datadog US region.
 
 1. Follow the [setup instructions](https://docs.datadoghq.com/agent/guide/private-link/?tab=logs#create-your-vpc-endpoint) to add an endpoint to your VPC for Datadog's **API** service.
 2. Follow the [same procedure](https://docs.datadoghq.com/agent/guide/private-link/?tab=logs#create-your-vpc-endpoint) to add a second endpoint to your VPC for Datadog's **Logs** service.
@@ -108,10 +108,6 @@ You can run the Forwarder in a VPC by using AWS PrivateLink to connect to Datado
 4. By default, the Forwarder's API key is stored in the Secrets Manager. The Secrets Manager endpoint needs to be added to the VPC. You can follow the instructions [here](https://docs.aws.amazon.com/vpc/latest/userguide/vpce-interface.html#create-interface-endpoint) for adding AWS services to a VPC.
 5. When installing the Forwarder with the CloudFormation template, enable 'DdUsePrivateLink' and set at least one Subnet Id and Security Group.
 
-### AWS PrivateLink Limitations
-
-* AWS PrivateLink can only be configured with Datadog organizations in the Datadog US region.
-* Trace forwarding is currently unsupported via AWS PrivateLink.
 
 ## Troubleshooting
 

--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -100,7 +100,7 @@ If you can't install the Forwarder using the provided CloudFormation template, y
 
 ## AWS PrivateLink Support
 
-You can run the Forwarder in a VPC by using AWS PrivateLink to connect to Datadog. Note that AWS PrivateLink can only be configured with Datadog organizations in the Datadog US region.
+You can run the Forwarder in a VPC by using AWS PrivateLink to connect to Datadog. Note that AWS PrivateLink can only be configured with Datadog organizations using the Datadog US site (i.e. datadoghq.com, not datadoghq.eu).
 
 1. Follow the [setup instructions](https://docs.datadoghq.com/agent/guide/private-link/?tab=logs#create-your-vpc-endpoint) to add an endpoint to your VPC for Datadog's **API** service.
 2. Follow the [same procedure](https://docs.datadoghq.com/agent/guide/private-link/?tab=logs#create-your-vpc-endpoint) to add a second endpoint to your VPC for Datadog's **Logs** service.

--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -100,12 +100,13 @@ If you can't install the Forwarder using the provided CloudFormation template, y
 
 ## AWS PrivateLink Support
 
-You can run the Forwarder in a VPC by using AWS PrivateLink.
+You can run the Forwarder in a VPC by using AWS PrivateLink to connect to Datadog.
 
-1. Follow the [setup instructions](https://docs.datadoghq.com/agent/guide/private-link/?tab=logs#create-your-vpc-endpoint) for adding Datadog's **API** endpoint to your VPC.
-2. Follow the [same procedure](https://docs.datadoghq.com/agent/guide/private-link/?tab=logs#create-your-vpc-endpoint) to add Datadog's **Logs** endpoint to your VPC. 
-3. By default, the Forwarder's API key is stored in the Secrets Manager. The secrets manager endpoint needs to be added to the VPC. You can follow the instructions [here for adding AWS services to a VPC](https://docs.aws.amazon.com/vpc/latest/userguide/vpce-interface.html#create-interface-endpoint).
-4. When installing the Forwarder with the CloudFormation template, enable 'DdUsePrivateLink' and set at least one Subnet Id and Security Group.
+1. Follow the [setup instructions](https://docs.datadoghq.com/agent/guide/private-link/?tab=logs#create-your-vpc-endpoint) to add an endpoint to your VPC for Datadog's **API** service.
+2. Follow the [same procedure](https://docs.datadoghq.com/agent/guide/private-link/?tab=logs#create-your-vpc-endpoint) to add a second endpoint to your VPC for Datadog's **Logs** service.
+3. Follow the [same procedure](https://docs.datadoghq.com/agent/guide/private-link/?tab=logs#create-your-vpc-endpoint) once more to add a third endpoint to your VPC for Datadog's **Traces** service. 
+4. By default, the Forwarder's API key is stored in the Secrets Manager. The Secrets Manager endpoint needs to be added to the VPC. You can follow the instructions [here](https://docs.aws.amazon.com/vpc/latest/userguide/vpce-interface.html#create-interface-endpoint) for adding AWS services to a VPC.
+5. When installing the Forwarder with the CloudFormation template, enable 'DdUsePrivateLink' and set at least one Subnet Id and Security Group.
 
 ### AWS PrivateLink Limitations
 

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -40,7 +40,6 @@ from settings import (
     DD_TRACE_INTAKE_URL,
     DD_URL,
     DD_PORT,
-    DD_FORWARD_TRACES,
     SCRUBBING_RULE_CONFIGS,
     INCLUDE_AT_MATCH,
     EXCLUDE_AT_MATCH,
@@ -88,9 +87,7 @@ if not validation_res.ok:
 api._api_key = DD_API_KEY
 api._api_host = DD_API_URL
 
-trace_connection = None
-if DD_FORWARD_TRACES:
-    trace_connection = TraceConnection(DD_TRACE_INTAKE_URL, DD_API_KEY)
+trace_connection = TraceConnection(DD_TRACE_INTAKE_URL, DD_API_KEY)
 
 # Use for include, exclude, and scrubbing rules
 def compileRegex(rule, pattern):
@@ -396,7 +393,7 @@ def datadog_forwarder(event, context):
 
     forward_metrics(metrics)
 
-    if DD_FORWARD_TRACES and len(trace_payloads) > 0:
+    if len(trace_payloads) > 0:
         forward_traces(trace_payloads)
 
     parse_and_submit_enhanced_metrics(logs)

--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -55,7 +55,7 @@ DD_API_KEY = "<YOUR_DATADOG_API_KEY>"
 
 ## @param DD_FORWARD_LOG - boolean - optional - default: true
 ## Set this variable to `False` to disable log forwarding.
-## E.g., when you only want to forward metrics from logs.
+## E.g., when you only want to forward metrics and traces from logs.
 #
 DD_FORWARD_LOG = get_env_var("DD_FORWARD_LOG", "true", boolean=True)
 
@@ -124,23 +124,22 @@ else:
     DD_URL = get_env_var("DD_URL", default="lambda-http-intake.logs." + DD_SITE)
     DD_PORT = int(get_env_var("DD_PORT", default="443"))
 
-DD_FORWARD_TRACES = True
-
-## @param DD_USE_PRIVATE_LINK - whether to forward logs via private link
+## @param DD_USE_PRIVATE_LINK - whether to forward logs via PrivateLink
 ## Overrides incompatible settings
 #
 DD_USE_PRIVATE_LINK = get_env_var("DD_USE_PRIVATE_LINK", "false", boolean=True)
 if DD_USE_PRIVATE_LINK:
     logger.debug("Private link enabled, overriding configuration settings")
-    # TCP isn't supported when private link is enabled
+    # Only the US Datadog site is supported when PrivateLink is enabled
+    DD_SITE = "datadoghq.com"
+    # TCP isn't supported when PrivateLink is enabled
     DD_USE_TCP = False
     DD_NO_SSL = False
     DD_PORT = 443
-    # Traces aren't supported via private link yet
-    DD_FORWARD_TRACES = False
-    # Override urls to use the private link url
+    # Override URLs
     DD_URL = "api-pvtlink.logs.datadoghq.com"
     DD_API_URL = "https://pvtlink.api.datadoghq.com"
+    DD_TRACE_INTAKE_URL = "https://trace-pvtlink.agent.datadoghq.com"
 
 
 class ScrubbingRuleConfig(object):

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -142,7 +142,7 @@ Parameters:
     AllowedValues:
       - true
       - false
-    Description: Set to true to enable sending logs and metrics via AWS PrivateLink. See https://dtdg.co/private-link .
+    Description: Set to true to enable sending logs, metrics, and traces via AWS PrivateLink. See https://dtdg.co/private-link .
   VPCSecurityGroupIds:
     Type: CommaDelimitedList
     Default: ""


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Allow customers to forward traces via AWS PrivateLink.

### Testing Guidelines

Manual testing.

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [x] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
