### PR TITLE
[SLS-617 + SLS-729] Refactor source identification to be stricter

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -1044,13 +1044,19 @@ def find_cloudwatch_source(log_group):
         "/aws/codebuild",  # e.g. /aws/codebuild/my-project
         "/aws/kinesis",  # e.g. /aws/kinesisfirehose/dev
         "/aws/docdb",  # e.g. /aws/docdb/yourClusterName/profile
-        "route53",  # this and the below substrings must be in your log group to be detected
+    ]:
+        if log_group.startswith(source):
+            return source.replace("/aws/", "")
+
+    # the below substrings must be in your log group to be detected
+    for source in [
+        "route53",
         "vpc",
         "fargate",
         "cloudtrail",
     ]:
         if source in log_group:
-            return source.replace("/aws/", "")
+            return source
 
     return "cloudwatch"
 

--- a/aws/logs_monitoring/tests/test_parse_event_source.py
+++ b/aws/logs_monitoring/tests/test_parse_event_source.py
@@ -186,6 +186,31 @@ class TestParseEventSource(unittest.TestCase):
             "cloudfront",
         )
 
+    def test_eks_event(self):
+        self.assertEqual(
+            parse_event_source(
+                {"awslogs": "logs"},
+                "/aws/eks/control-plane/cluster",
+            ),
+            "eks",
+        )
+
+    def test_msk_event(self):
+        self.assertEqual(
+            parse_event_source(
+                {"awslogs": "logs"},
+                "/myMSKLogGroup",
+            ),
+            "msk",
+        )
+        self.assertEqual(
+            parse_event_source(
+                {"Records": ["logs-from-s3"]},
+                "AWSLogs/amazon_msk/us-east-1/xxxxx.log.gz",
+            ),
+            "msk",
+        )
+
     def test_cloudwatch_source_if_none_found(self):
         self.assertEqual(parse_event_source({"awslogs": "logs"}, ""), "cloudwatch")
 

--- a/aws/logs_monitoring/tests/test_parse_event_source.py
+++ b/aws/logs_monitoring/tests/test_parse_event_source.py
@@ -44,6 +44,148 @@ class TestParseEventSource(unittest.TestCase):
             parse_event_source({"awslogs": "logs"}, "/aws/rds/my-rds-resource"), "rds"
         )
 
