### PR TITLE
Translate binary data type to be human readable

### DIFF
--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -147,7 +147,10 @@ class EventhubLogForwarder {
                 try {
                     message = JSON.parse(message.toString());
                 } catch (err) {
-                    this.context.log.warn('log is malformed json, skipping');
+                    this.context.log.warn(
+                        'log is malformed json, sending as string'
+                    );
+                    promises.push(this.formatLogAndSend(STRING_TYPE, message.toString()));
                     return;
                 }
             }

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -150,7 +150,9 @@ class EventhubLogForwarder {
                     this.context.log.warn(
                         'log is malformed json, sending as string'
                     );
-                    promises.push(this.formatLogAndSend(STRING_TYPE, message.toString()));
+                    promises.push(
+                        this.formatLogAndSend(STRING_TYPE, message.toString())
+                    );
                     return;
                 }
             }

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -11,6 +11,7 @@ const STRING = 'string'; // example: 'some message'
 const STRING_ARRAY = 'string-array'; // example: ['one message', 'two message', ...]
 const JSON_OBJECT = 'json-object'; // example: {"key": "value"}
 const JSON_ARRAY = 'json-array'; // example: [{"key": "value"}, {"key": "value"}, ...] or [{"records": [{}, {}, ...]}, {"records": [{}, {}, ...]}, ...]
+const BUFFER_ARRAY = 'buffer-array'; // example: [<Buffer obj>, <Buffer obj>]
 const JSON_STRING = 'json-string'; // example: '{"key": "value"}'
 const JSON_STRING_ARRAY = 'json-string-array'; // example: ['{"records": [{}, {}]}'] or ['{"key": "value"}']
 const INVALID = 'invalid';
@@ -113,6 +114,9 @@ class EventhubLogForwarder {
             case JSON_ARRAY:
                 promises = this.handleJSONArrayLogs(logs, JSON_ARRAY);
                 break;
+            case BUFFER_ARRAY:
+                this.handleJSONArrayLogs(logs, BUFFER_ARRAY);
+                break;
             case JSON_STRING_ARRAY:
                 promises = this.handleJSONArrayLogs(logs, JSON_STRING_ARRAY);
                 break;
@@ -135,6 +139,15 @@ class EventhubLogForwarder {
                         'log is malformed json, sending as string'
                     );
                     promises.push(this.formatLogAndSend(STRING_TYPE, message));
+                    return;
+                }
+            }
+            // If the message is a buffer object, the data type has been set to binary.
+            if (logsType == BUFFER_ARRAY) {
+                try {
+                    message = JSON.parse(message.toString());
+                } catch (err) {
+                    this.context.log.warn('log is malformed json, skipping');
                     return;
                 }
             }
