### PR TITLE
Fix flakiness in integration tests

### DIFF
--- a/aws/logs_monitoring/enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/enhanced_lambda_metrics.py
@@ -98,8 +98,7 @@ class LambdaTagsCache(object):
         self.last_tags_fetch_time = 0
 
     def _refresh(self):
-        """Populate the tags in the cache by making calls to GetResources
-        """
+        """Populate the tags in the cache by making calls to GetResources"""
         self.last_tags_fetch_time = time()
 
         # If the custom tag fetch env var is not set to true do not fetch
@@ -113,15 +112,14 @@ class LambdaTagsCache(object):
         self.missing_arns -= set(self.tags_by_arn.keys())
 
     def _is_expired(self):
-        """Returns bool for whether the tag fetch TTL has expired
-        """
+        """Returns bool for whether the tag fetch TTL has expired"""
         earliest_time_to_refetch_tags = (
             self.last_tags_fetch_time + self.tags_ttl_seconds
         )
         return time() > earliest_time_to_refetch_tags
 
     def _should_refresh_if_missing_arn(self, resource_arn):
-        """ Determines whether to try and fetch a missing lambda arn.
+        """Determines whether to try and fetch a missing lambda arn.
         We only refresh if we encounter an arn that we haven't seen
         since the last refresh. This prevents refreshing on every call when
         tags can't be found for an arn.
@@ -193,8 +191,7 @@ class DatadogMetricPoint(object):
         self.timestamp = timestamp
 
     def submit_to_dd(self):
-        """Submit this metric to the Datadog API
-        """
+        """Submit this metric to the Datadog API"""
         timestamp = self.timestamp
         if not timestamp:
             timestamp = time()
@@ -208,8 +205,7 @@ class DatadogMetricPoint(object):
 
 
 def should_fetch_custom_tags():
-    """Checks the env var to determine if the customer has opted-in to fetching custom tags
-    """
+    """Checks the env var to determine if the customer has opted-in to fetching custom tags"""
     return os.environ.get("DD_FETCH_LAMBDA_TAGS", "false").lower() == "true"
 
 
@@ -220,8 +216,7 @@ FixInit = re.compile(r"^[_\d]*", re.UNICODE).sub
 
 
 def sanitize_aws_tag_string(tag, remove_colons=False):
-    """Convert characters banned from DD but allowed in AWS tags to underscores
-    """
+    """Convert characters banned from DD but allowed in AWS tags to underscores"""
     global Sanitize, Dedupe, FixInit
 
     # 1. Replace colons with _
@@ -325,7 +320,9 @@ def build_tags_by_arn_cache():
             ResourceTypeFilters=[GET_RESOURCES_LAMBDA_FILTER], ResourcesPerPage=100
         ):
             lambda_stats.distribution(
-                "{}.get_resources_api_calls".format(prefix), 1, tags=tags,
+                "{}.get_resources_api_calls".format(prefix),
+                1,
+                tags=tags,
             )
             page_tags_by_arn = parse_get_resources_response_for_tags_by_arn(page)
             tags_by_arn_cache.update(page_tags_by_arn)
@@ -537,7 +534,7 @@ def calculate_estimated_cost(billed_duration_ms, memory_allocated):
 
 
 def get_enriched_lambda_log_tags(log_event):
-    """ Retrieves extra tags from lambda, either read from the function arn, or by fetching lambda tags from the function itself.
+    """Retrieves extra tags from lambda, either read from the function arn, or by fetching lambda tags from the function itself.
 
     Args:
         log (dict<str, str | dict | int>): a log parsed from the event in the split method
@@ -572,7 +569,8 @@ def create_timeout_enhanced_metric(log_line):
         return []
 
     dd_metric = DatadogMetricPoint(
-        f"{ENHANCED_METRICS_NAMESPACE_PREFIX}.{TIMEOUTS_METRIC_NAME}", 1.0,
+        f"{ENHANCED_METRICS_NAMESPACE_PREFIX}.{TIMEOUTS_METRIC_NAME}",
+        1.0,
     )
     return [dd_metric]
 
@@ -595,6 +593,7 @@ def create_out_of_memory_enhanced_metric(log_line):
         return []
 
     dd_metric = DatadogMetricPoint(
-        f"{ENHANCED_METRICS_NAMESPACE_PREFIX}.{OUT_OF_MEMORY_METRIC_NAME}", 1.0,
+        f"{ENHANCED_METRICS_NAMESPACE_PREFIX}.{OUT_OF_MEMORY_METRIC_NAME}",
+        1.0,
     )
     return [dd_metric]

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -650,8 +650,7 @@ def extract_metric(event):
 
 
 def split(events):
-    """Split events into metrics, logs, and trace payloads
-    """
+    """Split events into metrics, logs, and trace payloads"""
     metrics, logs, trace_payloads = [], [], []
     for event in events:
         metric = extract_metric(event)