+    def test_mariadb_event(self):
+        self.assertEqual(
+            parse_event_source({"awslogs": "logs"}, "/aws/rds/mariaDB-instance/error"),
+            "mariadb",
+        )
+
+    def test_mysql_event(self):
+        self.assertEqual(
+            parse_event_source({"awslogs": "logs"}, "/aws/rds/mySQL-instance/error"),
+            "mysql",
+        )
+
+    def test_lambda_event(self):
+        self.assertEqual(
+            parse_event_source({"awslogs": "logs"}, "/aws/lambda/postRestAPI"), "lambda"
+        )
+
+    def test_apigateway_event(self):
+        self.assertEqual(
+            parse_event_source(
+                {"awslogs": "logs"}, "Api-Gateway-Execution-Logs_a1b23c/test"
+            ),
+            "apigateway",
+        )
+
+    def test_dms_event(self):
+        self.assertEqual(
+            parse_event_source({"awslogs": "logs"}, "dms-tasks-test-instance"), "dms"
+        )
+        self.assertEqual(
+            parse_event_source(
+                {"Records": ["logs-from-s3"]}, "AWSLogs/amazon_dms/my-s3.json.gz"
+            ),
+            "dms",
+        )
+
+    def test_sns_event(self):
+        self.assertEqual(
+            parse_event_source(
+                {"awslogs": "logs"}, "sns/us-east-1/123456779121/SnsTopicX"
+            ),
+            "sns",
+        )
+
+    def test_codebuild_event(self):
+        self.assertEqual(
+            parse_event_source(
+                {"awslogs": "logs"}, "/aws/codebuild/new-project-sample"
+            ),
+            "codebuild",
+        )
+
+    def test_kinesis_event(self):
+        self.assertEqual(
+            parse_event_source({"awslogs": "logs"}, "/aws/kinesisfirehose/test"),
+            "kinesis",
+        )
+        self.assertEqual(
+            parse_event_source(
+                {"Records": ["logs-from-s3"]}, "AWSLogs/amazon_kinesis/my-s3.json.gz"
+            ),
+            "kinesis",
+        )
+
+    def test_docdb_event(self):
+        self.assertEqual(
+            parse_event_source({"awslogs": "logs"}, "/aws/docdb/testCluster/profile"),
+            "docdb",
+        )
+        self.assertEqual(
+            parse_event_source(
+                {"Records": ["logs-from-s3"]}, "/amazon_documentdb/dev/123abc.zip"
+            ),
+            "docdb",
+        )
+
+    def test_vpc_event(self):
+        self.assertEqual(
+            parse_event_source({"awslogs": "logs"}, "abc123_my_vpc_loggroup"), "vpc"
+        )
+        self.assertEqual(
+            parse_event_source(
+                {"Records": ["logs-from-s3"]},
+                "AWSLogs/123456779121/vpcflowlogs/us-east-1/2020/10/02/123456779121_vpcflowlogs_us-east-1_fl-xxxxx.log.gz",
+            ),
+            "vpc",
+        )
+
+    def test_elb_event(self):
+        self.assertEqual(
+            parse_event_source(
+                {"Records": ["logs-from-s3"]},
+                "AWSLogs/123456779121/elasticloadbalancing/us-east-1/2020/10/02/123456779121_elasticloadbalancing_us-east-1_app.alb.xxxxx.xx.xxx.xxx_x.log.gz",
+            ),
+            "elb",
+        )
+
+    def test_waf_event(self):
+        self.assertEqual(
+            parse_event_source(
+                {"Records": ["logs-from-s3"]},
+                "2020/10/02/21/aws-waf-logs-testing-1-2020-10-02-21-25-30-x123x-x456x",
+            ),
+            "waf",
+        )
+
+    def test_redshift_event(self):
+        self.assertEqual(
+            parse_event_source(
+                {"Records": ["logs-from-s3"]},
+                "AWSLogs/123456779121/redshift/us-east-1/2020/10/21/123456779121_redshift_us-east-1_mycluster_userlog_2020-10-21T18:01.gz",
+            ),
+            "redshift",
+        )
+
+    def test_route53_event(self):
+        self.assertEqual(
+            parse_event_source(
+                {"awslogs": "logs"},
+                "my-route53-loggroup123",
+            ),
+            "route53",
+        )
+
+    def test_fargate_event(self):
+        self.assertEqual(
+            parse_event_source(
+                {"awslogs": "logs"},
+                "/ecs/fargate-logs",
+            ),
+            "fargate",
+        )
+
+    def test_cloudfront_event(self):
+        self.assertEqual(
+            parse_event_source(
+                {"Records": ["logs-from-s3"]},
+                "AWSLogs/cloudfront/123456779121/test/01.gz",
+            ),
+            "cloudfront",
+        )
+
     def test_cloudwatch_source_if_none_found(self):
         self.assertEqual(parse_event_source({"awslogs": "logs"}, ""), "cloudwatch")
 

