### PR TITLE
Compute APM stats on the backend instead

### DIFF
--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_lambda_invocation.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_lambda_invocation.json~snapshot
@@ -369,6 +369,7 @@
               {
                 "duration": "458278320",
                 "meta": {
+                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -394,6 +395,7 @@
               {
                 "duration": "13428",
                 "meta": {
+                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -419,6 +421,7 @@
               {
                 "duration": "35645",
                 "meta": {
+                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -444,6 +447,7 @@
               {
                 "duration": "9277",
                 "meta": {
+                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -469,6 +473,7 @@
               {
                 "duration": "26367",
                 "meta": {
+                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -494,6 +499,7 @@
               {
                 "duration": "127197",
                 "meta": {
+                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -519,6 +525,7 @@
               {
                 "duration": "499751709",
                 "meta": {
+                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -547,6 +554,7 @@
               {
                 "duration": "218750",
                 "meta": {
+                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -575,6 +583,7 @@
               {
                 "duration": "460493896",
                 "meta": {
+                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -603,6 +612,7 @@
               {
                 "duration": "479066650",
                 "meta": {
+                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -639,6 +649,7 @@
               {
                 "duration": "577401367",
                 "meta": {
+                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -674,6 +685,7 @@
               {
                 "duration": "578297119",
                 "meta": {
+                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -714,12 +726,6 @@
         ]
       },
       "path": "/api/v0.2/traces",
-      "verb": "POST"
-    },
-    {
-      "content-type": "application/json",
-      "data": null,
-      "path": "/api/v0.2/stats",
       "verb": "POST"
     },
     {

--- a/aws/logs_monitoring/trace_forwarder/cmd/trace/main.go
+++ b/aws/logs_monitoring/trace_forwarder/cmd/trace/main.go
@@ -132,22 +132,12 @@ func aggregateTracePayloadsByEnv(tracePayloads []*pb.TracePayload) []*pb.TracePa
 }
 
 func sendTracesToIntake(tracePayloads []*pb.TracePayload) error {
-	hadErr := false
 	for _, tracePayload := range tracePayloads {
 		err := edgeConnection.SendTraces(context.Background(), tracePayload, 3)
 		if err != nil {
 			fmt.Printf("Failed to send traces with error %v\n", err)
-			hadErr = true
+			return errors.New("Failed to send traces to intake")
 		}
-		stats := apm.ComputeAPMStats(tracePayload)
-		err = edgeConnection.SendStats(context.Background(), stats, 3)
-		if err != nil {
-			fmt.Printf("Failed to send trace stats with error %v\n", err)
-			hadErr = true
-		}
-	}
-	if hadErr {
-		return errors.New("Failed to send traces or stats to intake")
 	}
 	return nil
 }

--- a/aws/logs_monitoring/trace_forwarder/internal/apm/model.go
+++ b/aws/logs_monitoring/trace_forwarder/internal/apm/model.go
@@ -45,6 +45,7 @@ type (
 
 const (
 	originMetadataKey       = "_dd.origin"
+	computeStatsKey         = "_dd.compute_stats"
 	parentSourceMetadataKey = "_dd.parent_source"
 	sourceXray              = "xray"
 )
@@ -83,6 +84,11 @@ func ParseTrace(content string) ([]*pb.TracePayload, error) {
 				sp.Meta = map[string]string{}
 			}
 			sp.Meta[originMetadataKey] = "lambda"
+
+			// Instruct the span intake pipeline to compute stats
+			// in the APM backend.
+			sp.Meta[computeStatsKey] = "1"
+
 			pbSpan := convertSpanToPB(sp)
 			// We skip root dd-trace spans that are parented to X-Ray,
 			// since those root spans are placeholders for the X-Ray

--- a/aws/logs_monitoring/trace_forwarder/internal/apm/testdata/basic.json~snapshot
+++ b/aws/logs_monitoring/trace_forwarder/internal/apm/testdata/basic.json~snapshot
@@ -16,7 +16,8 @@
       Start: (int64) 1586269922931758000,
       Duration: (int64) 254812000,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=6) {
+      Meta: (map[string]string) (len=7) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=10) "cold_start": (string) (len=5) "false",
        (string) (len=12) "function_arn": (string) (len=68) "arn:aws:lambda:us-east-1:172597598159:function:hello-dog-dev-hello36",
@@ -45,7 +46,8 @@
       Start: (int64) 1586269922945357000,
       Duration: (int64) 138997000,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=5) {
+      Meta: (map[string]string) (len=6) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=11) "http.method": (string) (len=3) "GET",
        (string) (len=16) "http.status_code": (string) (len=3) "200",
@@ -67,7 +69,8 @@
       Start: (int64) 1586269923086220000,
       Duration: (int64) 100232000,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=1) {
+      Meta: (map[string]string) (len=2) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda"
       },
       Metrics: (map[string]float64) <nil>,
@@ -89,7 +92,8 @@
     Start: (int64) 1586269922931758000,
     Duration: (int64) 254812000,
     Error: (int32) 0,
-    Meta: (map[string]string) (len=6) {
+    Meta: (map[string]string) (len=7) {
+     (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
      (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
      (string) (len=10) "cold_start": (string) (len=5) "false",
      (string) (len=12) "function_arn": (string) (len=68) "arn:aws:lambda:us-east-1:172597598159:function:hello-dog-dev-hello36",

--- a/aws/logs_monitoring/trace_forwarder/internal/apm/testdata/service_rename.json~snapshot
+++ b/aws/logs_monitoring/trace_forwarder/internal/apm/testdata/service_rename.json~snapshot
@@ -16,7 +16,8 @@
       Start: (int64) 1586269721581541000,
       Duration: (int64) 555729248,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=4) {
+      Meta: (map[string]string) (len=5) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=8) "language": (string) (len=10) "javascript",
        (string) (len=2) "my": (string) (len=5) "value",
@@ -38,7 +39,8 @@
       Start: (int64) 1586269722137387000,
       Duration: (int64) 11963,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=4) {
+      Meta: (map[string]string) (len=5) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=8) "language": (string) (len=10) "javascript",
        (string) (len=2) "my": (string) (len=5) "value",
@@ -60,7 +62,8 @@
       Start: (int64) 1586269722137368600,
       Duration: (int64) 32959,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=4) {
+      Meta: (map[string]string) (len=5) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=8) "language": (string) (len=10) "javascript",
        (string) (len=2) "my": (string) (len=5) "value",
@@ -82,7 +85,8 @@
       Start: (int64) 1586269722137421600,
       Duration: (int64) 9033,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=4) {
+      Meta: (map[string]string) (len=5) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=8) "language": (string) (len=10) "javascript",
        (string) (len=2) "my": (string) (len=5) "value",
@@ -104,7 +108,8 @@
       Start: (int64) 1586269722137407200,
       Duration: (int64) 25391,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=4) {
+      Meta: (map[string]string) (len=5) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=8) "language": (string) (len=10) "javascript",
        (string) (len=2) "my": (string) (len=5) "value",
@@ -126,7 +131,8 @@
       Start: (int64) 1586269722137314000,
       Duration: (int64) 120117,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=3) {
+      Meta: (map[string]string) (len=4) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=8) "language": (string) (len=10) "javascript",
        (string) (len=2) "my": (string) (len=5) "value"
@@ -147,7 +153,8 @@
       Start: (int64) 1586269721581080000,
       Duration: (int64) 556922119,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=5) {
+      Meta: (map[string]string) (len=6) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=11) "dns.address": (string) (len=13) "172.217.9.196",
        (string) (len=12) "dns.hostname": (string) (len=14) "www.google.com",
@@ -171,7 +178,8 @@
       Start: (int64) 1586269721580981500,
       Duration: (int64) 613575195,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=7) {
+      Meta: (map[string]string) (len=8) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=2) "my": (string) (len=5) "value",
        (string) (len=8) "out.host": (string) (len=14) "www.google.com",
@@ -203,7 +211,8 @@
       Start: (int64) 1586269721580333800,
       Duration: (int64) 654928711,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=6) {
+      Meta: (map[string]string) (len=7) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=11) "http.method": (string) (len=3) "GET",
        (string) (len=16) "http.status_code": (string) (len=3) "200",
@@ -233,7 +242,8 @@
       Start: (int64) 1586269721580143000,
       Duration: (int64) 674647949,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=7) {
+      Meta: (map[string]string) (len=8) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=10) "cold_start": (string) (len=5) "false",
        (string) (len=12) "function_arn": (string) (len=74) "arn:aws:lambda:us-east-1:172597598159:function:hello-dog-node-dev-hello10x",
@@ -271,7 +281,8 @@
     Start: (int64) 1586269721581080000,
     Duration: (int64) 556922119,
     Error: (int32) 0,
-    Meta: (map[string]string) (len=5) {
+    Meta: (map[string]string) (len=6) {
+     (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
      (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
      (string) (len=11) "dns.address": (string) (len=13) "172.217.9.196",
      (string) (len=12) "dns.hostname": (string) (len=14) "www.google.com",
@@ -295,7 +306,8 @@
     Start: (int64) 1586269721580981500,
     Duration: (int64) 613575195,
     Error: (int32) 0,
-    Meta: (map[string]string) (len=7) {
+    Meta: (map[string]string) (len=8) {
+     (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
      (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
      (string) (len=2) "my": (string) (len=5) "value",
      (string) (len=8) "out.host": (string) (len=14) "www.google.com",
@@ -327,7 +339,8 @@
     Start: (int64) 1586269721580333800,
     Duration: (int64) 654928711,
     Error: (int32) 0,
-    Meta: (map[string]string) (len=6) {
+    Meta: (map[string]string) (len=7) {
+     (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
      (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
      (string) (len=11) "http.method": (string) (len=3) "GET",
      (string) (len=16) "http.status_code": (string) (len=3) "200",
@@ -357,7 +370,8 @@
     Start: (int64) 1586269721580143000,
     Duration: (int64) 674647949,
     Error: (int32) 0,
-    Meta: (map[string]string) (len=7) {
+    Meta: (map[string]string) (len=8) {
+     (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
      (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
      (string) (len=10) "cold_start": (string) (len=5) "false",
      (string) (len=12) "function_arn": (string) (len=74) "arn:aws:lambda:us-east-1:172597598159:function:hello-dog-node-dev-hello10x",

--- a/aws/logs_monitoring/trace_forwarder/internal/apm/testdata/xray_reparent.json~snapshot
+++ b/aws/logs_monitoring/trace_forwarder/internal/apm/testdata/xray_reparent.json~snapshot
@@ -16,7 +16,8 @@
       Start: (int64) 1586269922945357000,
       Duration: (int64) 138997000,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=4) {
+      Meta: (map[string]string) (len=5) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=11) "http.method": (string) (len=3) "GET",
        (string) (len=16) "http.status_code": (string) (len=3) "200",
@@ -38,7 +39,8 @@
       Start: (int64) 1586269923086220000,
       Duration: (int64) 100232000,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=1) {
+      Meta: (map[string]string) (len=2) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda"
       },
       Metrics: (map[string]float64) (len=1) {
@@ -62,7 +64,8 @@
     Start: (int64) 1586269922945357000,
     Duration: (int64) 138997000,
     Error: (int32) 0,
-    Meta: (map[string]string) (len=4) {
+    Meta: (map[string]string) (len=5) {
+     (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
      (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
      (string) (len=11) "http.method": (string) (len=3) "GET",
      (string) (len=16) "http.status_code": (string) (len=3) "200",
@@ -84,7 +87,8 @@
     Start: (int64) 1586269923086220000,
     Duration: (int64) 100232000,
     Error: (int32) 0,
-    Meta: (map[string]string) (len=1) {
+    Meta: (map[string]string) (len=2) {
+     (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
      (string) (len=10) "_dd.origin": (string) (len=6) "lambda"
     },
     Metrics: (map[string]float64) (len=1) {


### PR DESCRIPTION
### What does this PR do?

Instead of computing APM stats in the Forwarder, compute it in the APM backend.

### Motivation

Take the advantage of backend stats computation.

### Testing Guidelines

- [x] APM stats still populate for serverless services

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [x] This PR passes the installation tests (ask a Datadog member to run the tests)
