### PR TITLE
Implemented same Datadog API-key retrieval into AWS lambda  as log forwareder has

### DIFF
--- a/aws/rds_enhanced_monitoring/lambda_function.py
+++ b/aws/rds_enhanced_monitoring/lambda_function.py
@@ -17,13 +17,48 @@ import boto3
 
 DD_SITE = os.getenv("DD_SITE", default="datadoghq.com")
 
-# retrieve datadog options from KMS
-KMS_ENCRYPTED_KEYS = os.environ['kmsEncryptedKeys']
-kms = boto3.client('kms')
-datadog_keys = json.loads(kms.decrypt(
-    CiphertextBlob=b64decode(KMS_ENCRYPTED_KEYS),
-    EncryptionContext={'LambdaFunctionName': os.environ['AWS_LAMBDA_FUNCTION_NAME']}
-)['Plaintext'])
+# DD API Key
+if "kmsEncryptedKeys" in os.environ:
+    # retrieve datadog options from KMS
+    KMS_ENCRYPTED_KEYS = os.environ['kmsEncryptedKeys']
+    kms = boto3.client('kms')
+    datadog_keys = json.loads(kms.decrypt(
+        CiphertextBlob=b64decode(KMS_ENCRYPTED_KEYS),
+        EncryptionContext={'LambdaFunctionName': os.environ['AWS_LAMBDA_FUNCTION_NAME']}
+    )['Plaintext'])
+elif "DD_API_KEY_SECRET_ARN" in os.environ:
+    SECRET_ARN = os.environ["DD_API_KEY_SECRET_ARN"]
+    DD_API_KEY = boto3.client("secretsmanager").get_secret_value(SecretId=SECRET_ARN)[
+        "SecretString"
+    ]
+    datadog_keys = {
+        "api_key": DD_API_KEY
+    }
+elif "DD_API_KEY_SSM_NAME" in os.environ:
+    SECRET_NAME = os.environ["DD_API_KEY_SSM_NAME"]
+    DD_API_KEY = boto3.client("ssm").get_parameter(
+        Name=SECRET_NAME, WithDecryption=True
+    )["Parameter"]["Value"]
+    datadog_keys = {
+        "api_key": DD_API_KEY
+    }
+elif "DD_KMS_API_KEY" in os.environ:
+    ENCRYPTED = os.environ["DD_KMS_API_KEY"]
+    DD_API_KEY = boto3.client("kms").decrypt(
+        CiphertextBlob=base64.b64decode(ENCRYPTED)
+    )["Plaintext"]
+    if type(DD_API_KEY) is bytes:
+        DD_API_KEY = DD_API_KEY.decode("utf-8")
+    datadog_keys = {
+        "api_key": DD_API_KEY
+    }
+elif "DD_API_KEY" in os.environ:
+    DD_API_KEY = os.environ["DD_API_KEY"]
+    datadog_keys = {
+        "api_key": DD_API_KEY
+    }
+else:
+    raise ValueError("Datadog API-key is missing. Need either 'kmsEncryptedKeys' or ")
 
 print('INFO Lambda function initialized, ready to send metrics')
 


### PR DESCRIPTION
### What does this PR do?

AWS RDS enhanced monitoring lambda function requires Datadog API-key via `kmsEncryptedKeys` environment variable. This is completely different approach than AWS log forwarder lambda has. 

### Motivation

To harmonise the API-key interface, code from log forwarder lambda was incorporated into RDS monitor. Now I don't need to setup Datadog API-key twice.

### Testing Guidelines

This is a trivial change. I'm running both lambdas in my environment.

### Additional Notes

none

### Types of changes

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [X] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