--- a/aws/logs_monitoring/tests/test_parse_event_source.py
+++ b/aws/logs_monitoring/tests/test_parse_event_source.py
@@ -23,7 +23,7 @@ class TestParseEventSource(unittest.TestCase):
     def test_cloudtrail_event(self):
         self.assertEqual(
             parse_event_source(
-                {},
+                {"Records": ["logs-from-s3"]},
                 "cloud-trail/AWSLogs/123456779121/CloudTrail/us-west-3/2018/01/07/123456779121_CloudTrail_eu-west-3_20180707T1735Z_abcdefghi0MCRL2O.json.gz",
             ),
             "cloudtrail",
@@ -33,14 +33,16 @@ class TestParseEventSource(unittest.TestCase):
         # Assert that source "cloudtrail" is parsed even though substrings "waf" and "sns" are present in the key
         self.assertEqual(
             parse_event_source(
-                {},
+                {"Records": ["logs-from-s3"]},
                 "cloud-trail/AWSLogs/123456779121/CloudTrail/us-west-3/2018/01/07/123456779121_CloudTrail_eu-west-3_20180707T1735Z_xywafKsnsXMBrdsMCRL2O.json.gz",
             ),
             "cloudtrail",
         )
 
     def test_rds_event(self):
-        self.assertEqual(parse_event_source({}, "/aws/rds/my-rds-resource"), "rds")
+        self.assertEqual(
+            parse_event_source({"awslogs": "logs"}, "/aws/rds/my-rds-resource"), "rds"
+        )
 
     def test_cloudwatch_source_if_none_found(self):
         self.assertEqual(parse_event_source({"awslogs": "logs"}, ""), "cloudwatch")

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_cloudtrail.json
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_cloudtrail.json
@@ -1,0 +1,26 @@
+{
+    "messageType": "DATA_MESSAGE",
+    "owner": "123456789123",
+    "logGroup": "aws-cloudtrail-logs-123456789123-c81b5193",
+    "logStream": "123456789123_CloudTrail_us-east-1",
+    "subscriptionFilters": [
+        "testFilter"
+    ],
+    "logEvents": [
+        {
+            "id": "35689263648391837472973739781728019701390240798247944192",
+            "timestamp": 1600361930988,
+            "message": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"AssumedRole\",\"principalId\":\"AROA55TKTI7VKCG3ZB64V:DatadogAWSIntegration\",\"arn\":\"arn:aws:sts::123456789123:assumed-role/DatadogAWSIntegrationRole/DatadogAWSIntegration\",\"accountId\":\"123456789123\",\"accessKeyId\":\"ASIA55TKTI7VANF3DEVD\",\"sessionContext\":{\"sessionIssuer\":{\"type\":\"Role\",\"principalId\":\"AROA55TKTI7VKCG3ZB64V\",\"arn\":\"arn:aws:iam::123456789123:role/DatadogAWSIntegrationRole\",\"accountId\":\"123456789123\",\"userName\":\"DatadogAWSIntegrationRole\"},\"webIdFederationData\":{},\"attributes\":{\"mfaAuthenticated\":\"false\",\"creationDate\":\"2020-09-17T16:29:28Z\"}}},\"eventTime\":\"2020-09-17T16:44:11Z\",\"eventSource\":\"logs.amazonaws.com\",\"eventName\":\"DescribeLogStreams\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"54.161.67.200\",\"userAgent\":\"Datadog\",\"requestParameters\":{\"logGroupName\":\"/aws/lambda/hello-dog-node-dev-hello12x\",\"descending\":true,\"orderBy\":\"LastEventTime\"},\"responseElements\":null,\"requestID\":\"149d9263-2a7a-4e79-b97e-07642b95b0ee\",\"eventID\":\"14b20909-b46b-4f74-b725-d987888edbc7\",\"eventType\":\"AwsApiCall\",\"apiVersion\":\"20140328\",\"recipientAccountId\":\"123456789123\"}"
+        },
+        {
+            "id": "35689263648391837472973739781728019701390240798247944193",
+            "timestamp": 1600361930988,
+            "message": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"Root\",\"principalId\":\"123456789123\",\"arn\":\"arn:aws:iam::123456789123:root\",\"accountId\":\"123456789123\",\"accessKeyId\":\"ASIA55TKTI7VJK52JDP3\",\"sessionContext\":{\"sessionIssuer\":{},\"webIdFederationData\":{},\"attributes\":{\"mfaAuthenticated\":\"false\",\"creationDate\":\"2020-09-17T14:19:46Z\"}}},\"eventTime\":\"2020-09-17T16:44:28Z\",\"eventSource\":\"health.amazonaws.com\",\"eventName\":\"DescribeEventAggregates\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"68.194.150.7\",\"userAgent\":\"console.amazonaws.com\",\"requestParameters\":{\"aggregateField\":\"eventTypeCategory\",\"filter\":{\"eventStatusCodes\":[\"open\",\"upcoming\"],\"startTimes\":[{\"from\":\"Sep 10, 2020 4:44:28 PM\"}]}},\"responseElements\":null,\"requestID\":\"f0cd8b48-77ce-4432-b458-478424f38a38\",\"eventID\":\"303c31dd-aeee-4d5d-9311-61a1aa802c6f\",\"eventType\":\"AwsApiCall\",\"recipientAccountId\":\"123456789123\"}"
+        },
+        {
+            "id": "35689263648391837472973739781728019701390240798247944194",
+            "timestamp": 1600361930988,
+            "message": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"AssumedRole\",\"principalId\":\"AROA55TKTI7VKCG3ZB64V:DatadogAWSIntegration\",\"arn\":\"arn:aws:sts::123456789123:assumed-role/DatadogAWSIntegrationRole/DatadogAWSIntegration\",\"accountId\":\"123456789123\",\"accessKeyId\":\"ASIA55TKTI7VANF3DEVD\",\"sessionContext\":{\"sessionIssuer\":{\"type\":\"Role\",\"principalId\":\"AROA55TKTI7VKCG3ZB64V\",\"arn\":\"arn:aws:iam::123456789123:role/DatadogAWSIntegrationRole\",\"accountId\":\"123456789123\",\"userName\":\"DatadogAWSIntegrationRole\"},\"webIdFederationData\":{},\"attributes\":{\"mfaAuthenticated\":\"false\",\"creationDate\":\"2020-09-17T16:29:28Z\"}}},\"eventTime\":\"2020-09-17T16:44:10Z\",\"eventSource\":\"logs.amazonaws.com\",\"eventName\":\"DescribeLogStreams\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"54.161.67.200\",\"userAgent\":\"Datadog\",\"requestParameters\":{\"logGroupName\":\"/aws/lambda/hello-dog-node-dev-hello10x\",\"descending\":true,\"orderBy\":\"LastEventTime\"},\"responseElements\":null,\"requestID\":\"8fdf17f5-1887-4008-88ee-96da7b039924\",\"eventID\":\"6b574dee-bdc5-4abe-b6ec-10888ac258a2\",\"eventType\":\"AwsApiCall\",\"apiVersion\":\"20140328\",\"recipientAccountId\":\"123456789123\"}"
+        }
+    ]
+}

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_cloudtrail.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_cloudtrail.json~snapshot
@@ -1,0 +1,116 @@
+{
+  "events": [
+    {
+      "content-type": "application/json",
+      "data": [
+        {
+          "aws": {
+            "awslogs": {
+              "logGroup": "aws-cloudtrail-logs-123456789123-c81b5193",
+              "logStream": "123456789123_CloudTrail_us-east-1",
+              "owner": "123456789123"
+            },
+            "function_version": "$LATEST",
+            "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
+          },
+          "ddsource": "cloudtrail",
+          "ddsourcecategory": "aws",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>",
+          "id": "35689263648391837472973739781728019701390240798247944192",
+          "message": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"AssumedRole\",\"principalId\":\"AROA55TKTI7VKCG3ZB64V:DatadogAWSIntegration\",\"arn\":\"arn:aws:sts::123456789123:assumed-role/DatadogAWSIntegrationRole/DatadogAWSIntegration\",\"accountId\":\"123456789123\",\"accessKeyId\":\"ASIA55TKTI7VANF3DEVD\",\"sessionContext\":{\"sessionIssuer\":{\"type\":\"Role\",\"principalId\":\"AROA55TKTI7VKCG3ZB64V\",\"arn\":\"arn:aws:iam::123456789123:role/DatadogAWSIntegrationRole\",\"accountId\":\"123456789123\",\"userName\":\"DatadogAWSIntegrationRole\"},\"webIdFederationData\":{},\"attributes\":{\"mfaAuthenticated\":\"false\",\"creationDate\":\"2020-09-17T16:29:28Z\"}}},\"eventTime\":\"2020-09-17T16:44:11Z\",\"eventSource\":\"logs.amazonaws.com\",\"eventName\":\"DescribeLogStreams\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"54.161.67.200\",\"userAgent\":\"Datadog\",\"requestParameters\":{\"logGroupName\":\"/aws/lambda/hello-dog-node-dev-hello12x\",\"descending\":true,\"orderBy\":\"LastEventTime\"},\"responseElements\":null,\"requestID\":\"149d9263-2a7a-4e79-b97e-07642b95b0ee\",\"eventID\":\"14b20909-b46b-4f74-b725-d987888edbc7\",\"eventType\":\"AwsApiCall\",\"apiVersion\":\"20140328\",\"recipientAccountId\":\"123456789123\"}",
+          "service": "cloudtrail",
+          "timestamp": 1600361930988
+        },
+        {
+          "aws": {
+            "awslogs": {
+              "logGroup": "aws-cloudtrail-logs-123456789123-c81b5193",
+              "logStream": "123456789123_CloudTrail_us-east-1",
+              "owner": "123456789123"
+            },
+            "function_version": "$LATEST",
+            "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
+          },
+          "ddsource": "cloudtrail",
+          "ddsourcecategory": "aws",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>",
+          "id": "35689263648391837472973739781728019701390240798247944193",
+          "message": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"Root\",\"principalId\":\"123456789123\",\"arn\":\"arn:aws:iam::123456789123:root\",\"accountId\":\"123456789123\",\"accessKeyId\":\"ASIA55TKTI7VJK52JDP3\",\"sessionContext\":{\"sessionIssuer\":{},\"webIdFederationData\":{},\"attributes\":{\"mfaAuthenticated\":\"false\",\"creationDate\":\"2020-09-17T14:19:46Z\"}}},\"eventTime\":\"2020-09-17T16:44:28Z\",\"eventSource\":\"health.amazonaws.com\",\"eventName\":\"DescribeEventAggregates\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"68.194.150.7\",\"userAgent\":\"console.amazonaws.com\",\"requestParameters\":{\"aggregateField\":\"eventTypeCategory\",\"filter\":{\"eventStatusCodes\":[\"open\",\"upcoming\"],\"startTimes\":[{\"from\":\"Sep 10, 2020 4:44:28 PM\"}]}},\"responseElements\":null,\"requestID\":\"f0cd8b48-77ce-4432-b458-478424f38a38\",\"eventID\":\"303c31dd-aeee-4d5d-9311-61a1aa802c6f\",\"eventType\":\"AwsApiCall\",\"recipientAccountId\":\"123456789123\"}",
+          "service": "cloudtrail",
+          "timestamp": 1600361930988
+        },
+        {
+          "aws": {
+            "awslogs": {
+              "logGroup": "aws-cloudtrail-logs-123456789123-c81b5193",
+              "logStream": "123456789123_CloudTrail_us-east-1",
+              "owner": "123456789123"
+            },
+            "function_version": "$LATEST",
+            "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
+          },
+          "ddsource": "cloudtrail",
+          "ddsourcecategory": "aws",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>",
+          "id": "35689263648391837472973739781728019701390240798247944194",
+          "message": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"AssumedRole\",\"principalId\":\"AROA55TKTI7VKCG3ZB64V:DatadogAWSIntegration\",\"arn\":\"arn:aws:sts::123456789123:assumed-role/DatadogAWSIntegrationRole/DatadogAWSIntegration\",\"accountId\":\"123456789123\",\"accessKeyId\":\"ASIA55TKTI7VANF3DEVD\",\"sessionContext\":{\"sessionIssuer\":{\"type\":\"Role\",\"principalId\":\"AROA55TKTI7VKCG3ZB64V\",\"arn\":\"arn:aws:iam::123456789123:role/DatadogAWSIntegrationRole\",\"accountId\":\"123456789123\",\"userName\":\"DatadogAWSIntegrationRole\"},\"webIdFederationData\":{},\"attributes\":{\"mfaAuthenticated\":\"false\",\"creationDate\":\"2020-09-17T16:29:28Z\"}}},\"eventTime\":\"2020-09-17T16:44:10Z\",\"eventSource\":\"logs.amazonaws.com\",\"eventName\":\"DescribeLogStreams\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"54.161.67.200\",\"userAgent\":\"Datadog\",\"requestParameters\":{\"logGroupName\":\"/aws/lambda/hello-dog-node-dev-hello10x\",\"descending\":true,\"orderBy\":\"LastEventTime\"},\"responseElements\":null,\"requestID\":\"8fdf17f5-1887-4008-88ee-96da7b039924\",\"eventID\":\"6b574dee-bdc5-4abe-b6ec-10888ac258a2\",\"eventType\":\"AwsApiCall\",\"apiVersion\":\"20140328\",\"recipientAccountId\":\"123456789123\"}",
+          "service": "cloudtrail",
+          "timestamp": 1600361930988
+        }
+      ],
+      "path": "/v1/input/abcdefghijklmnopqrstuvwxyz012345",
+      "verb": "POST"
+    },
+    {
+      "content-type": "application/json",
+      "data": {
+        "series": [
+          {
+            "device": null,
+            "host": null,
+            "interval": 10,
+            "metric": "aws.dd_forwarder.incoming_events",
+            "points": "<redacted from snapshot>",
+            "tags": [
+              "forwardername:test",
+              "forwarder_memorysize:1536",
+              "forwarder_version:<redacted from snapshot>",
+              "event_type:awslogs"
+            ],
+            "type": "distribution"
+          },
+          {
+            "device": null,
+            "host": null,
+            "interval": 10,
+            "metric": "aws.dd_forwarder.logs_forwarded",
+            "points": "<redacted from snapshot>",
+            "tags": [
+              "forwardername:test",
+              "forwarder_memorysize:1536",
+              "forwarder_version:<redacted from snapshot>",
+              "event_type:awslogs"
+            ],
+            "type": "distribution"
+          },
+          {
+            "device": null,
+            "host": null,
+            "interval": 10,
+            "metric": "aws.dd_forwarder.metrics_forwarded",
+            "points": "<redacted from snapshot>",
+            "tags": [
+              "forwardername:test",
+              "forwarder_memorysize:1536",
+              "forwarder_version:<redacted from snapshot>",
+              "event_type:awslogs"
+            ],
+            "type": "distribution"
+          }
+        ]
+      },
+      "path": "/api/v1/distribution_points?api_key=abcdefghijklmnopqrstuvwxyz012345",
+      "verb": "POST"
+    }
+  ]
+}

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_cloudtrail.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_cloudtrail.json~snapshot
@@ -11,13 +11,13 @@
               "owner": "123456789123"
             },
             "function_version": "$LATEST",
