### PR TITLE
Support sending data from VPC through a proxy

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -112,9 +112,22 @@ You can run the Forwarder in a VPC by using AWS PrivateLink to connect to Datado
 2. Follow the [same procedure](https://docs.datadoghq.com/agent/guide/private-link/?tab=logs#create-your-vpc-endpoint) to add a second endpoint to your VPC for Datadog's **Logs** service.
 3. Follow the [same procedure](https://docs.datadoghq.com/agent/guide/private-link/?tab=logs#create-your-vpc-endpoint) once more to add a third endpoint to your VPC for Datadog's **Traces** service. 
 4. Unless the Forwarder is deployed to a public subnet, follow the [instructions](https://docs.aws.amazon.com/vpc/latest/userguide/vpce-interface.html#create-interface-endpoint) to add endpoints for Secrets Manager and S3 to the VPC, so that the Forwarder can access those services.
-5. When installing the Forwarder with the CloudFormation template, enable 'DdUsePrivateLink' and set at least one Subnet Id and Security Group.
+5. When installing the Forwarder with the CloudFormation template, set `DdUsePrivateLink`, `VPCSecurityGroupIds` and `VPCSubnetIds`.
 6. Ensure the `DdFetchLambdaTags` option is disabled, because AWS VPC does not yet offer an endpoint for the Resource Groups Tagging API.
 
+## AWS VPC and Proxy Support
+
+If you must deploy the Forwarder to a VPC without direct public internet access, and you cannot use AWS PrivateLink to connect to Datadog, such as your organization is hosted on the Datadog EU site (datadoghq.eu), then you can send data via a proxy.
+
+1. Unless the Forwarder is deployed to a public subnet, follow the [instructions](https://docs.aws.amazon.com/vpc/latest/userguide/vpce-interface.html#create-interface-endpoint) to add endpoints for Secrets Manager and S3 to the VPC, so that the Forwarder can access those services.
+2. Update your proxy with following configurations ([HAProxy](https://github.com/DataDog/datadog-serverless-functions/blob/master/aws/logs_monitoring/proxy_conf/haproxy.txt) or [Nginx](https://github.com/DataDog/datadog-serverless-functions/blob/master/aws/logs_monitoring/proxy_conf/nginx.txt)).
+3. When installing the Forwarder with the CloudFormation template, set `DdUseVPC`, `VPCSecurityGroupIds` and `VPCSubnetIds`.
+4. Ensure the `DdFetchLambdaTags` option is disabled, because AWS VPC does not yet offer an endpoint for the Resource Groups Tagging API.
+5. Set `DdApiUrl` to `http://<proxy_host>:3834` or `https://<proxy_host>:3834`.
+6. Set `DdTraceIntakeUrl` to `http://<proxy_host>:3835` or `https://<proxy_host>:3835`.
+7. Set `DdUrl` to `<proxy_host>` and `DdPort` to `3837`.
+8. Set `DdNoSsl` to `true` if connecting to the proxy using `http`.
+9. Set `DdSkipSslValidation` to `true` if connecting to the proxy using `https` with a sef-signed certificate.
 
 ## Troubleshooting
 

--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -117,7 +117,7 @@ You can run the Forwarder in a VPC by using AWS PrivateLink to connect to Datado
 
 ## AWS VPC and Proxy Support
 
-If you must deploy the Forwarder to a VPC without direct public internet access, and you cannot use AWS PrivateLink to connect to Datadog, such as your organization is hosted on the Datadog EU site (datadoghq.eu), then you can send data via a proxy.
+If you must deploy the Forwarder to a VPC without direct public internet access, and you cannot use AWS PrivateLink to connect to Datadog (for example, if your organization is hosted on the Datadog EU site (i.e. datadoghq.eu)), then you can send data via a proxy.
 
 1. Unless the Forwarder is deployed to a public subnet, follow the [instructions](https://docs.aws.amazon.com/vpc/latest/userguide/vpce-interface.html#create-interface-endpoint) to add endpoints for Secrets Manager and S3 to the VPC, so that the Forwarder can access those services.
 2. Update your proxy with following configurations ([HAProxy](https://github.com/DataDog/datadog-serverless-functions/blob/master/aws/logs_monitoring/proxy_conf/haproxy.txt) or [Nginx](https://github.com/DataDog/datadog-serverless-functions/blob/master/aws/logs_monitoring/proxy_conf/nginx.txt)).

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -80,7 +80,8 @@ if len(DD_API_KEY) != 32:
     )
 # Validate the API key
 validation_res = requests.get(
-    "{}/api/v1/validate?api_key={}".format(DD_API_URL, DD_API_KEY)
+    "{}/api/v1/validate?api_key={}".format(DD_API_URL, DD_API_KEY),
+    verify=(not DD_SKIP_SSL_VALIDATION),
 )
 if not validation_res.ok:
     raise Exception("The API key is not valid.")
@@ -88,8 +89,11 @@ if not validation_res.ok:
 # Force the layer to use the exact same API key and host as the forwarder
 api._api_key = DD_API_KEY
 api._api_host = DD_API_URL
+api._cacert = not DD_SKIP_SSL_VALIDATION
 
-trace_connection = TraceConnection(DD_TRACE_INTAKE_URL, DD_API_KEY)
+trace_connection = TraceConnection(
+    DD_TRACE_INTAKE_URL, DD_API_KEY, DD_SKIP_SSL_VALIDATION
+)
 
 # Use for include, exclude, and scrubbing rules
 def compileRegex(rule, pattern):
@@ -204,6 +208,11 @@ class DatadogTCPClient(object):
         self._api_key = api_key
         self._scrubber = scrubber
         self._sock = None
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                f"Initialized tcp client for logs intake: "
+                f"<host: {host}, port: {port}, no_ssl: {no_ssl}>"
+            )
 
     def _connect(self):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -263,6 +272,12 @@ class DatadogHTTPClient(object):
         self._timeout = timeout
         self._session = None
         self._ssl_validation = not skip_ssl_validation
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                f"Initialized http client for logs intake: "
+                f"<host: {host}, port: {port}, url: {self._url}, no_ssl: {no_ssl}, "
+                f"skip_ssl_validation: {skip_ssl_validation}, timeout: {timeout}>"
+            )
 
     def _connect(self):
         self._session = requests.Session()
@@ -414,6 +429,8 @@ lambda_handler = datadog_lambda_wrapper(datadog_forwarder)
 
 def forward_logs(logs):
     """Forward logs to Datadog"""
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug(f"Forwarding {len(logs)} logs")
     logs_to_forward = filter_logs(list(map(json.dumps, logs)))
     scrubber = DatadogScrubber(SCRUBBING_RULE_CONFIGS)
     if DD_USE_TCP:
@@ -449,6 +466,8 @@ def parse(event, context):
     try:
         # Route to the corresponding parser
         event_type = parse_event_type(event)
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(f"Parsed event type: {event_type}")
         if event_type == "s3":
             events = s3_handler(event, context, metadata)
         elif event_type == "awslogs":
@@ -662,6 +681,12 @@ def split(events):
             trace_payloads.append(trace_payload)
         else:
             logs.append(event)
+
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug(
+            f"Extracted {len(metrics)} metrics, {len(trace_payloads)} traces, and {len(logs)} logs"
+        )
+
     return metrics, logs, trace_payloads
 
 
@@ -698,6 +723,9 @@ def forward_metrics(metrics):
     Forward custom metrics submitted via logs to Datadog in a background thread
     using `lambda_stats` that is provided by the Datadog Python Lambda Layer.
     """
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug(f"Forwarding {len(metrics)} metrics")
+
     for metric in metrics:
         try:
             lambda_stats.distribution(
@@ -717,6 +745,9 @@ def forward_metrics(metrics):
 
 
 def forward_traces(trace_payloads):
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug(f"Forwarding {len(trace_payloads)} traces")
+
     try:
         trace_connection.send_traces(trace_payloads)
     except Exception:

--- a/aws/logs_monitoring/proxy_conf/haproxy.txt
+++ b/aws/logs_monitoring/proxy_conf/haproxy.txt
@@ -1,0 +1,52 @@
+# For Datadog EU, change `datadoghq.com` to `datadoghq.eu`
+
+frontend metrics-forwarder
+    bind *:3834
+    mode http
+    option tcplog
+    default_backend datadog-metrics
+
+    use_backend datadog-api if { path_beg -i  /api/v1/validate }
+
+frontend traces-forwarder
+    bind *:3835
+    mode tcp
+    option tcplog
+    default_backend datadog-traces
+
+frontend logs-forwarder
+    bind *:3837
+    mode http
+    option tcplog
+    default_backend datadog-logs
+
+backend datadog-metrics
+    balance roundrobin
+    mode http
+    # The following configuration is for HAProxy 1.8 and newer
+    server-template mothership 5 haproxy-app.agent.datadoghq.com:443 check port 443 ssl verify none check resolvers my-dns init-addr none resolve-prefer ipv4
+    # Uncomment the following configuration for older HAProxy versions
+    # server mothership haproxy-app.agent.datadoghq.com:443 check port 443 ssl verify none
+
+backend datadog-api
+    mode http
+    # The following configuration is for HAProxy 1.8 and newer
+    server-template mothership 5 api.datadoghq.com:443 check port 443 ssl verify none check resolvers my-dns init-addr none resolve-prefer ipv4
+    # Uncomment the following configuration for older HAProxy versions
+    # server mothership api.datadoghq.com:443 check port 443 ssl verify none
+
+backend datadog-traces
+    balance roundrobin
+    mode tcp
+    # The following configuration is for HAProxy 1.8 and newer
+    server-template mothership 5 trace.agent.datadoghq.com:443 check port 443 ssl verify none check resolvers my-dns init-addr none resolve-prefer ipv4
+    # Uncomment the following configuration for older HAProxy versions
+    # server mothership trace.agent.datadoghq.com:443 check port 443 ssl verify none
+
+backend datadog-logs
+    balance roundrobin
+    mode http
+    # The following configuration is for HAProxy 1.8 and newer
+    server-template mothership 5 lambda-http-intake.logs.datadoghq.com:443  check port 443 ssl verify none check resolvers my-dns init-addr none resolve-prefer ipv4
+    # Uncomment the following configuration for older HAProxy versions
+    # server datadog lambda-http-intake.logs.datadoghq.com:443 check port 443 ssl verify none

--- a/aws/logs_monitoring/proxy_conf/nginx.txt
+++ b/aws/logs_monitoring/proxy_conf/nginx.txt
@@ -1,0 +1,30 @@
+# For Datadog EU, change `datadoghq.com` to `datadoghq.eu`
+
+# HTTP Proxy for Datadog Agent
+http {
+    server {
+        listen 3834;
+        access_log off;
+
+        location /api/v1/validate {
+            proxy_pass https://api.datadoghq.com:443/api/v1/validate;
+        }
+        location / {
+            proxy_pass https://haproxy-app.agent.datadoghq.com:443/;
+        }
+    }
+}
+
+# TCP Proxy for Datadog Agent
+stream {
+    server {
+        listen 3835;
+        proxy_ssl on;
+        proxy_pass trace.agent.datadoghq.com:443;
+    }
+    server {
+        listen 3837;
+        proxy_ssl on;
+        proxy_pass lambda-http-intake.logs.datadoghq.com:443;
+    }
+}

--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -103,12 +103,15 @@ DD_SITE = get_env_var("DD_SITE", default="datadoghq.com")
 DD_TAGS = get_env_var("DD_TAGS", "")
 
 ## @param DD_API_URL - Url to use for  validating the the api key.
-DD_API_URL = get_env_var("DD_API_URL", default="https://api.{}".format(DD_SITE))
-logger.debug(f"DD_API_URL: {DD_API_URL}")
+DD_API_URL = get_env_var(
+    "DD_API_URL",
+    default="{}://api.{}".format("http" if DD_NO_SSL else "https", DD_SITE),
+)
 
 ## @param DD_TRACE_INTAKE_URL
 DD_TRACE_INTAKE_URL = get_env_var(
-    "DD_TRACE_INTAKE_URL", default="https://trace.agent.{}".format(DD_SITE)
+    "DD_TRACE_INTAKE_URL",
+    default="{}://trace.agent.{}".format("http" if DD_NO_SSL else "https", DD_SITE),
 )
 
 if DD_USE_TCP:

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -142,15 +142,22 @@ Parameters:
     AllowedValues:
       - true
       - false
-    Description: Set to true to enable sending logs, metrics, and traces via AWS PrivateLink. See https://dtdg.co/private-link .
+    Description: Set to true to deploy the Forwarder to a VPC and send logs, metrics, and traces via AWS PrivateLink. When set to true, must also set VPCSecurityGroupIds and VPCSubnetIds. Find more details from https://dtdg.co/private-link.
+  DdUseVPC:
+    Type: String
+    Default: false
+    AllowedValues:
+      - true
+      - false
+    Description: Set to true to deploy the Forwarder to a VPC and send logs, metrics, and traces via a proxy. When set to true, must also set VPCSecurityGroupIds and VPCSubnetIds.
   VPCSecurityGroupIds:
     Type: CommaDelimitedList
     Default: ""
-    Description: Comma separated list of VPC Security Group Ids. Used when AWS PrivateLink is enabled.
+    Description: Comma separated list of VPC Security Group Ids. Used when DdUsePrivateLink or DdUseVPC is enabled.
   VPCSubnetIds:
     Type: CommaDelimitedList
     Default: ""
-    Description: Comma separated list of VPC Subnet Ids. Used when AWS PrivateLink is enabled.
+    Description: Comma separated list of VPC Subnet Ids. Used when DdUsePrivateLink or DdUseVPC is enabled.
   DdCompressionLevel:
     Type: Number
     Default: 6
@@ -164,6 +171,14 @@ Parameters:
     Type: CommaDelimitedList
     Default: ""
     Description: Comma separated list of lambda ARNs that get invoked asynchronously with the same input event
+  DdApiUrl:
+    Type: String
+    Default: ""
+    Description: The endpoint URL to forward the metrics to, useful for forwarding metrics through a proxy
+  DdTraceIntakeUrl:
+    Type: String
+    Default: ""
+    Description: The endpoint URL to forward the traces to, useful for forwarding traces through a proxy
 Conditions:
   IsAWSChina:
     Fn::Equals:
@@ -255,6 +270,14 @@ Conditions:
     Fn::Equals:
       - Ref: DdUsePrivateLink
       - true
+  SetDdUseVPC:
+    Fn::Equals:
+      - Ref: DdUseVPC
+      - true
+  UseVPC:
+    Fn::Or:
+      - Condition: SetDdUsePrivateLink
+      - Condition: SetDdUseVPC
   SetDdForwardLog:
     Fn::Equals:
       - Ref: DdForwardLog
@@ -277,6 +300,16 @@ Conditions:
     Fn::Not:
       - Fn::Equals:
           - Fn::Join: ["", !Ref AdditionalTargetLambdaArns]
+          - ""
+  SetDdApiUrl:
+    Fn::Not:
+      - Fn::Equals:
+          - Ref: DdApiUrl
+          - ""
+  SetDdTraceIntakeUrl:
+    Fn::Not:
+      - Fn::Equals:
+          - Ref: DdTraceIntakeUrl
           - ""
 Resources:
   Forwarder:
@@ -413,6 +446,16 @@ Resources:
                 - ','
                 - !Ref AdditionalTargetLambdaArns
               - !Ref AWS::NoValue
+          DD_API_URL:
+            Fn::If:
+              - SetDdApiUrl
+              - Ref: DdApiUrl
+              - Ref: AWS::NoValue
+          DD_TRACE_INTAKE_URL:
+            Fn::If:
+              - SetDdTraceIntakeUrl
+              - Ref: DdTraceIntakeUrl
+              - Ref: AWS::NoValue
       ReservedConcurrentExecutions:
         Ref: ReservedConcurrency
       PermissionsBoundary:
@@ -422,7 +465,7 @@ Resources:
           - Ref: AWS::NoValue
       VpcConfig:
         Fn::If:
-          - SetDdUsePrivateLink
+          - UseVPC
           - SecurityGroupIds: !Ref VPCSecurityGroupIds
             SubnetIds: !Ref VPCSubnetIds
           - Ref: AWS::NoValue
@@ -449,7 +492,7 @@ Resources:
                 Resource: "*"
               - Ref: AWS::NoValue
             - !If
-              - SetDdUsePrivateLink
+              - UseVPC
               - Effect: Allow
                 Action:
                   - ec2:CreateNetworkInterface
@@ -695,8 +738,12 @@ Metadata:
           - PermissionsBoundaryArn
           - DdApiKeySecretArn
           - DdUsePrivateLink
+          - DdUseVPC
           - VPCSecurityGroupIds
           - VPCSubnetIds
+          - DdApiUrl
+          - DdTraceIntakeUrl
+          - AdditionalTargetLambdaArns
     ParameterLabels:
       DdApiKey:
         default: "DdApiKey *"

--- a/aws/logs_monitoring/trace_forwarder/cmd/trace/main.go
+++ b/aws/logs_monitoring/trace_forwarder/cmd/trace/main.go
@@ -28,13 +28,13 @@ var (
 type (
 	RawTracePayload struct {
 		Message string `json:"message"`
-		Tags string    `json:"tags"`
+		Tags    string `json:"tags"`
 	}
 )
 
 // Configure will set up the bindings
 //export Configure
-func Configure(rootURL, apiKey string) {
+func Configure(rootURL, apiKey string, InsecureSkipVerify bool) {
 	// Need to make a copy of these values, otherwise the underlying memory
 	// might be cleaned up by the runtime.
 	localRootURL := fmt.Sprintf("%s", rootURL)
@@ -53,7 +53,7 @@ func Configure(rootURL, apiKey string) {
 		Redis:             true,
 		Memcached:         true,
 	})
-	edgeConnection = apm.CreateTraceEdgeConnection(localRootURL, localAPIKey)
+	edgeConnection = apm.CreateTraceEdgeConnection(localRootURL, localAPIKey, InsecureSkipVerify)
 }
 
 // returns 0 on success, 1 on error

--- a/aws/logs_monitoring/trace_forwarder/connection.py
+++ b/aws/logs_monitoring/trace_forwarder/connection.py
@@ -18,10 +18,14 @@ def make_go_string(str):
 
 
 class TraceConnection:
-    def __init__(self, root_url, api_key):
+    def __init__(self, root_url, api_key, insecure_skip_verify):
         dir = os.path.dirname(os.path.realpath(__file__))
         self.lib = cdll.LoadLibrary("{}/bin/trace-intake.so".format(dir))
-        self.lib.Configure(make_go_string(root_url), make_go_string(api_key))
+        self.lib.Configure(
+            make_go_string(root_url),
+            make_go_string(api_key),
+            insecure_skip_verify,
+        )
 
     def send_traces(self, trace_payloads):
         serialized_trace_paylods = json.dumps(trace_payloads)


### PR DESCRIPTION
### What does this PR do?

- Support `DD_NO_SSL` and `DD_SKIP_SSL_VALIDATION` for the Datadog API, metric and trace intake endpoints.
- Added a new parameter `UseVPC` to allow deploying the Forwarder to VPC without enabling PrivateLink.
- Added sample proxy configuration for HAProxy and Nginx
- Added extra debugging logs
- Updated docs on using VPC + Proxy

### Motivation

PrivateLink is not supported by `datadoghq.eu` and some customers must deploy the Forwarder to VPC for security reasons and they need to forward data through a proxy. `DD_NO_SSL` and `DD_SKIP_SSL_VALIDATION` are often needed because the proxy either has no SSL/TLS enabled or a self-signed certificate.

### Testing Guidelines

- [x] Forwarder able to forward data through a proxy with the help of `DD_NO_SSL` and `DD_SKIP_SSL_VALIDATION`
- [x] Forwarder able to forward data normally (i.e., without a proxy)

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [x] This PR passes the installation tests (ask a Datadog member to run the tests)
