### PR TITLE
Merge application added ddtags with forwarder added ddtags

### DIFF
--- a/aws/logs_monitoring/tests/snapshots/cloudwatch_log_custom_tags.json
+++ b/aws/logs_monitoring/tests/snapshots/cloudwatch_log_custom_tags.json
@@ -1,0 +1,14 @@
+{
+	"messageType": "DATA_MESSAGE",
+	"owner": "123456789123",
+	"logGroup": "testLogGroup",
+	"logStream": "testLogStream",
+	"subscriptionFilters": ["testFilter"],
+	"logEvents": [
+		{
+			"id": "eventId1",
+			"timestamp": 1440442987000,
+			"message": "{\"message\": \"hello world\", \"ddtags\": \"custom_tag1:value1,custom_tag2:value2\"}\n"
+		}
+	]
+}

--- a/aws/logs_monitoring/tests/snapshots/cloudwatch_log_custom_tags.json~snapshot
+++ b/aws/logs_monitoring/tests/snapshots/cloudwatch_log_custom_tags.json~snapshot
@@ -1,0 +1,30 @@
+{
+  "events": [
+    {
+      "path": "/v1/input/abcdefghijklmnopqrstuvwxyz012345",
+      "verb": "POST",
+      "content-type": "application/json",
+      "data": [
+        {
+          "id": "eventId1",
+          "timestamp": 1440442987000,
+          "message": "{\"message\": \"hello world\"}",
+          "aws": {
+            "awslogs": {
+              "logGroup": "testLogGroup",
+              "logStream": "testLogStream",
+              "owner": "123456789123"
+            },
+            "function_version": "$LATEST",
+            "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
+          },
+          "ddsourcecategory": "aws",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:x.x.x,custom_tag1:value1,custom_tag2:value2",
+          "ddsource": "cloudwatch",
+          "service": "cloudwatch",
+          "host": "testLogGroup"
+        }
+      ]
+    }
+  ]
+}

--- a/aws/logs_monitoring/tools/test_harness/tests/test_snapshots.py
+++ b/aws/logs_monitoring/tools/test_harness/tests/test_snapshots.py
@@ -99,3 +99,8 @@ class TestForwarderSnapshots(unittest.TestCase):
         input_filename = f"{snapshot_dir}/cloudwatch_log_timeout.json"
         snapshot_filename = f"{input_filename}~snapshot"
         self.compare_snapshot(input_filename, snapshot_filename)
+
+    def test_cloudwatch_log_custom_tags(self):
+        input_filename = f"{snapshot_dir}/cloudwatch_log_custom_tags.json"
+        snapshot_filename = f"{input_filename}~snapshot"
+        self.compare_snapshot(input_filename, snapshot_filename)


### PR DESCRIPTION
### What does this PR do?

When the logs intake pipeline detects a `message` field with a JSON content, it extracts the content to the top-level. The fields of same name from the top-level will be overridden. E.g. the application adds some tags to the log, which appear in the `message.ddtags` field, and the forwarder adds some common tags, such as `aws_account`, which appear in the top-level `ddtags` field:

```python
{
    "message": {
        "ddtags": "mytag:value", # tags added by the application
        ...
    },
    "ddtags": "env:xxx,aws_account", # tags added by the forwarder
    ...
}
```

Only the custom tags added by the application will be kept. We might want to change the intake pipeline to "merge" the conflicting fields rather than "overridding" in the future, but for now we should extract `message.ddtags` and merge it with the top-level `ddtags` field.

### Motivation

Allow customers to add custom tags to logs in Lambda function code when logging in JSON using the `ddtags` field.

### Testing Guidelines

- [x] When `ddtags` present in the log `message` field, its values get extracted and merged with the top-level `ddtags` field. See the added integration test case.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