-            "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
+            "invoked_function_arn": "arn:aws:lambda:us-east-1:0000000000:function:test"
           },
           "ddsource": "cloudtrail",
           "ddsourcecategory": "aws",
           "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>",
           "id": "35689263648391837472973739781728019701390240798247944192",
-          "message": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"AssumedRole\",\"principalId\":\"AROA55TKTI7VKCG3ZB64V:DatadogAWSIntegration\",\"arn\":\"arn:aws:sts::123456789123:assumed-role/DatadogAWSIntegrationRole/DatadogAWSIntegration\",\"accountId\":\"123456789123\",\"accessKeyId\":\"ASIA55TKTI7VANF3DEVD\",\"sessionContext\":{\"sessionIssuer\":{\"type\":\"Role\",\"principalId\":\"AROA55TKTI7VKCG3ZB64V\",\"arn\":\"arn:aws:iam::123456789123:role/DatadogAWSIntegrationRole\",\"accountId\":\"123456789123\",\"userName\":\"DatadogAWSIntegrationRole\"},\"webIdFederationData\":{},\"attributes\":{\"mfaAuthenticated\":\"false\",\"creationDate\":\"2020-09-17T16:29:28Z\"}}},\"eventTime\":\"2020-09-17T16:44:11Z\",\"eventSource\":\"logs.amazonaws.com\",\"eventName\":\"DescribeLogStreams\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"54.161.67.200\",\"userAgent\":\"Datadog\",\"requestParameters\":{\"logGroupName\":\"/aws/lambda/hello-dog-node-dev-hello12x\",\"descending\":true,\"orderBy\":\"LastEventTime\"},\"responseElements\":null,\"requestID\":\"149d9263-2a7a-4e79-b97e-07642b95b0ee\",\"eventID\":\"14b20909-b46b-4f74-b725-d987888edbc7\",\"eventType\":\"AwsApiCall\",\"apiVersion\":\"20140328\",\"recipientAccountId\":\"123456789123\"}",
+          "message": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"AssumedRole\",\"principalId\":\"AROA55TKTI7VKCG3ZB64V:DatadogAWSIntegration\",\"arn\":\"arn:aws:sts::123456789123:assumed-role/DatadogAWSIntegrationRole/DatadogAWSIntegration\",\"accountId\":\"123456789123\",\"accessKeyId\":\"ASIA55TKTI7VANF3DEVD\",\"sessionContext\":{\"sessionIssuer\":{\"type\":\"Role\",\"principalId\":\"AROA55TKTI7VKCG3ZB64V\",\"arn\":\"arn:aws:iam::123456789123:role/DatadogAWSIntegrationRole\",\"accountId\":\"123456789123\",\"userName\":\"DatadogAWSIntegrationRole\"},\"webIdFederationData\":{},\"attributes\":{\"mfaAuthenticated\":\"false\",\"creationDate\":\"2020-09-17T16:29:28Z\"}}},\"eventTime\":\"2020-09-17T16:44:11Z\",\"eventSource\":\"logs.amazonaws.com\",\"eventName\":\"DescribeLogStreams\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"54.161.67.200\",\"userAgent\":\"Datadog\",\"requestParameters\":{\"logGroupName\":\"/aws/lambda/hello-dog-node-dev-hello12x\",\"descending\":true,\"orderBy\":\"LastEventTime\"},\"responseElements\":null,\"requestID\":\"<redacted from snapshot>\",\"eventID\":\"<redacted from snapshot>\",\"eventType\":\"AwsApiCall\",\"apiVersion\":\"20140328\",\"recipientAccountId\":\"123456789123\"}",
           "service": "cloudtrail",
           "timestamp": 1600361930988
         },