@@ -161,6 +174,9 @@ class EventhubLogForwarder {
         }
         if (!Array.isArray(logs)) {
             return INVALID;
+        }
+        if (Buffer.isBuffer(logs[0])) {
+            return BUFFER_ARRAY;
         }
         if (typeof logs[0] === 'object') {
             return JSON_ARRAY;
@@ -261,6 +277,7 @@ module.exports.forTests = {
         STRING_ARRAY,
         JSON_OBJECT,
         JSON_ARRAY,
+        BUFFER_ARRAY,
         JSON_STRING,
         JSON_STRING_ARRAY,
         INVALID

--- a/azure/test/client.test.js
+++ b/azure/test/client.test.js
@@ -268,18 +268,8 @@ describe('Azure Log Monitoring', function() {
         });
 
         it('should handle buffer array without records properly', function() {
-            record = [Buffer.from('{[{ "test": "testing"}]}')];
-            expected = [{ test: 'testing' }];
-            assert.equal(
-                EventhubLogForwarderInstance.getLogFormat(record),
-                constants.BUFFER_ARRAY
-            );
-            testHandleLogs(record, expected, true);
-        });
-
-        it('should handle buffer array without records properly', function() {
-            record = [Buffer.from('{[{ "test": "testing"}]}')];
-            expected = [{ test: 'testing' }];
+            record = [Buffer.from('{ "test": "example"}')];
+            expected = [{ test: 'example' }];
             assert.equal(
                 EventhubLogForwarderInstance.getLogFormat(record),
                 constants.BUFFER_ARRAY
@@ -294,8 +284,6 @@ describe('Azure Log Monitoring', function() {
                 EventhubLogForwarderInstance.getLogFormat(record),
                 constants.BUFFER_ARRAY
             );
-            // just assert that the string method is called for the second message,
-            // we don't care about the first one for this test
             testHandleLogs(record, expected, false);
         });
 

--- a/azure/test/client.test.js
+++ b/azure/test/client.test.js
@@ -259,23 +259,32 @@ describe('Azure Log Monitoring', function() {
 
         it('should handle buffer array properly', function() {
             record = [Buffer.from('{"records": [{ "test": "testing"}]}')];
-            expected = [{"test": "testing"}]
-            assert.equal(EventhubLogForwarderInstance.getLogFormat(record), constants.BUFFER_ARRAY)
-            testHandleLogs(record, expected, true)
+            expected = [{ test: 'testing' }];
+            assert.equal(
+                EventhubLogForwarderInstance.getLogFormat(record),
+                constants.BUFFER_ARRAY
+            );
+            testHandleLogs(record, expected, true);
         });
 
         it('should handle buffer array without records properly', function() {
             record = [Buffer.from('{[{ "test": "testing"}]}')];
-            expected = [{"test": "testing"}]
-            assert.equal(EventhubLogForwarderInstance.getLogFormat(record), constants.BUFFER_ARRAY)
-            testHandleLogs(record, expected, true)
+            expected = [{ test: 'testing' }];
+            assert.equal(
+                EventhubLogForwarderInstance.getLogFormat(record),
+                constants.BUFFER_ARRAY
+            );
+            testHandleLogs(record, expected, true);
         });
 
         it('should handle buffer array without records properly', function() {
             record = [Buffer.from('{[{ "test": "testing"}]}')];
-            expected = [{"test": "testing"}]
-            assert.equal(EventhubLogForwarderInstance.getLogFormat(record), constants.BUFFER_ARRAY)
-            testHandleLogs(record, expected, true)
+            expected = [{ test: 'testing' }];
+            assert.equal(
+                EventhubLogForwarderInstance.getLogFormat(record),
+                constants.BUFFER_ARRAY
+            );
+            testHandleLogs(record, expected, true);
         });
 
         it('should handle buffer array with malformed string', function() {

--- a/azure/test/client.test.js
+++ b/azure/test/client.test.js
@@ -257,6 +257,39 @@ describe('Azure Log Monitoring', function() {
             testHandleLogs(record, expected, true);
         });
 
+        it('should handle buffer array properly', function() {
+            record = [Buffer.from('{"records": [{ "test": "testing"}]}')];
+            expected = [{"test": "testing"}]
+            assert.equal(EventhubLogForwarderInstance.getLogFormat(record), constants.BUFFER_ARRAY)
+            testHandleLogs(record, expected, true)
+        });
+
+        it('should handle buffer array without records properly', function() {
+            record = [Buffer.from('{[{ "test": "testing"}]}')];
+            expected = [{"test": "testing"}]
+            assert.equal(EventhubLogForwarderInstance.getLogFormat(record), constants.BUFFER_ARRAY)
+            testHandleLogs(record, expected, true)
+        });
+
+        it('should handle buffer array without records properly', function() {
+            record = [Buffer.from('{[{ "test": "testing"}]}')];
+            expected = [{"test": "testing"}]
+            assert.equal(EventhubLogForwarderInstance.getLogFormat(record), constants.BUFFER_ARRAY)
+            testHandleLogs(record, expected, true)
+        });
+
+        it('should handle buffer array with malformed string', function() {
+            record = [Buffer.from('{"time": "xy')];
+            expected = ['{"time": "xy'];
+            assert.equal(
+                EventhubLogForwarderInstance.getLogFormat(record),
+                constants.BUFFER_ARRAY
+            );
+            // just assert that the string method is called for the second message,
+            // we don't care about the first one for this test
+            testHandleLogs(record, expected, false);
+        });
+
         it('should handle json-string-array properly records', function() {
             record = ['{"records": [{ "time": "xyz"}, {"time": "abc"}]}'];
             expected = [{ time: 'xyz' }];


### PR DESCRIPTION
### What does this PR do?

We’d like to allow customers to be able to send logs as binary format to the datadog forwarder. We should handle the binary type (example of where it is set is here: https://a.cl.ly/E0uzNmg0)

Here is what this type of log would look like in DD prior to this change: https://a.cl.ly/yAub7zbb

Here is the same logs after the change: https://a.cl.ly/z8uZEoPv

### Motivation

https://datadoghq.atlassian.net/jira/software/projects/AGAI/boards/207?selectedIssue=AGAI-417

### Testing Guidelines

Tested in the Azure portal and locally with unit tests.

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
