### PR TITLE
Forwarder: add KMS permission to get log from Encrypted S3 Bucket

### DIFF
--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -497,6 +497,14 @@ Resources:
               Resource: "*"
             - Effect: Allow
               Action:
+                - kms:Encrypt
+                - kms:Decrypt
+                - kms:ReEncrypt*
+                - kms:GenerateDataKey*
+                - kms:DescribeKey
+              Resource: "*"
+            - Effect: Allow
+              Action:
                 - secretsmanager:GetSecretValue
               Resource:
                 Fn::If:

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -497,11 +497,7 @@ Resources:
               Resource: "*"
             - Effect: Allow
               Action:
-                - kms:Encrypt
                 - kms:Decrypt
-                - kms:ReEncrypt*
-                - kms:GenerateDataKey*
-                - kms:DescribeKey
               Resource: "*"
             - Effect: Allow
               Action:


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

Fix Forwarder function fail to invoke `s3:GetObject` with Encrypted S3 Bucket.
Now Forwarder support Encrypted S3 Bucket.

### Motivation

<!--- What inspired you to submit this pull request? --->

If Trigger S3 bucket is encrypted, Lambda Execution IAM Role require KMS priviledges.

> Object is encrypted by AWS KMS - https://aws.amazon.com/premiumsupport/knowledge-center/s3-troubleshoot-403

### Testing Guidelines

<!--- How did you test this pull request? --->
Create S3 Bucket with KMS Encyrpted, 

* Deploy original CF and forwarder cause error as `s3:GetObject` Access Denied.

![image](https://user-images.githubusercontent.com/3856350/91332123-a7bf4780-e806-11ea-9f62-7e95391fed5b.png)

* Deploy new CF and forwarder run without error.

![image](https://user-images.githubusercontent.com/3856350/91332148-b279dc80-e806-11ea-987e-38f7794d239b.png)

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [x] This PR passes the installation tests (ask a Datadog member to run the tests)