@@ -29,13 +29,13 @@
               "owner": "123456789123"
             },
             "function_version": "$LATEST",
-            "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
+            "invoked_function_arn": "arn:aws:lambda:us-east-1:0000000000:function:test"
           },
           "ddsource": "cloudtrail",
           "ddsourcecategory": "aws",
           "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>",
           "id": "35689263648391837472973739781728019701390240798247944193",
-          "message": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"Root\",\"principalId\":\"123456789123\",\"arn\":\"arn:aws:iam::123456789123:root\",\"accountId\":\"123456789123\",\"accessKeyId\":\"ASIA55TKTI7VJK52JDP3\",\"sessionContext\":{\"sessionIssuer\":{},\"webIdFederationData\":{},\"attributes\":{\"mfaAuthenticated\":\"false\",\"creationDate\":\"2020-09-17T14:19:46Z\"}}},\"eventTime\":\"2020-09-17T16:44:28Z\",\"eventSource\":\"health.amazonaws.com\",\"eventName\":\"DescribeEventAggregates\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"68.194.150.7\",\"userAgent\":\"console.amazonaws.com\",\"requestParameters\":{\"aggregateField\":\"eventTypeCategory\",\"filter\":{\"eventStatusCodes\":[\"open\",\"upcoming\"],\"startTimes\":[{\"from\":\"Sep 10, 2020 4:44:28 PM\"}]}},\"responseElements\":null,\"requestID\":\"f0cd8b48-77ce-4432-b458-478424f38a38\",\"eventID\":\"303c31dd-aeee-4d5d-9311-61a1aa802c6f\",\"eventType\":\"AwsApiCall\",\"recipientAccountId\":\"123456789123\"}",
+          "message": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"Root\",\"principalId\":\"123456789123\",\"arn\":\"arn:aws:iam::123456789123:root\",\"accountId\":\"123456789123\",\"accessKeyId\":\"ASIA55TKTI7VJK52JDP3\",\"sessionContext\":{\"sessionIssuer\":{},\"webIdFederationData\":{},\"attributes\":{\"mfaAuthenticated\":\"false\",\"creationDate\":\"2020-09-17T14:19:46Z\"}}},\"eventTime\":\"2020-09-17T16:44:28Z\",\"eventSource\":\"health.amazonaws.com\",\"eventName\":\"DescribeEventAggregates\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"68.194.150.7\",\"userAgent\":\"console.amazonaws.com\",\"requestParameters\":{\"aggregateField\":\"eventTypeCategory\",\"filter\":{\"eventStatusCodes\":[\"open\",\"upcoming\"],\"startTimes\":[{\"from\":\"Sep 10, 2020 4:44:28 PM\"}]}},\"responseElements\":null,\"requestID\":\"<redacted from snapshot>\",\"eventID\":\"<redacted from snapshot>\",\"eventType\":\"AwsApiCall\",\"recipientAccountId\":\"123456789123\"}",
           "service": "cloudtrail",
           "timestamp": 1600361930988
         },
