### PR TITLE
[azure] Add new source types and other cleanup

### DIFF
--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -226,7 +226,11 @@ class EventhubLogForwarder {
     }
 
     formatSourceType(sourceType) {
-        return sourceType.replace('microsoft.', 'azure.');
+        if (sourceType.includes('microsoft')) {
+            return sourceType.replace('microsoft.', 'azure.');
+        } else {
+            return '';
+        }
     }
 
     extractMetadataFromResource(record) {
@@ -256,9 +260,7 @@ class EventhubLogForwarder {
                 }
             }
             if (resourceId.length > 5 && resourceId[5]) {
-                if (resourceId[5].includes('microsoft')) {
-                    metadata.source = this.formatSourceType(resourceId[5]);
-                }
+                metadata.source = this.formatSourceType(resourceId[5]);
             }
         } else if (resourceId[0] === 'tenants') {
             if (resourceId.length > 3 && resourceId[3]) {
@@ -284,7 +286,7 @@ module.exports = async function(context, eventHubMessages) {
         eventHubMessages
     );
 
-    return Promise.allSettled(promises);
+    return Promise.all(promises.map(p => p.catch(e => e)));
 };
 
 module.exports.forTests = {

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -226,7 +226,7 @@ class EventhubLogForwarder {
     }
 
     formatSourceType(sourceType) {
-        if (sourceType.includes('microsoft')) {
+        if (sourceType.includes('microsoft.')) {
             return sourceType.replace('microsoft.', 'azure.');
         } else {
             return '';
@@ -244,6 +244,9 @@ class EventhubLogForwarder {
         var resourceId = record.resourceId.toLowerCase().split('/');
         if (resourceId[0] === '') {
             resourceId = resourceId.slice(1);
+        }
+        if (resourceId[resourceId.length - 1] === '') {
+            resourceId.pop();
         }
 
         if (resourceId[0] === 'subscriptions') {

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -241,8 +241,10 @@ class EventhubLogForwarder {
         ) {
             return metadata;
         }
-        var lowerResourceId = record.resourceId.toLowerCase();
-        var resourceId = lowerResourceId.split('/').filter(Boolean);
+        var resourceId = record.resourceId.toLowerCase().split('/');
+        if (resourceId[0] === '') {
+            resourceId = resourceId.slice(1);
+        }
 
         if (resourceId[0] === 'subscriptions') {
             if (resourceId.length > 1) {

--- a/azure/test/client.test.js
+++ b/azure/test/client.test.js
@@ -113,10 +113,27 @@ describe('Azure Log Monitoring', function() {
                 this.forwarder.extractMetadataFromResource(record)
             );
         });
-        it('should parse a valid record without provider', function() {
+        it('should parse a valid resource group resource', function() {
             record = {
                 resourceId:
                     '/SUBSCRIPTIONS/12345678-1234-ABCD-1234-1234567890AB/RESOURCEGROUPS/SOME-RESOURCE-GROUP'
+            };
+            expectedMetadata = {
+                tags: [
+                    'subscription_id:12345678-1234-abcd-1234-1234567890ab',
+                    'resource_group:some-resource-group'
+                ],
+                source: 'azure.resourcegroup'
+            };
+            assert.deepEqual(
+                expectedMetadata,
+                this.forwarder.extractMetadataFromResource(record)
+            );
+        });
+        it('should parse a valid resource group resource ending slash', function() {
+            record = {
+                resourceId:
+                    '/SUBSCRIPTIONS/12345678-1234-ABCD-1234-1234567890AB/RESOURCEGROUPS/SOME-RESOURCE-GROUP/'
             };
             expectedMetadata = {
                 tags: [
@@ -147,10 +164,24 @@ describe('Azure Log Monitoring', function() {
                 this.forwarder.extractMetadataFromResource(record)
             );
         });
-        it('should parse a valid record without provider and resource group', function() {
+        it('should parse a valid subscription type resource', function() {
             record = {
                 resourceId:
                     '/SUBSCRIPTIONS/12345678-1234-ABCD-1234-1234567890AB'
+            };
+            expectedMetadata = {
+                tags: ['subscription_id:12345678-1234-abcd-1234-1234567890ab'],
+                source: 'azure.subscription'
+            };
+            assert.deepEqual(
+                expectedMetadata,
+                this.forwarder.extractMetadataFromResource(record)
+            );
+        });
+        it('should parse a valid subscription type resource ending slash', function() {
+            record = {
+                resourceId:
+                    '/SUBSCRIPTIONS/12345678-1234-ABCD-1234-1234567890AB/'
             };
             expectedMetadata = {
                 tags: ['subscription_id:12345678-1234-abcd-1234-1234567890ab'],

--- a/azure/test/client.test.js
+++ b/azure/test/client.test.js
@@ -233,6 +233,23 @@ describe('Azure Log Monitoring', function() {
                 this.forwarder.extractMetadataFromResource(record)
             );
         });
+        it('should handle when first element of resource id list is not empty', function() {
+            record = {
+                resourceId:
+                    'SUBSCRIPTIONS/12345678-1234-ABCD-1234-1234567890AB/RESOURCEGROUPS/SOME-RESOURCE-GROUP/PROVIDERS/NOTTHESAMEFORMAT/VIRTUALMACHINES/SOME-VM'
+            };
+            expectedMetadata = {
+                tags: [
+                    'subscription_id:12345678-1234-abcd-1234-1234567890ab',
+                    'resource_group:some-resource-group'
+                ],
+                source: ''
+            };
+            assert.deepEqual(
+                expectedMetadata,
+                this.forwarder.extractMetadataFromResource(record)
+            );
+        });
     });
 
     function testHandleJSONLogs(forwarder, logs, expected) {

--- a/azure/test/client.test.js
+++ b/azure/test/client.test.js
@@ -216,6 +216,23 @@ describe('Azure Log Monitoring', function() {
                 this.forwarder.extractMetadataFromResource(record)
             );
         });
+        it('should return empty source when not correct source format', function() {
+            record = {
+                resourceId:
+                    '/SUBSCRIPTIONS/12345678-1234-ABCD-1234-1234567890AB/RESOURCEGROUPS/SOME-RESOURCE-GROUP/PROVIDERS/NOTTHESAMEFORMAT/VIRTUALMACHINES/SOME-VM'
+            };
+            expectedMetadata = {
+                tags: [
+                    'subscription_id:12345678-1234-abcd-1234-1234567890ab',
+                    'resource_group:some-resource-group'
+                ],
+                source: ''
+            };
+            assert.deepEqual(
+                expectedMetadata,
+                this.forwarder.extractMetadataFromResource(record)
+            );
+        });
     });
 
     function testHandleJSONLogs(forwarder, logs, expected) {
@@ -354,6 +371,21 @@ describe('Azure Log Monitoring', function() {
             // just assert that the string method is called for the second message,
             // we don't care about the first one for this test
             testHandleStringLogs(this.forwarder, log, expected);
+        });
+    });
+    describe('#formatSourceType', function() {
+        beforeEach(function() {
+            this.forwarder = setUp();
+        });
+        it('should replace microsoft with azure', function() {
+            expected = 'azure.bleh';
+            actual = this.forwarder.formatSourceType('microsoft.bleh');
+            assert.equal(actual, expected);
+        });
+        it('should return empty source', function() {
+            expected = '';
+            actual = this.forwarder.formatSourceType('something');
+            assert.equal(actual, expected);
         });
     });
 });

--- a/azure/test/client.test.js
+++ b/azure/test/client.test.js
@@ -92,7 +92,7 @@ describe('Azure Log Monitoring', function() {
         });
     });
 
-    describe('#extractResourceId', function() {
+    describe('#extractMetadataFromResource', function() {
         beforeEach(function() {
             this.forwarder = setUp();
         });
@@ -110,7 +110,7 @@ describe('Azure Log Monitoring', function() {
             };
             assert.deepEqual(
                 expectedMetadata,
-                this.forwarder.extractResourceId(record)
+                this.forwarder.extractMetadataFromResource(record)
             );
         });
         it('should parse a valid record without provider', function() {
@@ -123,11 +123,28 @@ describe('Azure Log Monitoring', function() {
                     'subscription_id:12345678-1234-abcd-1234-1234567890ab',
                     'resource_group:some-resource-group'
                 ],
+                source: 'azure.resourcegroup'
+            };
+            assert.deepEqual(
+                expectedMetadata,
+                this.forwarder.extractMetadataFromResource(record)
+            );
+        });
+        it('should parse a valid record without provider length 5', function() {
+            record = {
+                resourceId:
+                    '/SUBSCRIPTIONS/12345678-1234-ABCD-1234-1234567890AB/RESOURCEGROUPS/SOME-RESOURCE-GROUP/ffffff'
+            };
+            expectedMetadata = {
+                tags: [
+                    'subscription_id:12345678-1234-abcd-1234-1234567890ab',
+                    'resource_group:some-resource-group'
+                ],
                 source: ''
             };
             assert.deepEqual(
                 expectedMetadata,
-                this.forwarder.extractResourceId(record)
+                this.forwarder.extractMetadataFromResource(record)
             );
         });
         it('should parse a valid record without provider and resource group', function() {
@@ -137,11 +154,25 @@ describe('Azure Log Monitoring', function() {
             };
             expectedMetadata = {
                 tags: ['subscription_id:12345678-1234-abcd-1234-1234567890ab'],
+                source: 'azure.subscription'
+            };
+            assert.deepEqual(
+                expectedMetadata,
+                this.forwarder.extractMetadataFromResource(record)
+            );
+        });
+        it('should parse a valid record without provider and resource group length 3', function() {
+            record = {
+                resourceId:
+                    '/SUBSCRIPTIONS/12345678-1234-ABCD-1234-1234567890AB/ffffff'
+            };
+            expectedMetadata = {
+                tags: ['subscription_id:12345678-1234-abcd-1234-1234567890ab'],
                 source: ''
             };
             assert.deepEqual(
                 expectedMetadata,
-                this.forwarder.extractResourceId(record)
+                this.forwarder.extractMetadataFromResource(record)
             );
         });
         it('should not fail on record without resourceId', function() {
@@ -149,7 +180,7 @@ describe('Azure Log Monitoring', function() {
             expectedMetadata = { tags: [], source: '' };
             assert.deepEqual(
                 expectedMetadata,
-                this.forwarder.extractResourceId(record)
+                this.forwarder.extractMetadataFromResource(record)
             );
         });
         it('should not fail on string record', function() {
@@ -157,7 +188,7 @@ describe('Azure Log Monitoring', function() {
             expectedMetadata = { tags: [], source: '' };
             assert.deepEqual(
                 expectedMetadata,
-                this.forwarder.extractResourceId(record)
+                this.forwarder.extractMetadataFromResource(record)
             );
         });
         it('should not fail on improper resourceId', function() {
@@ -165,7 +196,7 @@ describe('Azure Log Monitoring', function() {
             expectedMetadata = { tags: [], source: '' };
             assert.deepEqual(
                 expectedMetadata,
-                this.forwarder.extractResourceId(record)
+                this.forwarder.extractMetadataFromResource(record)
             );
         });
         it('should not fail with an invalid source', function() {
@@ -182,7 +213,7 @@ describe('Azure Log Monitoring', function() {
             };
             assert.deepEqual(
                 expectedMetadata,
-                this.forwarder.extractResourceId(record)
+                this.forwarder.extractMetadataFromResource(record)
             );
         });
     });
@@ -209,10 +240,7 @@ describe('Azure Log Monitoring', function() {
         it('should handle string properly', function() {
             log = 'hello';
             expected = ['hello'];
-            assert.equal(
-                this.forwarder.getLogFormat(log),
-                constants.STRING
-            );
+            assert.equal(this.forwarder.getLogFormat(log), constants.STRING);
             testHandleStringLogs(this.forwarder, log, expected);
         });
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

- Adds new source type support for `azure.subscription` and `azure.resourcegroup`
- Refactors the way we split the resource ID so indexing makes more sense
- Replaces `Promise.allSettled` with `Promise.all`, since allSettled is fairly new and may cause problems for existing customers moving to the new version of the code.
- Renames extractResourceId method to extractMetadataFromResource
- Fixes issue with some azure logs coming in with sources that aren't formatted the same way as others, since `microsoft.` isn't in field we use for parsing the source.

### Motivation
<!--- A brief description of the change being made with this pull request. --->

More support for log forwarder, ease of dev

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

Currently running in our demo subscription, confirmed it's still sending logs. Also tested by throwing an error to confirm the function does not fail when one Promise rejects.

Logs for the test or show both azure.subscription and azure.resourcegroup sources.

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
