### PR TITLE
[aws-ints] change rds lambda runtime to 3.7

### DIFF
--- a/aws/rds_enhanced_monitoring/rds-enhanced-sam-template.yaml
+++ b/aws/rds_enhanced_monitoring/rds-enhanced-sam-template.yaml
@@ -18,7 +18,7 @@ Resources:
       Policies:
         KMSDecryptPolicy:
           KeyId: !Ref KMSKeyId
-      Runtime: python2.7
+      Runtime: python3.7
       Timeout: 10
       KmsKeyArn:
         !Sub


### PR DESCRIPTION
### What does this PR do?
This pr changes the runtime for the rds enhanced monitoring lambda to python 3.7.

### Motivation
We've changed the code to work with python3, so we should also change the runtime to be consistent.
