### PR TITLE
[azure][automation] Add function app template

### DIFF
--- a/azure/eventhub_log_forwarder/function_template.json
+++ b/azure/eventhub_log_forwarder/function_template.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "functionAppName": {
+      "type": "string",
+      "defaultValue": "datadog-functionapp",
+      "metadata": {
+        "description": "The name of the function app "
+      }
+    },
+    "functionName": {
+      "type": "string",
+      "defaultValue": "datadog-function",
+      "metadata": {
+        "description": "The name of the function."
+      }
+    },
+    "eventhubName": {
+      "type": "string",
+      "defaultValue": "datadog-eventhub",
+      "metadata": {
+        "description": "The name of the eventhub."
+      }
+    },
+    "eventhubNamespace": {
+      "type": "string",
+      "defaultValue": "datadog-eventhub-namespace",
+      "metadata": {
+        "description": "The name of the eventhub namespace."
+      }
+    },
+    "functionCode": {
+      "type": "string",
+      "metadata": {
+        "description": "Code for the function to run, saved into index.js"
+      }
+    },
+    "apiKey": {
+      "type": "string",
+      "metadata": {
+        "description": "Datadog API key"
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location for all resources."
+      }
+    }
+  },
+  "variables": {
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'functions')]",
+    "connectionStringKey": "[concat('Datadog-',toLower(parameters('eventhubNamespace')),'-AccessKey')]",
+    "authRule": "[resourceId('Microsoft.EventHub/namespaces/authorizationRules', parameters('eventhubNamespace'),'RootManageSharedAccessKey')]",
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2019-06-01",
+      "name": "[variables('storageAccountName')]",
+      "location": "[parameters('location')]",
+      "kind": "StorageV2",
+      "sku": {
+        "name": "Standard_LRS"
+      }
+    },
+    {
+      "apiVersion": "2018-11-01",
+      "type": "Microsoft.Web/sites",
+      "name": "[parameters('functionAppName')]",
+      "location": "[parameters('location')]",
+      "kind": "functionapp",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+      ],
+      "properties": {
+        "name": "[parameters('functionAppName')]",
+        "clientAffinityEnabled": false,
+        "siteConfig": {
+          "cors": {
+            "allowedOrigins": [
+              "*"
+            ]
+          },
+          "appSettings": [
+            {
+              "name": "FUNCTIONS_EXTENSION_VERSION",
+              "value": "~3"
+            },
+            {
+              "name": "DD_API_KEY",
+              "value": "[parameters('apiKey')]"
+            },
+            {
+              "name": "AzureWebJobsStorage",
+              "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2018-11-01').keys[0].value,';')]"
+            },
+            {
+              "name": "FUNCTIONS_WORKER_RUNTIME",
+              "value": "node"
+            },
+            {
+              "name": "[variables('connectionStringKey')]",
+              "value": "[listKeys(variables('authRule'),'2017-04-01').primaryConnectionString]"
+            },
+            {
+              "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
+              "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2018-11-01').keys[0].value,';')]"
+            },
+            {
+              "name": "WEBSITE_CONTENTSHARE",
+              "value": "[toLower(parameters('functionAppName'))]"
+            },
+            {
+              "name": "WEBSITE_NODE_DEFAULT_VERSION",
+              "value": "~12"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "[concat(parameters('functionAppName'), '/', parameters('functionName'))]",
+      "type": "Microsoft.Web/sites/functions",
+      "apiVersion": "2020-06-01",
+      "properties": {
+        "config": {
+          "bindings": [
+            {
+              "name": "eventHubMessages",
+              "type": "eventHubTrigger",
+              "direction": "in",
+              "eventHubName": "[parameters('eventhubName')]",
+              "connection": "[variables('connectionStringKey')]",
+              "cardinality": "many",
+              "dataType": "",
+              "consumerGroup": "$Default"
+            }
+          ],
+          "disabled": false
+        },
+        "files": {
+          "index.js": "[parameters('functionCode')]"
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/sites', parameters('functionAppName'))]"
+      ]
+    }
+  ]
+}

--- a/azure/eventhub_log_forwarder/function_template.json
+++ b/azure/eventhub_log_forwarder/function_template.json
@@ -52,7 +52,7 @@
   },
   "variables": {
     "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'functions')]",
-    "connectionStringKey": "[concat('Datadog-',toLower(parameters('eventhubNamespace')),'-AccessKey')]",
+    "connectionStringKey": "[concat('Datadog-',parameters('eventhubNamespace'),'-AccessKey')]",
     "authRule": "[resourceId('Microsoft.EventHub/namespaces/authorizationRules', parameters('eventhubNamespace'),'RootManageSharedAccessKey')]",
   },
   "resources": [


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adds the template for creating a function app/function.

Configures:
- Function app with app settings, including API key
- Storage
- Hosting plan is configured by default to a consumption plan in the resource group
- Function with eventhub trigger, pointing to input eventhub/eventhub namespace

Code must be passed in directly to the template, it doesn't seem like there's an easy way to fetch this the way we need to in the template itself. In our final powershell script we can run the commands to pull the code so there is no need for users to know about it.

<!--- A brief description of the change being made with this pull request. --->

### Motivation
Log forwarder automation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

Powershell commands to run:

```
$templateFile = "function_template.json"

$codePath = "https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/master/azure/activity_logs_monitoring/index.js"

$code = (New-Object System.Net.WebClient).DownloadString($codePath)

New-AzResourceGroupDeployment -ResourceGroupName $resourceGroupName -TemplateFile $templateFile -functionCode $code -apiKey <REDACTED>
```

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