@@ -47,13 +47,13 @@
               "owner": "123456789123"
             },
             "function_version": "$LATEST",
-            "invoked_function_arn": "arn:aws:lambda:us-east-1:0:function:test"
+            "invoked_function_arn": "arn:aws:lambda:us-east-1:0000000000:function:test"
           },
           "ddsource": "cloudtrail",
           "ddsourcecategory": "aws",
           "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>",
           "id": "35689263648391837472973739781728019701390240798247944194",
-          "message": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"AssumedRole\",\"principalId\":\"AROA55TKTI7VKCG3ZB64V:DatadogAWSIntegration\",\"arn\":\"arn:aws:sts::123456789123:assumed-role/DatadogAWSIntegrationRole/DatadogAWSIntegration\",\"accountId\":\"123456789123\",\"accessKeyId\":\"ASIA55TKTI7VANF3DEVD\",\"sessionContext\":{\"sessionIssuer\":{\"type\":\"Role\",\"principalId\":\"AROA55TKTI7VKCG3ZB64V\",\"arn\":\"arn:aws:iam::123456789123:role/DatadogAWSIntegrationRole\",\"accountId\":\"123456789123\",\"userName\":\"DatadogAWSIntegrationRole\"},\"webIdFederationData\":{},\"attributes\":{\"mfaAuthenticated\":\"false\",\"creationDate\":\"2020-09-17T16:29:28Z\"}}},\"eventTime\":\"2020-09-17T16:44:10Z\",\"eventSource\":\"logs.amazonaws.com\",\"eventName\":\"DescribeLogStreams\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"54.161.67.200\",\"userAgent\":\"Datadog\",\"requestParameters\":{\"logGroupName\":\"/aws/lambda/hello-dog-node-dev-hello10x\",\"descending\":true,\"orderBy\":\"LastEventTime\"},\"responseElements\":null,\"requestID\":\"8fdf17f5-1887-4008-88ee-96da7b039924\",\"eventID\":\"6b574dee-bdc5-4abe-b6ec-10888ac258a2\",\"eventType\":\"AwsApiCall\",\"apiVersion\":\"20140328\",\"recipientAccountId\":\"123456789123\"}",
+          "message": "{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"AssumedRole\",\"principalId\":\"AROA55TKTI7VKCG3ZB64V:DatadogAWSIntegration\",\"arn\":\"arn:aws:sts::123456789123:assumed-role/DatadogAWSIntegrationRole/DatadogAWSIntegration\",\"accountId\":\"123456789123\",\"accessKeyId\":\"ASIA55TKTI7VANF3DEVD\",\"sessionContext\":{\"sessionIssuer\":{\"type\":\"Role\",\"principalId\":\"AROA55TKTI7VKCG3ZB64V\",\"arn\":\"arn:aws:iam::123456789123:role/DatadogAWSIntegrationRole\",\"accountId\":\"123456789123\",\"userName\":\"DatadogAWSIntegrationRole\"},\"webIdFederationData\":{},\"attributes\":{\"mfaAuthenticated\":\"false\",\"creationDate\":\"2020-09-17T16:29:28Z\"}}},\"eventTime\":\"2020-09-17T16:44:10Z\",\"eventSource\":\"logs.amazonaws.com\",\"eventName\":\"DescribeLogStreams\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"54.161.67.200\",\"userAgent\":\"Datadog\",\"requestParameters\":{\"logGroupName\":\"/aws/lambda/hello-dog-node-dev-hello10x\",\"descending\":true,\"orderBy\":\"LastEventTime\"},\"responseElements\":null,\"requestID\":\"<redacted from snapshot>\",\"eventID\":\"<redacted from snapshot>\",\"eventType\":\"AwsApiCall\",\"apiVersion\":\"20140328\",\"recipientAccountId\":\"123456789123\"}",
           "service": "cloudtrail",
           "timestamp": 1600361930988
         }

