### PR TITLE
Handle malformed metrics

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -643,6 +643,8 @@ def extract_metric(event):
             return None
         if not isinstance(metric["t"], list):
             return None
+        if not (isinstance(metric["v"], int) or isinstance(metric["v"], float)):
+            return None
 
         metric["t"] += event[DD_CUSTOM_TAGS].split(",")
         return metric

--- a/aws/logs_monitoring/tests/test_extract_metric.py
+++ b/aws/logs_monitoring/tests/test_extract_metric.py
@@ -1,0 +1,36 @@
+from mock import MagicMock, patch
+import os
+import sys
+import unittest
+
+sys.modules["trace_forwarder.connection"] = MagicMock()
+sys.modules["datadog_lambda.wrapper"] = MagicMock()
+sys.modules["datadog_lambda.metric"] = MagicMock()
+sys.modules["datadog"] = MagicMock()
+sys.modules["requests"] = MagicMock()
+
+env_patch = patch.dict(os.environ, {"DD_API_KEY": "11111111111111111111111111111111"})
+env_patch.start()
+from lambda_function import extract_metric
+
+env_patch.stop()
+
+
+class TestExtractMetric(unittest.TestCase):
+    def test_empty_event(self):
+        self.assertEqual(extract_metric({}), None)
+
+    def test_missing_keys(self):
+        self.assertEqual(extract_metric({"e": 0, "v": 1, "m": "foo" }), None)
+
+    def test_tags_instance(self):
+        self.assertEqual(extract_metric({"e": 0, "v": 1, "m": "foo", "t": 666 }), None)
+
+    def test_value_instance(self):
+        self.assertEqual(extract_metric({"e": 0, "v": 1.1, "m": "foo", "t": [] }), None)
+
+    def test_value_instance_float(self):
+        self.assertEqual(extract_metric({"e": 0, "v": None, "m": "foo", "t": [] }), None)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/aws/logs_monitoring/tests/test_extract_metric.py
+++ b/aws/logs_monitoring/tests/test_extract_metric.py
@@ -9,7 +9,10 @@ sys.modules["datadog_lambda.metric"] = MagicMock()
 sys.modules["datadog"] = MagicMock()
 sys.modules["requests"] = MagicMock()
 
-env_patch = patch.dict(os.environ, {"DD_API_KEY": "11111111111111111111111111111111"})
+env_patch = patch.dict(os.environ, {
+    "DD_API_KEY": "11111111111111111111111111111111",
+    "DD_ADDITIONAL_TARGET_LAMBDAS": "ironmaiden,megadeth",
+})
 env_patch.start()
 from lambda_function import extract_metric
 

--- a/aws/logs_monitoring/tests/test_extract_metric.py
+++ b/aws/logs_monitoring/tests/test_extract_metric.py
@@ -9,10 +9,13 @@ sys.modules["datadog_lambda.metric"] = MagicMock()
 sys.modules["datadog"] = MagicMock()
 sys.modules["requests"] = MagicMock()
 
-env_patch = patch.dict(os.environ, {
-    "DD_API_KEY": "11111111111111111111111111111111",
-    "DD_ADDITIONAL_TARGET_LAMBDAS": "ironmaiden,megadeth",
-})
+env_patch = patch.dict(
+    os.environ,
+    {
+        "DD_API_KEY": "11111111111111111111111111111111",
+        "DD_ADDITIONAL_TARGET_LAMBDAS": "ironmaiden,megadeth",
+    },
+)
 env_patch.start()
 from lambda_function import extract_metric
 
@@ -24,16 +27,17 @@ class TestExtractMetric(unittest.TestCase):
         self.assertEqual(extract_metric({}), None)
 
     def test_missing_keys(self):
-        self.assertEqual(extract_metric({"e": 0, "v": 1, "m": "foo" }), None)
+        self.assertEqual(extract_metric({"e": 0, "v": 1, "m": "foo"}), None)
 
     def test_tags_instance(self):
-        self.assertEqual(extract_metric({"e": 0, "v": 1, "m": "foo", "t": 666 }), None)
+        self.assertEqual(extract_metric({"e": 0, "v": 1, "m": "foo", "t": 666}), None)
 
     def test_value_instance(self):
-        self.assertEqual(extract_metric({"e": 0, "v": 1.1, "m": "foo", "t": [] }), None)
+        self.assertEqual(extract_metric({"e": 0, "v": 1.1, "m": "foo", "t": []}), None)
 
     def test_value_instance_float(self):
-        self.assertEqual(extract_metric({"e": 0, "v": None, "m": "foo", "t": [] }), None)
+        self.assertEqual(extract_metric({"e": 0, "v": None, "m": "foo", "t": []}), None)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Working in support a found a case of a customer getting exceptions while sending their metrics to the intake endpoint. Since we use batch the metrics and flush them in a process we noticed that 1 bad metric would make the whole batch fail. This fix addresses some of the malformed cases for metrics. Since `null` is a valid value in JSON it's then parsed to `None` in JSON which causes issues upstream.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->
Again a user posting malformed data would cause issues for all of their other data points.

### Testing Guidelines

<!--- How did you test this pull request? --->
- Units
- Integration
- Installation

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