@@ -1096,7 +1095,9 @@ def invoke_additional_target_lambdas(event):
     for lambda_arn in lambda_arns:
         try:
             lambda_client.invoke(
-                FunctionName=lambda_arn, InvocationType="Event", Payload=lambda_payload,
+                FunctionName=lambda_arn,
+                InvocationType="Event",
+                Payload=lambda_payload,
             )
         except Exception as e:
             logger.exception(

--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -17,8 +17,8 @@ logger.setLevel(logging.getLevelName(os.environ.get("DD_LOG_LEVEL", "INFO").uppe
 
 def get_env_var(envvar, default, boolean=False):
     """
-        Return the value of the given environment variable with debug logging.
-        When boolean=True, parse the value as a boolean case-insensitively.
+    Return the value of the given environment variable with debug logging.
+    When boolean=True, parse the value as a boolean case-insensitively.
     """
     value = os.getenv(envvar, default=default)
     if boolean:

--- a/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
@@ -143,25 +143,37 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
             [
                 {
                     "name": "aws.lambda.enhanced.duration",
-                    "tags": ["memorysize:128", "cold_start:false",],
+                    "tags": [
+                        "memorysize:128",
+                        "cold_start:false",
+                    ],
                     "value": 0.00062,
                     "timestamp": None,
                 },
                 {
                     "name": "aws.lambda.enhanced.billed_duration",
-                    "tags": ["memorysize:128", "cold_start:false",],
+                    "tags": [
+                        "memorysize:128",
+                        "cold_start:false",
+                    ],
                     "value": 0.1000,
                     "timestamp": None,
                 },
                 {
                     "name": "aws.lambda.enhanced.max_memory_used",
-                    "tags": ["memorysize:128", "cold_start:false",],
+                    "tags": [
+                        "memorysize:128",
+                        "cold_start:false",
+                    ],
                     "value": 51.0,
                     "timestamp": None,
                 },
                 {
                     "name": "aws.lambda.enhanced.estimated_cost",
-                    "tags": ["memorysize:128", "cold_start:false",],
+                    "tags": [
+                        "memorysize:128",
+                        "cold_start:false",
+                    ],
                     "timestamp": None,
                     "value": 4.0833375e-07,
                 },
@@ -174,31 +186,46 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
             [
                 {
                     "name": "aws.lambda.enhanced.duration",
-                    "tags": ["memorysize:128", "cold_start:true",],
+                    "tags": [
+                        "memorysize:128",
+                        "cold_start:true",
+                    ],
                     "value": 0.0008100000000000001,
                     "timestamp": None,
                 },
                 {
                     "name": "aws.lambda.enhanced.billed_duration",
-                    "tags": ["memorysize:128", "cold_start:true",],
+                    "tags": [
+                        "memorysize:128",
+                        "cold_start:true",
+                    ],
                     "value": 0.1000,
                     "timestamp": None,
                 },
                 {
                     "name": "aws.lambda.enhanced.max_memory_used",
-                    "tags": ["memorysize:128", "cold_start:true",],
+                    "tags": [
+                        "memorysize:128",
+                        "cold_start:true",
+                    ],
                     "value": 90.0,
                     "timestamp": None,
                 },
                 {
                     "name": "aws.lambda.enhanced.init_duration",
-                    "tags": ["memorysize:128", "cold_start:true",],
+                    "tags": [
+                        "memorysize:128",
+                        "cold_start:true",
+                    ],
                     "value": 1.234,
                     "timestamp": None,
                 },
                 {
                     "name": "aws.lambda.enhanced.estimated_cost",
-                    "tags": ["memorysize:128", "cold_start:true",],
+                    "tags": [
+                        "memorysize:128",
+                        "cold_start:true",
+                    ],
                     "timestamp": None,
                     "value": 4.0833375e-07,
                 },
@@ -210,25 +237,37 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
             [
                 {
                     "name": "aws.lambda.enhanced.duration",
-                    "tags": ["memorysize:128", "cold_start:false",],
+                    "tags": [
+                        "memorysize:128",
+                        "cold_start:false",
+                    ],
                     "timestamp": None,
                     "value": 1.71187,
                 },
                 {
                     "name": "aws.lambda.enhanced.billed_duration",
-                    "tags": ["memorysize:128", "cold_start:false",],
+                    "tags": [
+                        "memorysize:128",
+                        "cold_start:false",
+                    ],
                     "timestamp": None,
                     "value": 1.8,
                 },
                 {
                     "name": "aws.lambda.enhanced.max_memory_used",
-                    "tags": ["memorysize:128", "cold_start:false",],
+                    "tags": [
+                        "memorysize:128",
+                        "cold_start:false",
+                    ],
                     "timestamp": None,
                     "value": 98.0,
                 },
                 {
                     "name": "aws.lambda.enhanced.estimated_cost",
-                    "tags": ["memorysize:128", "cold_start:false",],
+                    "tags": [
+                        "memorysize:128",
+                        "cold_start:false",
+                    ],
                     "timestamp": None,
                     "value": 3.9500075e-06,
                 },

--- a/aws/logs_monitoring/tools/integration_tests/integration_tests.sh
+++ b/aws/logs_monitoring/tools/integration_tests/integration_tests.sh
@@ -5,9 +5,6 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019 Datadog, Inc
 
-# Usage - run commands from the REPO_ROOT/aws/logs_monitoring directory:
-# aws-vault exec sandbox-account-admin -- ./scripts/run_integration_tests
-
 set -e
 
 PYTHON_VERSION="python3.7"
@@ -20,7 +17,7 @@ SNAPSHOT_DIR="${INTEGRATION_TESTS_DIR}/snapshots/*"
 SNAPS=($SNAPSHOT_DIR)
 ADDITIONAL_LAMBDA=false
 
-script_start_time=$(date --iso-8601=seconds)
+script_start_time=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 echo "Starting script time: $script_start_time"
 
 # Parse arguments
@@ -59,6 +56,9 @@ do
 
 		# -a or --additional-lambda
 		# Run additionalLambda tests
+
+		# Requires AWS credentials
+		# Use aws-vault exec sandbox-account-admin -- ./integration_tests.sh
 		-a|--additional-lambda)
 		ADDITIONAL_LAMBDA=true
 		shift
@@ -81,7 +81,7 @@ if ! [ $SKIP_FORWARDER_BUILD == true ]; then
 fi
 
 
-# Deploy additional target lambda
+# Deploy additional target Lambdas
 if [ $ADDITIONAL_LAMBDA == true ]; then
 	SERVERLESS_NAME="forwarder-tests-external-lambda-dev"
 	EXTERNAL_LAMBDA_NAMES=("ironmaiden" "megadeth")
@@ -165,6 +165,6 @@ if [ $ADDITIONAL_LAMBDA == true ]; then
 		    exit 1
 		fi
 	done
-fi
 
-echo "SUCCESS: No difference found between input events and events in the additional target lambda"
+	echo "SUCCESS: No difference found between input events and events in the additional target lambda"
+fi

--- a/aws/logs_monitoring/tools/integration_tests/recorder/pb/span_pb2.py
+++ b/aws/logs_monitoring/tools/integration_tests/recorder/pb/span_pb2.py
@@ -378,7 +378,10 @@ _SPAN = _descriptor.Descriptor(
         ),
     ],
     extensions=[],
-    nested_types=[_SPAN_METAENTRY, _SPAN_METRICSENTRY,],
+    nested_types=[
+        _SPAN_METAENTRY,
+        _SPAN_METRICSENTRY,
+    ],
     enum_types=[],
     serialized_options=None,
     is_extendable=False,

--- a/aws/logs_monitoring/tools/integration_tests/recorder/pb/trace_payload_pb2.py
+++ b/aws/logs_monitoring/tools/integration_tests/recorder/pb/trace_payload_pb2.py
@@ -23,7 +23,10 @@ DESCRIPTOR = _descriptor.FileDescriptor(
     serialized_options=None,
     create_key=_descriptor._internal_create_key,
     serialized_pb=b'\n\x13trace_payload.proto\x12\x02pb\x1a\x0btrace.proto\x1a\nspan.proto"k\n\x0cTracePayload\x12\x10\n\x08hostName\x18\x01 \x01(\t\x12\x0b\n\x03\x65nv\x18\x02 \x01(\t\x12\x1c\n\x06traces\x18\x03 \x03(\x0b\x32\x0c.pb.APITrace\x12\x1e\n\x0ctransactions\x18\x04 \x03(\x0b\x32\x08.pb.Spanb\x06proto3',
-    dependencies=[trace__pb2.DESCRIPTOR, span__pb2.DESCRIPTOR,],
+    dependencies=[
+        trace__pb2.DESCRIPTOR,
+        span__pb2.DESCRIPTOR,
+    ],
 )
 
 

--- a/aws/logs_monitoring/tools/integration_tests/recorder/pb/trace_pb2.py
+++ b/aws/logs_monitoring/tools/integration_tests/recorder/pb/trace_pb2.py
@@ -22,7 +22,9 @@ DESCRIPTOR = _descriptor.FileDescriptor(
     serialized_options=None,
     create_key=_descriptor._internal_create_key,
     serialized_pb=b'\n\x0btrace.proto\x12\x02pb\x1a\nspan.proto"X\n\x08\x41PITrace\x12\x0f\n\x07traceID\x18\x01 \x01(\x04\x12\x17\n\x05spans\x18\x02 \x03(\x0b\x32\x08.pb.Span\x12\x11\n\tstartTime\x18\x06 \x01(\x03\x12\x0f\n\x07\x65ndTime\x18\x07 \x01(\x03\x62\x06proto3',
-    dependencies=[span__pb2.DESCRIPTOR,],
+    dependencies=[
+        span__pb2.DESCRIPTOR,
+    ],
 )
 
 

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log.json~snapshot
@@ -1,14 +1,9 @@
 {
   "events": [
     {
-      "path": "/v1/input/abcdefghijklmnopqrstuvwxyz012345",
-      "verb": "POST",
       "content-type": "application/json",
       "data": [
         {
-          "id": "eventId1",
-          "timestamp": 1440442987000,
-          "message": "[ERROR] First test message",
           "aws": {
             "awslogs": {
               "logGroup": "testLogGroup",
@@ -18,16 +13,16 @@
             "function_version": "$LATEST",
             "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
           },
+          "ddsource": "cloudwatch",
           "ddsourcecategory": "aws",
           "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>",
-          "ddsource": "cloudwatch",
+          "host": "testLogGroup",
+          "id": "eventId1",
+          "message": "[ERROR] First test message",
           "service": "cloudwatch",
-          "host": "testLogGroup"
+          "timestamp": 1440442987000
         },
         {
-          "id": "eventId2",
-          "timestamp": 1440442987001,
-          "message": "[ERROR] Second test message",
           "aws": {
             "awslogs": {
               "logGroup": "testLogGroup",
@@ -37,64 +32,69 @@
             "function_version": "$LATEST",
             "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
           },
+          "ddsource": "cloudwatch",
           "ddsourcecategory": "aws",
           "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>",
-          "ddsource": "cloudwatch",
+          "host": "testLogGroup",
+          "id": "eventId2",
+          "message": "[ERROR] Second test message",
           "service": "cloudwatch",
-          "host": "testLogGroup"
+          "timestamp": 1440442987001
         }
-      ]
+      ],
+      "path": "/v1/input/abcdefghijklmnopqrstuvwxyz012345",
+      "verb": "POST"
     },
     {
-      "path": "/api/v1/distribution_points?api_key=abcdefghijklmnopqrstuvwxyz012345",
-      "verb": "POST",
       "content-type": "application/json",
       "data": {
         "series": [
           {
+            "device": null,
+            "host": null,
+            "interval": 10,
             "metric": "aws.dd_forwarder.incoming_events",
             "points": "<redacted from snapshot>",
-            "type": "distribution",
-            "host": null,
-            "device": null,
             "tags": [
               "forwardername:test",
               "forwarder_memorysize:1536",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs"
             ],
-            "interval": 10
+            "type": "distribution"
           },
           {
+            "device": null,
+            "host": null,
+            "interval": 10,
             "metric": "aws.dd_forwarder.logs_forwarded",
             "points": "<redacted from snapshot>",
-            "type": "distribution",
-            "host": null,
-            "device": null,
             "tags": [
               "forwardername:test",
               "forwarder_memorysize:1536",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs"
             ],
-            "interval": 10
+            "type": "distribution"
           },
           {
+            "device": null,
+            "host": null,
+            "interval": 10,
             "metric": "aws.dd_forwarder.metrics_forwarded",
             "points": "<redacted from snapshot>",
-            "type": "distribution",
-            "host": null,
-            "device": null,
             "tags": [
               "forwardername:test",
               "forwarder_memorysize:1536",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs"
             ],
-            "interval": 10
+            "type": "distribution"
           }
         ]
-      }
+      },
+      "path": "/api/v1/distribution_points?api_key=abcdefghijklmnopqrstuvwxyz012345",
+      "verb": "POST"
     }
   ]
 }

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_coldstart.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_coldstart.json~snapshot
@@ -1,14 +1,31 @@
 {
   "events": [
     {
-      "path": "/v1/input/abcdefghijklmnopqrstuvwxyz012345",
-      "verb": "POST",
       "content-type": "application/json",
       "data": [
         {
+          "aws": {
+            "awslogs": {
+              "logGroup": "/aws/lambda/storms-cloudwatch-event",
+              "logStream": "2020/06/04/[$LATEST]af2b1e1843b84a2d80c67840ae3ffa72",
+              "owner": "601427279990"
+            },
+            "function_version": "$LATEST",
+            "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
+          },
+          "ddsource": "lambda",
+          "ddsourcecategory": "aws",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>,env:none,account_id:0,aws_account:0,functionname:storms-cloudwatch-event,region:us-east-1,service:storms-cloudwatch-event",
+          "host": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event",
           "id": "35486831490800643125153606102923171443962457178576257024",
-          "timestamp": 1591284559098,
+          "lambda": {
+            "arn": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event"
+          },
           "message": "START RequestId: db275f87-a934-471a-8980-b63bf4dc1beb Version: $LATEST\\n",
+          "service": "storms-cloudwatch-event",
+          "timestamp": 1591284559098
+        },
+        {
           "aws": {
             "awslogs": {
               "logGroup": "/aws/lambda/storms-cloudwatch-event",
@@ -18,41 +35,19 @@
             "function_version": "$LATEST",
             "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
           },
-          "lambda": {
-            "arn": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event"
-          },
+          "ddsource": "lambda",
           "ddsourcecategory": "aws",
           "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>,env:none,account_id:0,aws_account:0,functionname:storms-cloudwatch-event,region:us-east-1,service:storms-cloudwatch-event",
-          "ddsource": "lambda",
-          "service": "storms-cloudwatch-event",
-          "host": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event"
-        },
-        {
+          "host": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event",
           "id": "35486831490867545360749197972347778598780402263094198273",
-          "timestamp": 1591284559101,
-          "message": "END RequestId: db275f87-a934-471a-8980-b63bf4dc1beb\\n",
-          "aws": {
-            "awslogs": {
-              "logGroup": "/aws/lambda/storms-cloudwatch-event",
-              "logStream": "2020/06/04/[$LATEST]af2b1e1843b84a2d80c67840ae3ffa72",
-              "owner": "601427279990"
-            },
-            "function_version": "$LATEST",
-            "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
-          },
           "lambda": {
             "arn": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event"
           },
-          "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>,env:none,account_id:0,aws_account:0,functionname:storms-cloudwatch-event,region:us-east-1,service:storms-cloudwatch-event",
-          "ddsource": "lambda",
+          "message": "END RequestId: db275f87-a934-471a-8980-b63bf4dc1beb\\n",
           "service": "storms-cloudwatch-event",
-          "host": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event"
+          "timestamp": 1591284559101
         },
         {
-          "id": "35486831490867545360749197972347778598780402263094198274",
-          "timestamp": 1591284559101,
-          "message": "REPORT RequestId: db275f87-a934-471a-8980-b63bf4dc1beb\\tDuration: 1.76 ms\\tBilled Duration: 100 ms\\tMemory Size: 128 MB\\tMax Memory Used: 48 MB\\tInit Duration: 120.96 ms\\t\\n",
           "aws": {
             "awslogs": {
               "logGroup": "/aws/lambda/storms-cloudwatch-event",
@@ -62,67 +57,72 @@
             "function_version": "$LATEST",
             "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
           },
+          "ddsource": "lambda",
+          "ddsourcecategory": "aws",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>,env:none,account_id:0,aws_account:0,functionname:storms-cloudwatch-event,region:us-east-1,service:storms-cloudwatch-event",
+          "host": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event",
+          "id": "35486831490867545360749197972347778598780402263094198274",
           "lambda": {
             "arn": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event"
           },
-          "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>,env:none,account_id:0,aws_account:0,functionname:storms-cloudwatch-event,region:us-east-1,service:storms-cloudwatch-event",
-          "ddsource": "lambda",
+          "message": "REPORT RequestId: db275f87-a934-471a-8980-b63bf4dc1beb\\tDuration: 1.76 ms\\tBilled Duration: 100 ms\\tMemory Size: 128 MB\\tMax Memory Used: 48 MB\\tInit Duration: 120.96 ms\\t\\n",
           "service": "storms-cloudwatch-event",
-          "host": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event"
+          "timestamp": 1591284559101
         }
-      ]
+      ],
+      "path": "/v1/input/abcdefghijklmnopqrstuvwxyz012345",
+      "verb": "POST"
     },
     {
-      "path": "/api/v1/distribution_points?api_key=abcdefghijklmnopqrstuvwxyz012345",
-      "verb": "POST",
       "content-type": "application/json",
       "data": {
         "series": [
           {
+            "device": null,
+            "host": null,
+            "interval": 10,
             "metric": "aws.dd_forwarder.incoming_events",
             "points": "<redacted from snapshot>",
-            "type": "distribution",
-            "host": null,
-            "device": null,
             "tags": [
               "forwardername:test",
               "forwarder_memorysize:1536",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs"
             ],
-            "interval": 10
+            "type": "distribution"
           },
           {
+            "device": null,
+            "host": null,
+            "interval": 10,
             "metric": "aws.dd_forwarder.logs_forwarded",
             "points": "<redacted from snapshot>",
-            "type": "distribution",
-            "host": null,
-            "device": null,
             "tags": [
               "forwardername:test",
               "forwarder_memorysize:1536",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs"
             ],
-            "interval": 10
+            "type": "distribution"
           },
           {
+            "device": null,
+            "host": null,
+            "interval": 10,
             "metric": "aws.dd_forwarder.metrics_forwarded",
             "points": "<redacted from snapshot>",
-            "type": "distribution",
-            "host": null,
-            "device": null,
             "tags": [
               "forwardername:test",
               "forwarder_memorysize:1536",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs"
             ],
-            "interval": 10
+            "type": "distribution"
           }
         ]
-      }
+      },
+      "path": "/api/v1/distribution_points?api_key=abcdefghijklmnopqrstuvwxyz012345",
+      "verb": "POST"
     }
   ]
 }

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_custom_tags.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_custom_tags.json~snapshot
@@ -1,14 +1,9 @@
 {
   "events": [
     {
-      "path": "/v1/input/abcdefghijklmnopqrstuvwxyz012345",
-      "verb": "POST",
       "content-type": "application/json",
       "data": [
         {
-          "id": "eventId1",
-          "timestamp": 1440442987000,
-          "message": "{\"message\": \"hello world\"}",
           "aws": {
             "awslogs": {
               "logGroup": "testLogGroup",
@@ -18,64 +13,69 @@
             "function_version": "$LATEST",
             "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
           },
+          "ddsource": "cloudwatch",
           "ddsourcecategory": "aws",
           "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>,custom_tag1:value1,custom_tag2:value2",
-          "ddsource": "cloudwatch",
+          "host": "testLogGroup",
+          "id": "eventId1",
+          "message": "{\"message\": \"hello world\"}",
           "service": "cloudwatch",
-          "host": "testLogGroup"
+          "timestamp": 1440442987000
         }
-      ]
+      ],
+      "path": "/v1/input/abcdefghijklmnopqrstuvwxyz012345",
+      "verb": "POST"
     },
     {
-      "path": "/api/v1/distribution_points?api_key=abcdefghijklmnopqrstuvwxyz012345",
-      "verb": "POST",
       "content-type": "application/json",
       "data": {
         "series": [
           {
+            "device": null,
+            "host": null,
+            "interval": 10,
             "metric": "aws.dd_forwarder.incoming_events",
             "points": "<redacted from snapshot>",
-            "type": "distribution",
-            "host": null,
-            "device": null,
             "tags": [
               "forwardername:test",
               "forwarder_memorysize:1536",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs"
             ],
-            "interval": 10
+            "type": "distribution"
           },
           {
+            "device": null,
+            "host": null,
+            "interval": 10,
             "metric": "aws.dd_forwarder.logs_forwarded",
             "points": "<redacted from snapshot>",
-            "type": "distribution",
-            "host": null,
-            "device": null,
             "tags": [
               "forwardername:test",
               "forwarder_memorysize:1536",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs"
             ],
-            "interval": 10
+            "type": "distribution"
           },
           {
+            "device": null,
+            "host": null,
+            "interval": 10,
             "metric": "aws.dd_forwarder.metrics_forwarded",
             "points": "<redacted from snapshot>",
-            "type": "distribution",
-            "host": null,
-            "device": null,
             "tags": [
               "forwardername:test",
               "forwarder_memorysize:1536",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs"
             ],
-            "interval": 10
+            "type": "distribution"
           }
         ]
-      }
+      },
+      "path": "/api/v1/distribution_points?api_key=abcdefghijklmnopqrstuvwxyz012345",
+      "verb": "POST"
     }
   ]
 }

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_lambda_invocation.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_lambda_invocation.json~snapshot
@@ -1,14 +1,31 @@
 {
   "events": [
     {
-      "path": "/v1/input/abcdefghijklmnopqrstuvwxyz012345",
-      "verb": "POST",
       "content-type": "application/json",
       "data": [
         {
+          "aws": {
+            "awslogs": {
+              "logGroup": "/aws/lambda/hello-dog-node-dev-hello12x",
+              "logStream": "2020/03/05/[$LATEST]20bddfd5a2dc4c6b97ac02800eae90d0",
+              "owner": "601427279990"
+            },
+            "function_version": "$LATEST",
+            "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
+          },
+          "ddsource": "lambda",
+          "ddsourcecategory": "aws",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1,service:hello-dog-node-dev-hello12x",
+          "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x",
           "id": "35311576111948622874033876462979853992919938886093242368",
-          "timestamp": 1583425836114,
+          "lambda": {
+            "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
+          },
           "message": "2020-03-05T16:30:36.113Z\tf08bb4c8-d6b2-4f05-ac17-af7e2ba005fb\tDEBUG\t[dd.trace_id=3172564172058669914 dd.span_id=14292093692483532556] {\"status\":\"debug\",\"message\":\"datadog:Patched console output with trace context\"}\n",
+          "service": "hello-dog-node-dev-hello12x",
+          "timestamp": 1583425836114
+        },
+        {
           "aws": {
             "awslogs": {
               "logGroup": "/aws/lambda/hello-dog-node-dev-hello12x",
@@ -18,19 +35,19 @@
             "function_version": "$LATEST",
             "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
           },
-          "lambda": {
-            "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
-          },
+          "ddsource": "lambda",
           "ddsourcecategory": "aws",
           "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1,service:hello-dog-node-dev-hello12x",
-          "ddsource": "lambda",
-          "service": "hello-dog-node-dev-hello12x",
-          "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
-        },
-        {
+          "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x",
           "id": "35311576111948622874033876462979853992919938886093242369",
-          "timestamp": 1583425836114,
+          "lambda": {
+            "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
+          },
           "message": "2020-03-05T16:30:36.114Z\tf08bb4c8-d6b2-4f05-ac17-af7e2ba005fb\tDEBUG\t[dd.trace_id=3172564172058669914 dd.span_id=14292093692483532556] {\"autoPatchHTTP\":true,\"tracerInitialized\":true,\"status\":\"debug\",\"message\":\"datadog:Not patching HTTP libraries\"}\n",
+          "service": "hello-dog-node-dev-hello12x",
+          "timestamp": 1583425836114
+        },
+        {
           "aws": {
             "awslogs": {
               "logGroup": "/aws/lambda/hello-dog-node-dev-hello12x",
@@ -40,19 +57,19 @@
             "function_version": "$LATEST",
             "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
           },
-          "lambda": {
-            "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
-          },
+          "ddsource": "lambda",
           "ddsourcecategory": "aws",
           "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1,service:hello-dog-node-dev-hello12x",
-          "ddsource": "lambda",
-          "service": "hello-dog-node-dev-hello12x",
-          "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
-        },
-        {
+          "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x",
           "id": "35311576111948622874033876462979853992919938886093242370",
-          "timestamp": 1583425836114,
+          "lambda": {
+            "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
+          },
           "message": "2020-03-05T16:30:36.114Z\tf08bb4c8-d6b2-4f05-ac17-af7e2ba005fb\tDEBUG\t[dd.trace_id=3172564172058669914 dd.span_id=14292093692483532556] {\"status\":\"debug\",\"message\":\"datadog:Reading trace context from env var Root=1-5e61292c-cc1229a4dfbeae1043928548;Parent=c657b77d9514f70c;Sampled=1\"}\n",
+          "service": "hello-dog-node-dev-hello12x",
+          "timestamp": 1583425836114
+        },
+        {
           "aws": {
             "awslogs": {
               "logGroup": "/aws/lambda/hello-dog-node-dev-hello12x",
@@ -62,19 +79,19 @@
             "function_version": "$LATEST",
             "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
           },
-          "lambda": {
-            "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
-          },
+          "ddsource": "lambda",
           "ddsourcecategory": "aws",
           "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1,service:hello-dog-node-dev-hello12x",
-          "ddsource": "lambda",
-          "service": "hello-dog-node-dev-hello12x",
-          "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
-        },
-        {
+          "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x",
           "id": "35311576111948622874033876462979853992919938886093242371",
-          "timestamp": 1583425836114,
+          "lambda": {
+            "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
+          },
           "message": "2020-03-05T16:30:36.114Z\tf08bb4c8-d6b2-4f05-ac17-af7e2ba005fb\tDEBUG\t[dd.trace_id=3172564172058669914 dd.span_id=14292093692483532556] {\"parentID\":\"14292093692483532556\",\"sampleMode\":2,\"source\":\"xray\",\"traceID\":\"6899143064054564168\",\"status\":\"debug\",\"message\":\"datadog:read trace context from environment\"}\n",
+          "service": "hello-dog-node-dev-hello12x",
+          "timestamp": 1583425836114
+        },
+        {
           "aws": {
             "awslogs": {
               "logGroup": "/aws/lambda/hello-dog-node-dev-hello12x",
@@ -84,19 +101,19 @@
             "function_version": "$LATEST",
             "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
           },
-          "lambda": {
-            "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
-          },
+          "ddsource": "lambda",
           "ddsourcecategory": "aws",
           "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1,service:hello-dog-node-dev-hello12x",
-          "ddsource": "lambda",
-          "service": "hello-dog-node-dev-hello12x",
-          "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
-        },
-        {
+          "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x",
           "id": "35311576112305434797210366433244425485282312670188929029",
-          "timestamp": 1583425836130,
+          "lambda": {
+            "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
+          },
           "message": "2020-03-05T16:30:36.130Z\tf08bb4c8-d6b2-4f05-ac17-af7e2ba005fb\tDEBUG\t[dd.trace_id=6899143064054564168 dd.span_id=14292093692483532556] {\"status\":\"debug\",\"message\":\"datadog:set trace context from xray with parent 14292093692483532556 from segment\"}\n",
+          "service": "hello-dog-node-dev-hello12x",
+          "timestamp": 1583425836130
+        },
+        {
           "aws": {
             "awslogs": {
               "logGroup": "/aws/lambda/hello-dog-node-dev-hello12x",
@@ -106,19 +123,19 @@
             "function_version": "$LATEST",
             "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
           },
-          "lambda": {
-            "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
-          },
+          "ddsource": "lambda",
           "ddsourcecategory": "aws",
           "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1,service:hello-dog-node-dev-hello12x",
-          "ddsource": "lambda",
-          "service": "hello-dog-node-dev-hello12x",
-          "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
-        },
-        {
+          "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x",
           "id": "35311576113197464605151591358905854216188247130428145670",
-          "timestamp": 1583425836170,
+          "lambda": {
+            "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
+          },
           "message": "2020-03-05T16:30:36.131Z\tf08bb4c8-d6b2-4f05-ac17-af7e2ba005fb\tDEBUG\t[dd.trace_id=6899143064054564168 dd.span_id=14292093692483532556] {\"status\":\"debug\",\"message\":\"datadog:set trace context from xray with parent 14292093692483532556 from segment\"}\n",
+          "service": "hello-dog-node-dev-hello12x",
+          "timestamp": 1583425836170
+        },
+        {
           "aws": {
             "awslogs": {
               "logGroup": "/aws/lambda/hello-dog-node-dev-hello12x",
@@ -128,19 +145,19 @@
             "function_version": "$LATEST",
             "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
           },
-          "lambda": {
-            "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
-          },
+          "ddsource": "lambda",
           "ddsourcecategory": "aws",
           "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1,service:hello-dog-node-dev-hello12x",
-          "ddsource": "lambda",
-          "service": "hello-dog-node-dev-hello12x",
-          "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
-        },
-        {
+          "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x",
           "id": "35311576113197464605151591358905854216188247130428145671",
-          "timestamp": 1583425836170,
+          "lambda": {
+            "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
+          },
           "message": "2020-03-05T16:30:36.131Z\tf08bb4c8-d6b2-4f05-ac17-af7e2ba005fb\tDEBUG\t[dd.trace_id=6899143064054564168 dd.span_id=14292093692483532556] {\"status\":\"debug\",\"message\":\"datadog:set trace context from xray with parent 14292093692483532556 from segment\"}\n",
+          "service": "hello-dog-node-dev-hello12x",
+          "timestamp": 1583425836170
+        },
+        {
           "aws": {
             "awslogs": {
               "logGroup": "/aws/lambda/hello-dog-node-dev-hello12x",
@@ -150,19 +167,19 @@
             "function_version": "$LATEST",
             "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
           },
-          "lambda": {
-            "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
-          },
+          "ddsource": "lambda",
           "ddsourcecategory": "aws",
           "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1,service:hello-dog-node-dev-hello12x",
-          "ddsource": "lambda",
-          "service": "hello-dog-node-dev-hello12x",
-          "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
-        },
-        {
+          "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x",
           "id": "35311576113197464605151591358905854216188247130428145672",
-          "timestamp": 1583425836170,
+          "lambda": {
+            "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
+          },
           "message": "2020-03-05T16:30:36.131Z\tf08bb4c8-d6b2-4f05-ac17-af7e2ba005fb\tDEBUG\t[dd.trace_id=6899143064054564168 dd.span_id=14292093692483532556] {\"status\":\"debug\",\"message\":\"datadog:set trace context from xray with parent 14292093692483532556 from segment\"}\n",
+          "service": "hello-dog-node-dev-hello12x",
+          "timestamp": 1583425836170
+        },
+        {
           "aws": {
             "awslogs": {
               "logGroup": "/aws/lambda/hello-dog-node-dev-hello12x",
@@ -172,19 +189,19 @@
             "function_version": "$LATEST",
             "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
           },
-          "lambda": {
-            "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
-          },
+          "ddsource": "lambda",
           "ddsourcecategory": "aws",
           "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1,service:hello-dog-node-dev-hello12x",
-          "ddsource": "lambda",
-          "service": "hello-dog-node-dev-hello12x",
-          "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
-        },
-        {
+          "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x",
           "id": "35311576113197464605151591358905854216188247130428145673",
-          "timestamp": 1583425836170,
+          "lambda": {
+            "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
+          },
           "message": "2020-03-05T16:30:36.131Z\tf08bb4c8-d6b2-4f05-ac17-af7e2ba005fb\tDEBUG\t[dd.trace_id=6899143064054564168 dd.span_id=14292093692483532556] {\"status\":\"debug\",\"message\":\"datadog:Attempting to find parent for datadog trace trace\"}\n",
+          "service": "hello-dog-node-dev-hello12x",
+          "timestamp": 1583425836170
+        },
+        {
           "aws": {
             "awslogs": {
               "logGroup": "/aws/lambda/hello-dog-node-dev-hello12x",
@@ -194,19 +211,19 @@
             "function_version": "$LATEST",
             "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
           },
-          "lambda": {
-            "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
-          },
+          "ddsource": "lambda",
           "ddsourcecategory": "aws",
           "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1,service:hello-dog-node-dev-hello12x",
-          "ddsource": "lambda",
-          "service": "hello-dog-node-dev-hello12x",
-          "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
-        },
-        {
+          "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x",
           "id": "35311576113197464605151591358905854216188247130428145674",
-          "timestamp": 1583425836170,
+          "lambda": {
+            "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
+          },
           "message": "2020-03-05T16:30:36.131Z\tf08bb4c8-d6b2-4f05-ac17-af7e2ba005fb\tDEBUG\t[dd.trace_id=6899143064054564168 dd.span_id=14292093692483532556] {\"status\":\"debug\",\"message\":\"datadog:Applying lambda context to datadog traces\"}\n",
+          "service": "hello-dog-node-dev-hello12x",
+          "timestamp": 1583425836170
+        },
+        {
           "aws": {
             "awslogs": {
               "logGroup": "/aws/lambda/hello-dog-node-dev-hello12x",
@@ -216,19 +233,19 @@
             "function_version": "$LATEST",
             "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
           },
-          "lambda": {
-            "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
-          },
+          "ddsource": "lambda",
           "ddsourcecategory": "aws",
           "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1,service:hello-dog-node-dev-hello12x",
-          "ddsource": "lambda",
-          "service": "hello-dog-node-dev-hello12x",
-          "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
-        },
-        {
+          "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x",
           "id": "35311576113643479509122203821736568581641214360547753995",
-          "timestamp": 1583425836190,
+          "lambda": {
+            "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
+          },
           "message": "2020-03-05T16:30:36.172Z\tf08bb4c8-d6b2-4f05-ac17-af7e2ba005fb\tINFO\t[dd.trace_id=6899143064054564168 dd.span_id=2927617725217152879] Request Headers undefined\n",
+          "service": "hello-dog-node-dev-hello12x",
+          "timestamp": 1583425836190
+        },
+        {
           "aws": {
             "awslogs": {
               "logGroup": "/aws/lambda/hello-dog-node-dev-hello12x",
@@ -238,19 +255,19 @@
             "function_version": "$LATEST",
             "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
           },
-          "lambda": {
-            "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
-          },
+          "ddsource": "lambda",
           "ddsourcecategory": "aws",
           "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1,service:hello-dog-node-dev-hello12x",
-          "ddsource": "lambda",
-          "service": "hello-dog-node-dev-hello12x",
-          "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
-        },
-        {
+          "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x",
           "id": "35311576113643479509122203821736568581641214360547753996",
-          "timestamp": 1583425836190,
+          "lambda": {
+            "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
+          },
           "message": "2020-03-05T16:30:36.172Z\tf08bb4c8-d6b2-4f05-ac17-af7e2ba005fb\tINFO\t[dd.trace_id=6899143064054564168 dd.span_id=2927617725217152879] Root=1-5e61292c-cc1229a4dfbeae1043928548;Parent=c657b77d9514f70c;Sampled=1\n",
+          "service": "hello-dog-node-dev-hello12x",
+          "timestamp": 1583425836190
+        },
+        {
           "aws": {
             "awslogs": {
               "logGroup": "/aws/lambda/hello-dog-node-dev-hello12x",
@@ -260,19 +277,19 @@
             "function_version": "$LATEST",
             "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
           },
-          "lambda": {
-            "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
-          },
+          "ddsource": "lambda",
           "ddsourcecategory": "aws",
           "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1,service:hello-dog-node-dev-hello12x",
-          "ddsource": "lambda",
-          "service": "hello-dog-node-dev-hello12x",
-          "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
-        },
-        {
+          "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x",
           "id": "35311576123455807396475678004012284621606493423179137038",
-          "timestamp": 1583425836630,
+          "lambda": {
+            "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
+          },
           "message": "2020-03-05T16:30:36.592Z\tf08bb4c8-d6b2-4f05-ac17-af7e2ba005fb\tINFO\t[dd.trace_id=6899143064054564168 dd.span_id=3694123456155101779] 8103.047457805628\n",
+          "service": "hello-dog-node-dev-hello12x",
+          "timestamp": 1583425836630
+        },
+        {
           "aws": {
             "awslogs": {
               "logGroup": "/aws/lambda/hello-dog-node-dev-hello12x",
@@ -282,19 +299,19 @@
             "function_version": "$LATEST",
             "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
           },
-          "lambda": {
-            "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
-          },
+          "ddsource": "lambda",
           "ddsourcecategory": "aws",
           "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1,service:hello-dog-node-dev-hello12x",
-          "ddsource": "lambda",
-          "service": "hello-dog-node-dev-hello12x",
-          "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
-        },
-        {
+          "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x",
           "id": "35311576123478108141674208627153820339879141784685117455",
-          "timestamp": 1583425836631,
+          "lambda": {
+            "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
+          },
           "message": "2020-03-05T16:30:36.631Z\tf08bb4c8-d6b2-4f05-ac17-af7e2ba005fb\tINFO\t[dd.trace_id=6899143064054564168 dd.span_id=2927617725217152879] Finishing Span\n",
+          "service": "hello-dog-node-dev-hello12x",
+          "timestamp": 1583425836631
+        },
+        {
           "aws": {
             "awslogs": {
               "logGroup": "/aws/lambda/hello-dog-node-dev-hello12x",
@@ -304,41 +321,19 @@
             "function_version": "$LATEST",
             "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
           },
-          "lambda": {
-            "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
-          },
+          "ddsource": "lambda",
           "ddsourcecategory": "aws",
           "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1,service:hello-dog-node-dev-hello12x",
-          "ddsource": "lambda",
-          "service": "hello-dog-node-dev-hello12x",
-          "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
-        },
-        {
+          "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x",
           "id": "35311576126131896820299352780996570814324296803896786961",
-          "timestamp": 1583425836750,
-          "message": "END RequestId: f08bb4c8-d6b2-4f05-ac17-af7e2ba005fb\n",
-          "aws": {
-            "awslogs": {
-              "logGroup": "/aws/lambda/hello-dog-node-dev-hello12x",
-              "logStream": "2020/03/05/[$LATEST]20bddfd5a2dc4c6b97ac02800eae90d0",
-              "owner": "601427279990"
-            },
-            "function_version": "$LATEST",
-            "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
-          },
           "lambda": {
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
-          "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1,service:hello-dog-node-dev-hello12x",
-          "ddsource": "lambda",
+          "message": "END RequestId: f08bb4c8-d6b2-4f05-ac17-af7e2ba005fb\n",
           "service": "hello-dog-node-dev-hello12x",
-          "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
+          "timestamp": 1583425836750
         },
         {
-          "id": "35311576126131896820299352780996570814324296803896786962",
-          "timestamp": 1583425836750,
-          "message": "REPORT RequestId: f08bb4c8-d6b2-4f05-ac17-af7e2ba005fb\tDuration: 619.31 ms\tBilled Duration: 700 ms\tMemory Size: 128 MB\tMax Memory Used: 118 MB\t\nXRAY TraceId: 1-5e61292c-cc1229a4dfbeae1043928548\tSegmentId: 07a85e713f6302b2\tSampled: true\t\n",
           "aws": {
             "awslogs": {
               "logGroup": "/aws/lambda/hello-dog-node-dev-hello12x",
@@ -348,448 +343,451 @@
             "function_version": "$LATEST",
             "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
           },
+          "ddsource": "lambda",
+          "ddsourcecategory": "aws",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1,service:hello-dog-node-dev-hello12x",
+          "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x",
+          "id": "35311576126131896820299352780996570814324296803896786962",
           "lambda": {
             "arn": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
           },
-          "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>,env:none,account_id:0,aws_account:0,functionname:hello-dog-node-dev-hello12x,region:us-east-1,service:hello-dog-node-dev-hello12x",
-          "ddsource": "lambda",
+          "message": "REPORT RequestId: f08bb4c8-d6b2-4f05-ac17-af7e2ba005fb\tDuration: 619.31 ms\tBilled Duration: 700 ms\tMemory Size: 128 MB\tMax Memory Used: 118 MB\t\nXRAY TraceId: 1-5e61292c-cc1229a4dfbeae1043928548\tSegmentId: 07a85e713f6302b2\tSampled: true\t\n",
           "service": "hello-dog-node-dev-hello12x",
-          "host": "arn:aws:lambda:us-east-1:0:function:hello-dog-node-dev-hello12x"
+          "timestamp": 1583425836750
         }
-      ]
+      ],
+      "path": "/v1/input/abcdefghijklmnopqrstuvwxyz012345",
+      "verb": "POST"
     },
     {
-      "path": "/api/v0.2/traces",
-      "verb": "POST",
       "content-type": "application/x-protobuf",
       "data": {
         "env": "none",
         "traces": [
           {
-            "traceID": "6899143064054564168",
             "spans": [
               {
-                "service": "hello-dog-node-dev-hello12x",
-                "name": "calculation-long-number",
-                "resource": "calculation-long-number",
-                "traceID": "6899143064054564168",
-                "spanID": "3694123456155101779",
-                "parentID": "2927617725217152879",
-                "start": "1583425836164691700",
                 "duration": "458278320",
                 "meta": {
-                  "region": "us-east-1",
                   "_dd.origin": "lambda",
                   "account_id": "0",
-                  "forwarder_version": "3.16.4",
-                  "forwarder_memorysize": "1536",
                   "aws_account": "0",
-                  "functionname": "hello-dog-node-dev-hello12x",
-                  "forwardername": "test",
-                  "language": "javascript"
-                },
-                "metrics": {
-                  "_sampling_priority_v1": 2.0,
-                  "_sample_rate": 1.0
-                }
-              },
-              {
-                "service": "hello-dog-node-dev-hello12x",
-                "name": "recursive-func",
-                "resource": "recursive-func",
-                "traceID": "6899143064054564168",
-                "spanID": "1738181381438651579",
-                "parentID": "5202649218623954467",
-                "start": "1583425836623188200",
-                "duration": "13428",
-                "meta": {
-                  "_dd.origin": "lambda",
-                  "language": "javascript",
-                  "account_id": "0",
-                  "functionname": "hello-dog-node-dev-hello12x",
-                  "aws_account": "0",
-                  "forwarder_version": "3.16.4",
-                  "region": "us-east-1",
                   "forwarder_memorysize": "1536",
-                  "forwardername": "test"
-                },
-                "metrics": {
-                  "_sample_rate": 1.0,
-                  "_sampling_priority_v1": 2.0
-                }
-              },
-              {
-                "service": "hello-dog-node-dev-hello12x",
-                "name": "recursive-func",
-                "resource": "recursive-func",
-                "traceID": "6899143064054564168",
-                "spanID": "5202649218623954467",
-                "parentID": "5998620148937486365",
-                "start": "1583425836623169000",
-                "duration": "35645",
-                "meta": {
+                  "forwarder_version": "<redacted from snapshot>",
                   "forwardername": "test",
-                  "_dd.origin": "lambda",
                   "functionname": "hello-dog-node-dev-hello12x",
                   "language": "javascript",
-                  "aws_account": "0",
-                  "account_id": "0",
-                  "forwarder_memorysize": "1536",
-                  "forwarder_version": "3.16.4",
                   "region": "us-east-1"
                 },
                 "metrics": {
                   "_sample_rate": 1.0,
                   "_sampling_priority_v1": 2.0
-                }
+                },
+                "name": "calculation-long-number",
+                "parentID": "2927617725217152879",
+                "resource": "calculation-long-number",
+                "service": "hello-dog-node-dev-hello12x",
+                "spanID": "3694123456155101779",
+                "start": "1583425836164691700",
+                "traceID": "6899143064054564168"
               },
               {
-                "service": "hello-dog-node-dev-hello12x",
+                "duration": "13428",
+                "meta": {
+                  "_dd.origin": "lambda",
+                  "account_id": "0",
+                  "aws_account": "0",
+                  "forwarder_memorysize": "1536",
+                  "forwarder_version": "<redacted from snapshot>",
+                  "forwardername": "test",
+                  "functionname": "hello-dog-node-dev-hello12x",
+                  "language": "javascript",
+                  "region": "us-east-1"
+                },
+                "metrics": {
+                  "_sample_rate": 1.0,
+                  "_sampling_priority_v1": 2.0
+                },
                 "name": "recursive-func",
+                "parentID": "5202649218623954467",
                 "resource": "recursive-func",
-                "traceID": "6899143064054564168",
-                "spanID": "2282933403056196235",
-                "parentID": "3380767519770723072",
-                "start": "1583425836623226000",
+                "service": "hello-dog-node-dev-hello12x",
+                "spanID": "1738181381438651579",
+                "start": "1583425836623188200",
+                "traceID": "6899143064054564168"
+              },
+              {
+                "duration": "35645",
+                "meta": {
+                  "_dd.origin": "lambda",
+                  "account_id": "0",
+                  "aws_account": "0",
+                  "forwarder_memorysize": "1536",
+                  "forwarder_version": "<redacted from snapshot>",
+                  "forwardername": "test",
+                  "functionname": "hello-dog-node-dev-hello12x",
+                  "language": "javascript",
+                  "region": "us-east-1"
+                },
+                "metrics": {
+                  "_sample_rate": 1.0,
+                  "_sampling_priority_v1": 2.0
+                },
+                "name": "recursive-func",
+                "parentID": "5998620148937486365",
+                "resource": "recursive-func",
+                "service": "hello-dog-node-dev-hello12x",
+                "spanID": "5202649218623954467",
+                "start": "1583425836623169000",
+                "traceID": "6899143064054564168"
+              },
+              {
                 "duration": "9277",
                 "meta": {
-                  "region": "us-east-1",
-                  "forwarder_version": "3.16.4",
-                  "language": "javascript",
+                  "_dd.origin": "lambda",
+                  "account_id": "0",
                   "aws_account": "0",
                   "forwarder_memorysize": "1536",
-                  "account_id": "0",
+                  "forwarder_version": "<redacted from snapshot>",
+                  "forwardername": "test",
                   "functionname": "hello-dog-node-dev-hello12x",
-                  "_dd.origin": "lambda",
-                  "forwardername": "test"
+                  "language": "javascript",
+                  "region": "us-east-1"
                 },
                 "metrics": {
-                  "_sampling_priority_v1": 2.0,
-                  "_sample_rate": 1.0
-                }
+                  "_sample_rate": 1.0,
+                  "_sampling_priority_v1": 2.0
+                },
+                "name": "recursive-func",
+                "parentID": "3380767519770723072",
+                "resource": "recursive-func",
+                "service": "hello-dog-node-dev-hello12x",
+                "spanID": "2282933403056196235",
+                "start": "1583425836623226000",
+                "traceID": "6899143064054564168"
               },
               {
-                "service": "hello-dog-node-dev-hello12x",
-                "name": "recursive-func",
-                "resource": "recursive-func",
-                "traceID": "6899143064054564168",
-                "spanID": "3380767519770723072",
-                "parentID": "5998620148937486365",
-                "start": "1583425836623211000",
                 "duration": "26367",
                 "meta": {
-                  "language": "javascript",
-                  "forwardername": "test",
-                  "account_id": "0",
-                  "functionname": "hello-dog-node-dev-hello12x",
                   "_dd.origin": "lambda",
-                  "region": "us-east-1",
+                  "account_id": "0",
                   "aws_account": "0",
-                  "forwarder_version": "3.16.4",
-                  "forwarder_memorysize": "1536"
+                  "forwarder_memorysize": "1536",
+                  "forwarder_version": "<redacted from snapshot>",
+                  "forwardername": "test",
+                  "functionname": "hello-dog-node-dev-hello12x",
+                  "language": "javascript",
+                  "region": "us-east-1"
                 },
                 "metrics": {
                   "_sample_rate": 1.0,
                   "_sampling_priority_v1": 2.0
-                }
+                },
+                "name": "recursive-func",
+                "parentID": "5998620148937486365",
+                "resource": "recursive-func",
+                "service": "hello-dog-node-dev-hello12x",
+                "spanID": "3380767519770723072",
+                "start": "1583425836623211000",
+                "traceID": "6899143064054564168"
               },
               {
-                "service": "hello-dog-node-dev-hello12x",
-                "name": "recursive-func",
-                "resource": "recursive-func",
-                "traceID": "6899143064054564168",
-                "spanID": "5998620148937486365",
-                "parentID": "2927617725217152879",
-                "start": "1583425836623111700",
                 "duration": "127197",
                 "meta": {
-                  "forwarder_memorysize": "1536",
-                  "region": "us-east-1",
-                  "forwarder_version": "3.16.4",
-                  "functionname": "hello-dog-node-dev-hello12x",
+                  "_dd.origin": "lambda",
                   "account_id": "0",
                   "aws_account": "0",
-                  "language": "javascript",
+                  "forwarder_memorysize": "1536",
+                  "forwarder_version": "<redacted from snapshot>",
                   "forwardername": "test",
-                  "_dd.origin": "lambda"
+                  "functionname": "hello-dog-node-dev-hello12x",
+                  "language": "javascript",
+                  "region": "us-east-1"
                 },
                 "metrics": {
                   "_sample_rate": 1.0,
                   "_sampling_priority_v1": 2.0
-                }
+                },
+                "name": "recursive-func",
+                "parentID": "2927617725217152879",
+                "resource": "recursive-func",
+                "service": "hello-dog-node-dev-hello12x",
+                "spanID": "5998620148937486365",
+                "start": "1583425836623111700",
+                "traceID": "6899143064054564168"
               },
               {
-                "service": "hello-dog-node-dev-hello12x-dns",
-                "name": "dns.lookup",
-                "resource": "0.0.0.0",
-                "traceID": "6899143064054564168",
-                "spanID": "6811927158109850313",
-                "parentID": "2927617725217152879",
-                "start": "1583425836123944000",
                 "duration": "499751709",
                 "meta": {
-                  "forwarder_version": "3.16.4",
-                  "account_id": "0",
                   "_dd.origin": "lambda",
-                  "forwarder_memorysize": "1536",
-                  "dns.address": "0.0.0.0",
-                  "forwardername": "test",
+                  "account_id": "0",
                   "aws_account": "0",
+                  "dns.address": "0.0.0.0",
                   "dns.hostname": "0.0.0.0",
-                  "region": "us-east-1",
+                  "forwarder_memorysize": "1536",
+                  "forwarder_version": "<redacted from snapshot>",
+                  "forwardername": "test",
                   "functionname": "hello-dog-node-dev-hello12x",
+                  "region": "us-east-1",
                   "span.kind": "client"
                 },
                 "metrics": {
-                  "_top_level": 1.0,
                   "_sample_rate": 1.0,
-                  "_sampling_priority_v1": 2.0
-                }
+                  "_sampling_priority_v1": 2.0,
+                  "_top_level": 1.0
+                },
+                "name": "dns.lookup",
+                "parentID": "2927617725217152879",
+                "resource": "0.0.0.0",
+                "service": "hello-dog-node-dev-hello12x-dns",
+                "spanID": "6811927158109850313",
+                "start": "1583425836123944000",
+                "traceID": "6899143064054564168"
               },
               {
-                "service": "hello-dog-node-dev-hello12x-dns",
-                "name": "dns.lookup",
-                "resource": "169.254.79.2",
-                "traceID": "6899143064054564168",
-                "spanID": "7325853929267943283",
-                "parentID": "2927617725217152879",
-                "start": "1583425836623786500",
                 "duration": "218750",
                 "meta": {
-                  "aws_account": "0",
-                  "forwarder_memorysize": "1536",
-                  "region": "us-east-1",
-                  "dns.address": "169.254.79.2",
                   "_dd.origin": "lambda",
-                  "forwarder_version": "3.16.4",
                   "account_id": "0",
-                  "functionname": "hello-dog-node-dev-hello12x",
-                  "forwardername": "test",
+                  "aws_account": "0",
+                  "dns.address": "169.254.79.2",
                   "dns.hostname": "169.254.79.2",
+                  "forwarder_memorysize": "1536",
+                  "forwarder_version": "<redacted from snapshot>",
+                  "forwardername": "test",
+                  "functionname": "hello-dog-node-dev-hello12x",
+                  "region": "us-east-1",
                   "span.kind": "client"
                 },
                 "metrics": {
-                  "_top_level": 1.0,
+                  "_sample_rate": 1.0,
                   "_sampling_priority_v1": 2.0,
-                  "_sample_rate": 1.0
-                }
+                  "_top_level": 1.0
+                },
+                "name": "dns.lookup",
+                "parentID": "2927617725217152879",
+                "resource": "169.254.79.2",
+                "service": "hello-dog-node-dev-hello12x-dns",
+                "spanID": "7325853929267943283",
+                "start": "1583425836623786500",
+                "traceID": "6899143064054564168"
               },
               {
-                "service": "hello-dog-node-dev-hello12x-dns",
-                "name": "dns.lookup",
-                "resource": "www.google.com",
-                "traceID": "6899143064054564168",
-                "spanID": "6696506019546132474",
-                "parentID": "5181421763343194920",
-                "start": "1583425836164049000",
                 "duration": "460493896",
                 "meta": {
-                  "dns.hostname": "www.google.com",
-                  "span.kind": "client",
-                  "forwardername": "test",
                   "_dd.origin": "lambda",
-                  "region": "us-east-1",
-                  "forwarder_version": "3.16.4",
                   "account_id": "0",
-                  "functionname": "hello-dog-node-dev-hello12x",
+                  "aws_account": "0",
                   "dns.address": "172.217.15.68",
+                  "dns.hostname": "www.google.com",
                   "forwarder_memorysize": "1536",
-                  "aws_account": "0"
+                  "forwarder_version": "<redacted from snapshot>",
+                  "forwardername": "test",
+                  "functionname": "hello-dog-node-dev-hello12x",
+                  "region": "us-east-1",
+                  "span.kind": "client"
                 },
                 "metrics": {
                   "_sample_rate": 1.0,
                   "_sampling_priority_v1": 2.0,
                   "_top_level": 1.0
-                }
+                },
+                "name": "dns.lookup",
+                "parentID": "5181421763343194920",
+                "resource": "www.google.com",
+                "service": "hello-dog-node-dev-hello12x-dns",
+                "spanID": "6696506019546132474",
+                "start": "1583425836164049000",
+                "traceID": "6899143064054564168"
               },
               {
-                "service": "hello-dog-node-dev-hello12x-tcp",
-                "name": "tcp.connect",
-                "resource": "www.google.com:443",
-                "traceID": "6899143064054564168",
-                "spanID": "5181421763343194920",
-                "parentID": "6008770062380438555",
-                "start": "1583425836163914000",
                 "duration": "479066650",
                 "meta": {
-                  "out.port": "443",
                   "_dd.origin": "lambda",
-                  "tcp.remote.host": "www.google.com",
-                  "region": "us-east-1",
-                  "forwarder_memorysize": "1536",
-                  "aws_account": "0",
-                  "tcp.remote.port": "443",
-                  "tcp.family": "IPv4",
-                  "functionname": "hello-dog-node-dev-hello12x",
                   "account_id": "0",
-                  "forwarder_version": "3.16.4",
+                  "aws_account": "0",
+                  "forwarder_memorysize": "1536",
+                  "forwarder_version": "<redacted from snapshot>",
+                  "forwardername": "test",
+                  "functionname": "hello-dog-node-dev-hello12x",
                   "out.host": "www.google.com",
-                  "tcp.local.port": "37484",
-                  "forwardername": "test",
-                  "span.kind": "client",
-                  "tcp.local.address": "169.254.76.1"
-                },
-                "metrics": {
-                  "_sampling_priority_v1": 2.0,
-                  "_sublayers.duration.by_service.sublayer_service:hello-dog-node-dev-hello12x-tcp": 18572754.0,
-                  "_sample_rate": 1.0,
-                  "_sublayers.span_count": 2.0,
-                  "_top_level": 1.0,
-                  "_sublayers.duration.by_service.sublayer_service:hello-dog-node-dev-hello12x-dns": 460493896.0
-                }
-              },
-              {
-                "service": "hello-dog-node-dev-hello12x-http-client",
-                "name": "http.request",
-                "resource": "GET",
-                "traceID": "6899143064054564168",
-                "spanID": "6008770062380438555",
-                "parentID": "2927617725217152879",
-                "start": "1583425836124274200",
-                "duration": "577401367",
-                "meta": {
-                  "functionname": "hello-dog-node-dev-hello12x",
-                  "account_id": "0",
-                  "forwardername": "test",
-                  "forwarder_version": "3.16.4",
-                  "http.method": "GET",
-                  "aws_account": "0",
+                  "out.port": "443",
                   "region": "us-east-1",
-                  "http.url": "https://www.google.com/",
-                  "http.status_code": "200",
-                  "forwarder_memorysize": "1536",
                   "span.kind": "client",
-                  "_dd.origin": "lambda"
+                  "tcp.family": "IPv4",
+                  "tcp.local.address": "169.254.76.1",
+                  "tcp.local.port": "37484",
+                  "tcp.remote.host": "www.google.com",
+                  "tcp.remote.port": "443"
                 },
                 "metrics": {
-                  "_sublayers.duration.by_service.sublayer_service:hello-dog-node-dev-hello12x-dns": 460493896.0,
-                  "_sublayers.span_count": 3.0,
-                  "_sublayers.duration.by_service.sublayer_service:hello-dog-node-dev-hello12x-http-client": 98334717.0,
-                  "_sublayers.duration.by_type.sublayer_type:http": 98334717.0,
-                  "_sublayers.duration.by_service.sublayer_service:hello-dog-node-dev-hello12x-tcp": 18572754.0,
-                  "_sampling_priority_v1": 2.0,
                   "_sample_rate": 1.0,
+                  "_sampling_priority_v1": 2.0,
+                  "_sublayers.duration.by_service.sublayer_service:hello-dog-node-dev-hello12x-dns": 460493896.0,
+                  "_sublayers.duration.by_service.sublayer_service:hello-dog-node-dev-hello12x-tcp": 18572754.0,
+                  "_sublayers.span_count": 2.0,
                   "_top_level": 1.0
                 },
+                "name": "tcp.connect",
+                "parentID": "6008770062380438555",
+                "resource": "www.google.com:443",
+                "service": "hello-dog-node-dev-hello12x-tcp",
+                "spanID": "5181421763343194920",
+                "start": "1583425836163914000",
+                "traceID": "6899143064054564168"
+              },
+              {
+                "duration": "577401367",
+                "meta": {
+                  "_dd.origin": "lambda",
+                  "account_id": "0",
+                  "aws_account": "0",
+                  "forwarder_memorysize": "1536",
+                  "forwarder_version": "<redacted from snapshot>",
+                  "forwardername": "test",
+                  "functionname": "hello-dog-node-dev-hello12x",
+                  "http.method": "GET",
+                  "http.status_code": "200",
+                  "http.url": "https://www.google.com/",
+                  "region": "us-east-1",
+                  "span.kind": "client"
+                },
+                "metrics": {
+                  "_sample_rate": 1.0,
+                  "_sampling_priority_v1": 2.0,
+                  "_sublayers.duration.by_service.sublayer_service:hello-dog-node-dev-hello12x-dns": 460493896.0,
+                  "_sublayers.duration.by_service.sublayer_service:hello-dog-node-dev-hello12x-http-client": 98334717.0,
+                  "_sublayers.duration.by_service.sublayer_service:hello-dog-node-dev-hello12x-tcp": 18572754.0,
+                  "_sublayers.duration.by_type.sublayer_type:http": 98334717.0,
+                  "_sublayers.span_count": 3.0,
+                  "_top_level": 1.0
+                },
+                "name": "http.request",
+                "parentID": "2927617725217152879",
+                "resource": "GET",
+                "service": "hello-dog-node-dev-hello12x-http-client",
+                "spanID": "6008770062380438555",
+                "start": "1583425836124274200",
+                "traceID": "6899143064054564168",
                 "type": "http"
               },
               {
-                "service": "hello-dog-node-dev-hello12x",
-                "name": "aws.lambda",
-                "resource": "handler.hello",
-                "traceID": "6899143064054564168",
-                "spanID": "2927617725217152879",
-                "parentID": "14292093692483532556",
-                "start": "1583425836123549200",
                 "duration": "578297119",
                 "meta": {
-                  "forwardername": "test",
-                  "functionname": "hello-dog-node-dev-hello12x",
-                  "cold_start": "false",
-                  "resource_names": "hello-dog-node-dev-hello12x",
                   "_dd.origin": "lambda",
-                  "region": "us-east-1",
-                  "forwarder_version": "3.16.4",
-                  "request_id": "f08bb4c8-d6b2-4f05-ac17-af7e2ba005fb",
-                  "forwarder_memorysize": "1536",
                   "account_id": "0",
                   "aws_account": "0",
+                  "cold_start": "false",
+                  "forwarder_memorysize": "1536",
+                  "forwarder_version": "<redacted from snapshot>",
+                  "forwardername": "test",
+                  "function_arn": "arn:aws:lambda:us-east-1:601427279990:function:hello-dog-node-dev-hello12x",
+                  "functionname": "hello-dog-node-dev-hello12x",
                   "language": "javascript",
-                  "function_arn": "arn:aws:lambda:us-east-1:601427279990:function:hello-dog-node-dev-hello12x"
+                  "region": "us-east-1",
+                  "request_id": "f08bb4c8-d6b2-4f05-ac17-af7e2ba005fb",
+                  "resource_names": "hello-dog-node-dev-hello12x"
                 },
                 "metrics": {
-                  "_sublayers.duration.by_service.sublayer_service:hello-dog-node-dev-hello12x-http-client": 78514817.0,
-                  "_top_level": 1.0,
-                  "_sublayers.span_count": 12.0,
-                  "_sublayers.duration.by_service.sublayer_service:hello-dog-node-dev-hello12x-tcp": 18505254.0,
-                  "_sampling_priority_v1": 2.0,
-                  "_sublayers.duration.by_type.sublayer_type:http": 78514817.0,
-                  "_sublayers.duration.by_service.sublayer_service:hello-dog-node-dev-hello12x": 153367391.0,
                   "_sample_rate": 1.0,
-                  "_sublayers.duration.by_service.sublayer_service:hello-dog-node-dev-hello12x-dns": 327909657.0
-                }
+                  "_sampling_priority_v1": 2.0,
+                  "_sublayers.duration.by_service.sublayer_service:hello-dog-node-dev-hello12x": 153367391.0,
+                  "_sublayers.duration.by_service.sublayer_service:hello-dog-node-dev-hello12x-dns": 327909657.0,
+                  "_sublayers.duration.by_service.sublayer_service:hello-dog-node-dev-hello12x-http-client": 78514817.0,
+                  "_sublayers.duration.by_service.sublayer_service:hello-dog-node-dev-hello12x-tcp": 18505254.0,
+                  "_sublayers.duration.by_type.sublayer_type:http": 78514817.0,
+                  "_sublayers.span_count": 12.0,
+                  "_top_level": 1.0
+                },
+                "name": "aws.lambda",
+                "parentID": "14292093692483532556",
+                "resource": "handler.hello",
+                "service": "hello-dog-node-dev-hello12x",
+                "spanID": "2927617725217152879",
+                "start": "1583425836123549200",
+                "traceID": "6899143064054564168"
               }
             ],
-            "startTime": "1583425836123549200"
+            "startTime": "1583425836123549200",
+            "traceID": "6899143064054564168"
           }
         ]
-      }
+      },
+      "path": "/api/v0.2/traces",
+      "verb": "POST"
     },
     {
-      "path": "/api/v0.2/stats",
-      "verb": "POST",
       "content-type": "application/json",
-      "data": null
+      "data": null,
+      "path": "/api/v0.2/stats",
+      "verb": "POST"
     },
     {
-      "path": "/api/v1/distribution_points?api_key=abcdefghijklmnopqrstuvwxyz012345",
-      "verb": "POST",
       "content-type": "application/json",
       "data": {
         "series": [
           {
+            "device": null,
+            "host": null,
+            "interval": 10,
             "metric": "aws.dd_forwarder.incoming_events",
             "points": "<redacted from snapshot>",
-            "type": "distribution",
-            "host": null,
-            "device": null,
             "tags": [
               "forwardername:test",
               "forwarder_memorysize:1536",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs"
             ],
-            "interval": 10
+            "type": "distribution"
           },
           {
+            "device": null,
+            "host": null,
+            "interval": 10,
             "metric": "aws.dd_forwarder.logs_forwarded",
             "points": "<redacted from snapshot>",
-            "type": "distribution",
-            "host": null,
-            "device": null,
             "tags": [
               "forwardername:test",
               "forwarder_memorysize:1536",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs"
             ],
-            "interval": 10
+            "type": "distribution"
           },
           {
+            "device": null,
+            "host": null,
+            "interval": 10,
             "metric": "aws.dd_forwarder.metrics_forwarded",
             "points": "<redacted from snapshot>",
-            "type": "distribution",
-            "host": null,
-            "device": null,
             "tags": [
               "forwardername:test",
               "forwarder_memorysize:1536",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs"
             ],
-            "interval": 10
+            "type": "distribution"
           },
           {
+            "device": null,
+            "host": null,
+            "interval": 10,
             "metric": "aws.dd_forwarder.traces_forwarded",
             "points": "<redacted from snapshot>",
-            "type": "distribution",
-            "host": null,
-            "device": null,
             "tags": [
               "forwardername:test",
               "forwarder_memorysize:1536",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs"
             ],
-            "interval": 10
+            "type": "distribution"
           },
           {
+            "device": null,
+            "host": null,
+            "interval": 10,
             "metric": "aws.lambda.enhanced.invocations",
             "points": "<redacted from snapshot>",
-            "type": "distribution",
-            "host": null,
-            "device": null,
             "tags": [
               "region:us-east-1",
               "account_id:601427279990",
@@ -807,14 +805,14 @@
               "region:us-east-1",
               "service:hello-dog-node-dev-hello12x"
             ],
-            "interval": 10
+            "type": "distribution"
           },
           {
+            "device": null,
+            "host": null,
+            "interval": 10,
             "metric": "hello.js10x.dog-2",
             "points": "<redacted from snapshot>",
-            "type": "distribution",
-            "host": null,
-            "device": null,
             "tags": [
               "dd_lambda_layer:datadog-nodev12.14.1",
               "forwardername:test",
@@ -827,14 +825,14 @@
               "region:us-east-1",
               "service:hello-dog-node-dev-hello12x"
             ],
-            "interval": 10
+            "type": "distribution"
           },
           {
+            "device": null,
+            "host": null,
+            "interval": 10,
             "metric": "aws.lambda.enhanced.duration",
             "points": "<redacted from snapshot>",
-            "type": "distribution",
-            "host": null,
-            "device": null,
             "tags": [
               "memorysize:128",
               "cold_start:false",
@@ -843,14 +841,14 @@
               "aws_account:0",
               "functionname:hello-dog-node-dev-hello12x"
             ],
-            "interval": 10
+            "type": "distribution"
           },
           {
+            "device": null,
+            "host": null,
+            "interval": 10,
             "metric": "aws.lambda.enhanced.billed_duration",
             "points": "<redacted from snapshot>",
-            "type": "distribution",
-            "host": null,
-            "device": null,
             "tags": [
               "memorysize:128",
               "cold_start:false",
@@ -859,14 +857,14 @@
               "aws_account:0",
               "functionname:hello-dog-node-dev-hello12x"
             ],
-            "interval": 10
+            "type": "distribution"
           },
           {
+            "device": null,
+            "host": null,
+            "interval": 10,
             "metric": "aws.lambda.enhanced.max_memory_used",
             "points": "<redacted from snapshot>",
-            "type": "distribution",
-            "host": null,
-            "device": null,
             "tags": [
               "memorysize:128",
               "cold_start:false",
@@ -875,14 +873,14 @@
               "aws_account:0",
               "functionname:hello-dog-node-dev-hello12x"
             ],
-            "interval": 10
+            "type": "distribution"
           },
           {
+            "device": null,
+            "host": null,
+            "interval": 10,
             "metric": "aws.lambda.enhanced.estimated_cost",
             "points": "<redacted from snapshot>",
-            "type": "distribution",
-            "host": null,
-            "device": null,
             "tags": [
               "memorysize:128",
               "cold_start:false",
@@ -891,10 +889,12 @@
               "aws_account:0",
               "functionname:hello-dog-node-dev-hello12x"
             ],
-            "interval": 10
+            "type": "distribution"
           }
         ]
-      }
+      },
+      "path": "/api/v1/distribution_points?api_key=abcdefghijklmnopqrstuvwxyz012345",
+      "verb": "POST"
     }
   ]
 }

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_timeout.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_timeout.json~snapshot
@@ -1,14 +1,31 @@
 {
   "events": [
     {
-      "path": "/v1/input/abcdefghijklmnopqrstuvwxyz012345",
-      "verb": "POST",
       "content-type": "application/json",
       "data": [
         {
+          "aws": {
+            "awslogs": {
+              "logGroup": "/aws/lambda/storms-cloudwatch-event",
+              "logStream": "2020/06/09/[$LATEST]b249865adaaf4fad80f95f8ad09725b8",
+              "owner": "601427279990"
+            },
+            "function_version": "$LATEST",
+            "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
+          },
+          "ddsource": "lambda",
+          "ddsourcecategory": "aws",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>,env:none,account_id:0,aws_account:0,functionname:storms-cloudwatch-event,region:us-east-1,service:storms-cloudwatch-event",
+          "host": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event",
           "id": "35496429375792603298393743017356257146982675867810398208",
-          "timestamp": 1591714943146,
+          "lambda": {
+            "arn": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event"
+          },
           "message": "START RequestId: 7c9567b5-107b-4a6c-8798-0157ac21db52 Version: $LATEST\\n",
+          "service": "storms-cloudwatch-event",
+          "timestamp": 1591714943146
+        },
+        {
           "aws": {
             "awslogs": {
               "logGroup": "/aws/lambda/storms-cloudwatch-event",
@@ -18,19 +35,19 @@
             "function_version": "$LATEST",
             "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
           },
-          "lambda": {
-            "arn": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event"
-          },
+          "ddsource": "lambda",
           "ddsourcecategory": "aws",
           "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>,env:none,account_id:0,aws_account:0,functionname:storms-cloudwatch-event,region:us-east-1,service:storms-cloudwatch-event",
-          "ddsource": "lambda",
-          "service": "storms-cloudwatch-event",
-          "host": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event"
-        },
-        {
+          "host": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event",
           "id": "35496429442806342619978265557671090556291002193281548289",
-          "timestamp": 1591714946151,
+          "lambda": {
+            "arn": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event"
+          },
           "message": "END RequestId: 7c9567b5-107b-4a6c-8798-0157ac21db52\\n",
+          "service": "storms-cloudwatch-event",
+          "timestamp": 1591714946151
+        },
+        {
           "aws": {
             "awslogs": {
               "logGroup": "/aws/lambda/storms-cloudwatch-event",
@@ -40,41 +57,19 @@
             "function_version": "$LATEST",
             "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
           },
-          "lambda": {
-            "arn": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event"
-          },
+          "ddsource": "lambda",
           "ddsourcecategory": "aws",
           "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>,env:none,account_id:0,aws_account:0,functionname:storms-cloudwatch-event,region:us-east-1,service:storms-cloudwatch-event",
-          "ddsource": "lambda",
-          "service": "storms-cloudwatch-event",
-          "host": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event"
-        },
-        {
+          "host": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event",
           "id": "35496429442806342619978265557671090556291002193281548290",
-          "timestamp": 1591714946151,
-          "message": "REPORT RequestId: 7c9567b5-107b-4a6c-8798-0157ac21db52\\tDuration: 3003.16 ms\\tBilled Duration: 3000 ms\\tMemory Size: 128 MB\\tMax Memory Used: 48 MB\\tInit Duration: 127.02 ms\\t\\n",
-          "aws": {
-            "awslogs": {
-              "logGroup": "/aws/lambda/storms-cloudwatch-event",
-              "logStream": "2020/06/09/[$LATEST]b249865adaaf4fad80f95f8ad09725b8",
-              "owner": "601427279990"
-            },
-            "function_version": "$LATEST",
-            "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
-          },
           "lambda": {
             "arn": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event"
           },
-          "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>,env:none,account_id:0,aws_account:0,functionname:storms-cloudwatch-event,region:us-east-1,service:storms-cloudwatch-event",
-          "ddsource": "lambda",
+          "message": "REPORT RequestId: 7c9567b5-107b-4a6c-8798-0157ac21db52\\tDuration: 3003.16 ms\\tBilled Duration: 3000 ms\\tMemory Size: 128 MB\\tMax Memory Used: 48 MB\\tInit Duration: 127.02 ms\\t\\n",
           "service": "storms-cloudwatch-event",
-          "host": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event"
+          "timestamp": 1591714946151
         },
         {
-          "id": "35496429442806342619978265557671090556291002193281548291",
-          "timestamp": 1591714946151,
-          "message": "2020-06-09T15:02:26.150Z 7c9567b5-107b-4a6c-8798-0157ac21db52 Task timed out after 3.00 seconds\\n\\n",
           "aws": {
             "awslogs": {
               "logGroup": "/aws/lambda/storms-cloudwatch-event",
@@ -84,81 +79,86 @@
             "function_version": "$LATEST",
             "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
           },
+          "ddsource": "lambda",
+          "ddsourcecategory": "aws",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>,env:none,account_id:0,aws_account:0,functionname:storms-cloudwatch-event,region:us-east-1,service:storms-cloudwatch-event",
+          "host": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event",
+          "id": "35496429442806342619978265557671090556291002193281548291",
           "lambda": {
             "arn": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event"
           },
-          "ddsourcecategory": "aws",
-          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>,env:none,account_id:0,aws_account:0,functionname:storms-cloudwatch-event,region:us-east-1,service:storms-cloudwatch-event",
-          "ddsource": "lambda",
+          "message": "2020-06-09T15:02:26.150Z 7c9567b5-107b-4a6c-8798-0157ac21db52 Task timed out after 3.00 seconds\\n\\n",
           "service": "storms-cloudwatch-event",
-          "host": "arn:aws:lambda:us-east-1:0:function:storms-cloudwatch-event"
+          "timestamp": 1591714946151
         }
-      ]
+      ],
+      "path": "/v1/input/abcdefghijklmnopqrstuvwxyz012345",
+      "verb": "POST"
     },
     {
-      "path": "/api/v1/distribution_points?api_key=abcdefghijklmnopqrstuvwxyz012345",
-      "verb": "POST",
       "content-type": "application/json",
       "data": {
         "series": [
           {
+            "device": null,
+            "host": null,
+            "interval": 10,
             "metric": "aws.dd_forwarder.incoming_events",
             "points": "<redacted from snapshot>",
-            "type": "distribution",
-            "host": null,
-            "device": null,
             "tags": [
               "forwardername:test",
               "forwarder_memorysize:1536",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs"
             ],
-            "interval": 10
+            "type": "distribution"
           },
           {
+            "device": null,
+            "host": null,
+            "interval": 10,
             "metric": "aws.dd_forwarder.logs_forwarded",
             "points": "<redacted from snapshot>",
-            "type": "distribution",
-            "host": null,
-            "device": null,
             "tags": [
               "forwardername:test",
               "forwarder_memorysize:1536",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs"
             ],
-            "interval": 10
+            "type": "distribution"
           },
           {
+            "device": null,
+            "host": null,
+            "interval": 10,
             "metric": "aws.dd_forwarder.metrics_forwarded",
             "points": "<redacted from snapshot>",
-            "type": "distribution",
-            "host": null,
-            "device": null,
             "tags": [
               "forwardername:test",
               "forwarder_memorysize:1536",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs"
             ],
-            "interval": 10
+            "type": "distribution"
           },
           {
+            "device": null,
+            "host": null,
+            "interval": 10,
             "metric": "aws.lambda.enhanced.timeouts",
             "points": "<redacted from snapshot>",
-            "type": "distribution",
-            "host": null,
-            "device": null,
             "tags": [
               "region:us-east-1",
               "account_id:0",
               "aws_account:0",
               "functionname:storms-cloudwatch-event"
             ],
-            "interval": 10
+            "type": "distribution"
           }
         ]
-      }
+      },
+      "path": "/api/v1/distribution_points?api_key=abcdefghijklmnopqrstuvwxyz012345",
+      "verb": "POST"
     }
   ]
 }

--- a/aws/logs_monitoring/tools/integration_tests/tester/test_snapshots.py
+++ b/aws/logs_monitoring/tools/integration_tests/tester/test_snapshots.py
@@ -40,10 +40,16 @@ class TestForwarderSnapshots(unittest.TestCase):
 
     def filter_snapshot(self, snapshot):
         # Remove things that can vary during each test run
-        # forwarder_version
+        # Forwarder version in tags
         snapshot = re.sub(
             r"forwarder_version:\d+\.\d+\.\d+",
             "forwarder_version:<redacted from snapshot>",
+            snapshot,
+        )
+        # Forwarder version in trace payloads
+        snapshot = re.sub(
+            r"\"forwarder_version\":\s\"\d+\.\d+\.\d+\"",
+            '"forwarder_version": "<redacted from snapshot>"',
             snapshot,
         )
         # Metric points
@@ -73,7 +79,8 @@ class TestForwarderSnapshots(unittest.TestCase):
 
         if update_snapshot:
             with open(snapshot_filename, "w") as snapshot_file:
-                snapshot_file.write(json.dumps(output_data, indent=2))
+                snapshot_file.write(json.dumps(output_data, indent=2, sort_keys=True))
+                # snapshot_file.write(json.dumps(output_data, indent=2))
         else:
             message = f"Snapshots didn't match for {input_filename}. To update run `integration_tests.sh --update`."
             self.assertEqual(output_data, snapshot_data, message)


### PR DESCRIPTION
### What does this PR do?

Prevent inconsistencies when running the integration tests:
- Redact forwarder version from trace payloads in the snapshots
- Alphabetize the dictionaries in the snapshots

Also:
- Use a different command for getting the timestamp in the integration tests that is compatible with `zsh`
- Do not print the success message for the additional lambda test if the test was not run

### Motivation

This should reduce false positives in the integration tests.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