--- a/aws/logs_monitoring/tools/integration_tests/tester/test_snapshots.py
+++ b/aws/logs_monitoring/tools/integration_tests/tester/test_snapshots.py
@@ -106,6 +106,11 @@ class TestForwarderSnapshots(unittest.TestCase):
         snapshot_filename = f"{input_filename}~snapshot"
         self.compare_snapshot(input_filename, snapshot_filename)
 
+    def test_cloudwatch_cloudtrail_log(self):
+        input_filename = f"{snapshot_dir}/cloudwatch_log_cloudtrail.json"
+        snapshot_filename = f"{input_filename}~snapshot"
+        self.compare_snapshot(input_filename, snapshot_filename)
+
     def test_cloudwatch_log_cold_start(self):
         input_filename = f"{snapshot_dir}/cloudwatch_log_coldstart.json"
         snapshot_filename = f"{input_filename}~snapshot"


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Makes `parse_event_source` adhere to stricter rules to prevent misidentifying a source. This involves separating the logic specific for the S3 logs from CloudWatch logs and identifying sources based on either expected naming conventions (e.g. log group of [`/aws/docdb/`](https://docs.aws.amazon.com/documentdb/latest/developerguide/profiling.html#profiling.accessing:~:text=%2Faws%2Fdocdb%2FyourClusterName%2Fprofile) in CloudWatch) or naming suggestions made in our documentation (e.g. target prefix of [`amazon_documentdb`](https://docs.datadoghq.com/integrations/amazon_documentdb/#enable-logging:~:text=amazon_documentdb) in S3).

**Notable Changes:**
Expected source conditions for Cloudwatch logs: 
- **lambda, codebuild, kinesis, docdb**: log group must start with `/aws/<source>`. e.g. `/aws/codebuild`
- **mariadb**: log group must start with `/aws/rds` and contain `mariadb`
- **mysql**: log group must start with `/aws/rds` and contain `mysql`
- **apigateway**: log group must start with `api-gateway`
- **dms**: log group must start with `dms-tasks`
- **sns**: log group must start with `sns/`
- **cloudtrail**: log stream must contain `_CloudTrail_`

Expected source conditions for S3 logs: 
- **vpc**: object key must contain `vpcflowlogs`
- **waf**: object key must contain `aws-waf-logs`
- **redshift**: object key must contain `_redshift_`
- **docdb**: object key must contain `amazon_documentdb`
- **codebuild, kinesis, dms, cloudfront**: object key must contain `amazon_<source>`. e.g. `amazon_dms`

### Motivation

Related cases have been brought up in the past (https://github.com/DataDog/datadog-serverless-functions/issues/212) and present (https://github.com/DataDog/datadog-serverless-functions/issues/284, https://github.com/DataDog/datadog-serverless-functions/issues/344, https://github.com/DataDog/datadog-serverless-functions/issues/308#issuecomment-665342182) where the culprit was either our logic being too lenient or the ordering of our source list gave an unexpected result.

### Testing Guidelines

Unit tests and running local build

### Additional Notes

<!--- Anything else we should know when reviewing? --->

Includes a fix that correctly identifies `source:cloudtrail` for `Cloudtrail -> Cloudwatch` and `Cloudtrail -> Cloudwatch -> Kinesis`.

### Types of changes

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [x] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [x] This PR passes the installation tests (ask a Datadog member to run the tests)
