### PR TITLE
Group TagsCacheTTLSeconds under Advanced

### DIFF
--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -750,6 +750,7 @@ Metadata:
           default: Advanced (Optional)
         Parameters:
           - DdFetchLambdaTags
+          - TagsCacheTTLSeconds
           - SourceZipUrl
           - PermissionsBoundaryArn
           - DdApiKeySecretArn


### PR DESCRIPTION
### What does this PR do?

Group parameter `TagsCacheTTLSeconds` under `Advanced`.

### Motivation

`TagsCacheTTLSeconds` isn't grouped.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [x] This PR passes the installation tests (ask a Datadog member to run the tests)
