### PR TITLE
Add source substrings for eks and msk

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -149,6 +149,8 @@ LOG_SOURCE_SUBSTRINGS = [
     "docdb",
     "fargate",
     "dms",
+    "eks",
+    "msk",
     "vpc",
     "sns",
     "waf",


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Add source substrings for eks and msk.

### Motivation

Currently eks and msk logs have their source set to `cloudwatch` which makes it difficult to work with them.

### Testing Guidelines

Tested locally.