### PR TITLE
Fix access to S3 within VPC

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -111,8 +111,9 @@ You can run the Forwarder in a VPC by using AWS PrivateLink to connect to Datado
 1. Follow the [setup instructions](https://docs.datadoghq.com/agent/guide/private-link/?tab=logs#create-your-vpc-endpoint) to add an endpoint to your VPC for Datadog's **API** service.
 2. Follow the [same procedure](https://docs.datadoghq.com/agent/guide/private-link/?tab=logs#create-your-vpc-endpoint) to add a second endpoint to your VPC for Datadog's **Logs** service.
 3. Follow the [same procedure](https://docs.datadoghq.com/agent/guide/private-link/?tab=logs#create-your-vpc-endpoint) once more to add a third endpoint to your VPC for Datadog's **Traces** service. 
-4. By default, the Forwarder's API key is stored in the Secrets Manager. The Secrets Manager endpoint needs to be added to the VPC. You can follow the instructions [here](https://docs.aws.amazon.com/vpc/latest/userguide/vpce-interface.html#create-interface-endpoint) for adding AWS services to a VPC.
+4. Unless the Forwarder is deployed to a public subnet, follow the [instructions](https://docs.aws.amazon.com/vpc/latest/userguide/vpce-interface.html#create-interface-endpoint) to add endpoints for Secrets Manager and S3 to the VPC, so that the Forwarder can access those services.
 5. When installing the Forwarder with the CloudFormation template, enable 'DdUsePrivateLink' and set at least one Subnet Id and Security Group.
+6. Ensure the `DdFetchLambdaTags` option is disabled, because AWS VPC does not yet offer an endpoint for the Resource Groups Tagging API.
 
 
 ## Troubleshooting

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -10,6 +10,7 @@ import os
 from collections import defaultdict
 
 import boto3
+import botocore
 import itertools
 import re
 import urllib
@@ -779,7 +780,11 @@ def parse_event_type(event):
 
 # Handle S3 events
 def s3_handler(event, context, metadata):
-    s3 = boto3.client("s3")
+    s3 = boto3.client(
+        "s3",
+        os.environ["AWS_REGION"],
+        config=botocore.config.Config(s3={"addressing_style": "path"}),
+    )
 
     # Get the object from the event and show its content type
     bucket = event["Records"][0]["s3"]["bucket"]["name"]


### PR DESCRIPTION
### What does this PR do?

Update the PrivateLink doc and the forwarder code to allow the Forwarder access S3 via VPC endpoint. The required code change is copied from [here](https://github.com/gford1000-aws/lambda_s3_access_using_vpc_endpoint#boto3-specific-notes).

### Motivation

The Forwarder times out on fetching log objects from S3 when deployed to a VPC.

### Testing Guidelines

- [x] Forwarder can fetch objects from S3 when deployed to VPC
- [x] Forwarder can fetch objects from S3 when NOT deployed to VPC

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [x] This PR passes the installation tests (ask a Datadog member to run the tests)
