### PR TITLE
Warn about using inefficient regex

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -327,16 +327,18 @@ The CloudFormation Stack creates following IAM roles:
 - `DdScrubbingRule` - Replace text matching the supplied regular expression with `xxxxx` (default) or
   `DdScrubbingRuleReplacement` (if supplied). Log scrubbing rule is applied to the full JSON-formatted
   log, including any metadata that is automatically added by the Lambda function. Each instance of a
-  pattern match is replaced until no more matches are found in each log.
-- `DdScrubbingRuleReplacement` - Replace text matching DdScrubbingRule with the supplied text
+  pattern match is replaced until no more matches are found in each log. Note, using inefficient regular
+  expression, such as `.*`, may slow down the Lambda function.
+- `DdScrubbingRuleReplacement` - Replace text matching DdScrubbingRule with the supplied text.
 
 ### Log Filtering (Optional)
 
 - `ExcludeAtMatch` - DO NOT send logs matching the supplied regular expression. If a log matches both
   the ExcludeAtMatch and IncludeAtMatch, it is excluded. Filtering rules are applied to the full
-  JSON-formatted log, including any metadata that is automatically added by the function.
+  JSON-formatted log, including any metadata that is automatically added by the function. Note, using
+  inefficient regular expression, such as `.*`, may slow down the Lambda function.
 - `IncludeAtMatch` - Only send logs matching the supplied regular expression and not excluded by
-  ExcludeAtMatch.
+  ExcludeAtMatch. Note, using inefficient regular expression, such as `.*`, may slow down the Lambda function.
 
 ### Advanced (Optional)
 

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -109,7 +109,7 @@ Parameters:
   DdScrubbingRule:
     Type: String
     Default: ""
-    Description: Replace text matching the supplied regular expression with xxxxx (default) or DdScrubbingRuleReplacement (if supplied). Log scrubbing rule is applied to the full JSON-formatted log, including any metadata that is automatically added by the Lambda function. Each instance of a pattern match is replaced until no more matches are found in each log.
+    Description: Replace text matching the supplied regular expression with xxxxx (default) or DdScrubbingRuleReplacement (if supplied). Log scrubbing rule is applied to the full JSON-formatted log, including any metadata that is automatically added by the Lambda function. Each instance of a pattern match is replaced until no more matches are found in each log. Note, using inefficient regular expression, such as `.*`, may slow down the Lambda function.
   DdScrubbingRuleReplacement:
     Type: String
     Default: ""
@@ -117,11 +117,11 @@ Parameters:
   ExcludeAtMatch:
     Type: String
     Default: ""
-    Description: DO NOT send logs matching the supplied regular expression. If a log matches both the ExcludeAtMatch and IncludeAtMatch, it is excluded. Filtering rules are applied to the full JSON-formatted log, including any metadata that is automatically added by the function.
+    Description: DO NOT send logs matching the supplied regular expression. If a log matches both the ExcludeAtMatch and IncludeAtMatch, it is excluded. Filtering rules are applied to the full JSON-formatted log, including any metadata that is automatically added by the function. Note, using inefficient regular expression, such as `.*`, may slow down the Lambda function.
   IncludeAtMatch:
     Type: String
     Default: ""
-    Description: Only send logs matching the supplied regular expression and not excluded by ExcludeAtMatch.
+    Description: Only send logs matching the supplied regular expression and not excluded by ExcludeAtMatch. Note, using inefficient regular expression, such as `.*`, may slow down the Lambda function.
   DdMultilineLogRegexPattern:
     Type: String
     Default: ""


### PR DESCRIPTION
### What does this PR do?

Add a warning about using inefficient regular expression, which might cause the forwarder to slow down or time out.

### Motivation

Same as above ^

### Testing Guidelines

Doc update only.

### Additional Notes

N/A

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [x] This PR passes the installation tests (ask a Datadog member to run the tests)
