### PR TITLE
Use s3 path style only in VPC

### DIFF
--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -127,6 +127,9 @@ else:
     DD_URL = get_env_var("DD_URL", default="lambda-http-intake.logs." + DD_SITE)
     DD_PORT = int(get_env_var("DD_PORT", default="443"))
 
+## @param DD_USE_VPC
+DD_USE_VPC = get_env_var("DD_USE_VPC", "false", boolean=True)
+
 ## @param DD_USE_PRIVATE_LINK - whether to forward logs via PrivateLink
 ## Overrides incompatible settings
 #

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -450,6 +450,11 @@ Resources:
               - SetDdUsePrivateLink
               - true
               - false
+          DD_USE_VPC:
+            Fn::If:
+              - UseVPC
+              - true
+              - false
           DD_ADDITIONAL_TARGET_LAMBDAS:
             Fn::If:
               - SetAdditionalTargetLambdas


### PR DESCRIPTION
### What does this PR do?

https://github.com/DataDog/datadog-serverless-functions/pull/340 fixed access to s3 buckets via VPC endpoints by changing the s3 client to use path style when addressing s3 objects. However, the path style is going to be [deprecated](https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/) in the future, so it's better to switch the address style back to the default (`virtual`) for forwarders not deployed to VPC. We expect AWS and boto3 provides a way to access s3 via VPC endpoints using the virtual host style in the future.

### Motivation

https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/

### Testing Guidelines

- [ ] No regression

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [x] This PR passes the installation tests (ask a Datadog member to run the tests)
