### PR TITLE
Add support for S3 events triggered via SNS

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -821,12 +821,9 @@ def s3_handler(event, context, metadata):
         os.environ["AWS_REGION"],
         config=botocore.config.Config(s3={"addressing_style": "path"}),
     )
+    # if this is a S3 event carried in a SNS message, extract it and override the event
     if "Sns" in event["Records"][0]:
-        snsS3EventMessage = event["Records"][0]["Sns"]["Message"]
-        if len(snsS3EventMessage) > 0:
-            snsS3Event = json.loads(snsS3EventMessage)
-            if "Records" in snsS3Event and len(snsS3Event["Records"]) > 0:
-                event = snsS3Event
+        event = json.loads(event["Records"][0]["Sns"]["Message"])
 
     # Get the object from the event and show its content type
     bucket = event["Records"][0]["s3"]["bucket"]["name"]

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -797,6 +797,11 @@ def parse_event_type(event):
         if "s3" in event["Records"][0]:
             return "s3"
         elif "Sns" in event["Records"][0]:
+            snsS3EventMessage = event["Records"][0]["Sns"]["Message"]
+            if len(snsS3EventMessage) > 0:
+                snsS3Event = json.loads(snsS3EventMessage)
+                if "Records" in snsS3Event and "s3" in snsS3Event["Records"][0]:
+                    return "s3"
             return "sns"
         elif "kinesis" in event["Records"][0]:
             return "kinesis"
@@ -816,6 +821,12 @@ def s3_handler(event, context, metadata):
         os.environ["AWS_REGION"],
         config=botocore.config.Config(s3={"addressing_style": "path"}),
     )
+    if "Sns" in event["Records"][0]:
+        snsS3EventMessage = event["Records"][0]["Sns"]["Message"]
+        if len(snsS3EventMessage) > 0:
+            snsS3Event = json.loads(snsS3EventMessage)
+            if "Records" in snsS3Event and len(snsS3Event["Records"]) > 0:
+                event = snsS3Event
 
     # Get the object from the event and show its content type
     bucket = event["Records"][0]["s3"]["bucket"]["name"]


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
- When S3 events are configured to push to SNS topics
- The DD Lambda Forwarder subscribes to the SNS topic
- Then in DD console the event shows up as SNS with SNS event data being logged rather than the S3 log being ingested
- This change extracts the S3 event from the SNS topic and then extract and ingests the S3 log from it

The new behavior should be desired/expected to most of users, but technically speaking it is a breaking change, because SNS logs carrying S3 events will stop appearing in Datadog, while the corresponding S3 objects will start showing up.

### Motivation
Talked to Tian (at Datadog NY offices) and we needed a solution for our organisation so wrote this PR.

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
We are using this codebase in our organisation now.

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [x] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [x] This PR passes the installation tests (ask a Datadog member to run the tests)
