### PR TITLE
[azure][automation] Add script to do infra-only deploy (no diag settings)

### DIFF
--- a/azure/eventhub_log_forwarder/resource_deploy.ps1
+++ b/azure/eventhub_log_forwarder/resource_deploy.ps1
@@ -1,22 +1,21 @@
-
-{
-If (Test-Path variable:SubscriptionId) {} Else {Write-Error "`$SubscriptionId` must be set"}
+&{
+If (Test-Path variable:SubscriptionId) {} Else {Write-Error "`$SubscriptionId` must be set"; Return }
+If (Test-Path variable:ApiKey) {} Else {Write-Error "`$ApiKey` must be set"; Return }
 Set-AzContext -SubscriptionId $SubscriptionId
-}
+
 $ResourceGroupLocation = If (Test-Path variable:ResourceGroupLocation) {$ResourceGroupLocation} Else {"westus2"}
-$ResourceGroupName = If (Test-Path variable:ResourceGroupName) {$ResourceGroupName} Else {"datadog-log-forwarder-rg" + $ResourceGroupLocation}
-$EventhubNamespace = If (Test-Path variable:EventhubNamespace) {$EventhubNamespace} Else {"datadog-eventhub-namespace" + $ResourceGroupLocation}
-$EventhubName = If (Test-Path variable:EventhubName) {$EventhubName} Else {"datadog-eventhub" + $ResourceGroupLocation}
-$FunctionAppName = If (Test-Path variable:FunctionAppName) {$FunctionAppName} Else {"datadog-functionapp" + $ResourceGroupLocation}
-$FunctionName = If (Test-Path variable:FunctionName) {$FunctionName} Else {"datadog-function" + $ResourceGroupLocation}
+$ResourceGroupName = If (Test-Path variable:ResourceGroupName) {$ResourceGroupName} Else {"datadog-log-forwarder-rg-" + $ResourceGroupLocation}
+$EventhubNamespace = If (Test-Path variable:EventhubNamespace) {$EventhubNamespace} Else {"datadog-eventhub-namespace-" + $ResourceGroupLocation}
+$EventhubName = If (Test-Path variable:EventhubName) {$EventhubName} Else {"datadog-eventhub-" + $ResourceGroupLocation}
+$FunctionAppName = If (Test-Path variable:FunctionAppName) {$FunctionAppName} Else {"datadog-functionapp-" + $ResourceGroupLocation}
+$FunctionName = If (Test-Path variable:FunctionName) {$FunctionName} Else {"datadog-function-" + $ResourceGroupLocation}
 $DatadogSite = If (Test-Path variable:DatadogSite) {$DatadogSite} Else {"datadoghq.com"}
 
 $code = (New-Object System.Net.WebClient).DownloadString("https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/master/azure/activity_logs_monitoring/index.js")
 
-If ($ResourceGroupName == "datadog-log-forwarder-rg" + $ResourceGroupLocation) {
-    New-AzResourceGroup -Name $ResourceGroupName -Location $ResourceGroupLocation
-}
+New-AzResourceGroup -Name $ResourceGroupName -Location $ResourceGroupLocation
 
+try {
 New-AzResourceGroupDeployment `
     -TemplateUri "https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/master/azure/eventhub_log_forwarder/parent_template.json" `
     -ResourceGroupName $ResourceGroupName `
@@ -28,4 +27,10 @@ New-AzResourceGroupDeployment `
     -functionAppName $FunctionAppName `
     -functionName $FunctionName `
     -datadogSite $DatadogSite `
-    -Verbose
+    -Verbose `
+    -ErrorAction Stop
+} catch {
+    Write-Error $_
+    Return
+}
+}

--- a/azure/eventhub_log_forwarder/resource_deploy.ps1
+++ b/azure/eventhub_log_forwarder/resource_deploy.ps1
@@ -1,0 +1,31 @@
+
+{
+If (Test-Path variable:SubscriptionId) {} Else {Write-Error "`$SubscriptionId` must be set"}
+Set-AzContext -SubscriptionId $SubscriptionId
+}
+$ResourceGroupLocation = If (Test-Path variable:ResourceGroupLocation) {$ResourceGroupLocation} Else {"westus2"}
+$ResourceGroupName = If (Test-Path variable:ResourceGroupName) {$ResourceGroupName} Else {"datadog-log-forwarder-rg" + $ResourceGroupLocation}
+$EventhubNamespace = If (Test-Path variable:EventhubNamespace) {$EventhubNamespace} Else {"datadog-eventhub-namespace" + $ResourceGroupLocation}
+$EventhubName = If (Test-Path variable:EventhubName) {$EventhubName} Else {"datadog-eventhub" + $ResourceGroupLocation}
+$FunctionAppName = If (Test-Path variable:FunctionAppName) {$FunctionAppName} Else {"datadog-functionapp" + $ResourceGroupLocation}
+$FunctionName = If (Test-Path variable:FunctionName) {$FunctionName} Else {"datadog-function" + $ResourceGroupLocation}
+$DatadogSite = If (Test-Path variable:DatadogSite) {$DatadogSite} Else {"datadoghq.com"}
+
+$code = (New-Object System.Net.WebClient).DownloadString("https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/master/azure/activity_logs_monitoring/index.js")
+
+If ($ResourceGroupName == "datadog-log-forwarder-rg" + $ResourceGroupLocation) {
+    New-AzResourceGroup -Name $ResourceGroupName -Location $ResourceGroupLocation
+}
+
+New-AzResourceGroupDeployment `
+    -TemplateUri "https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/master/azure/eventhub_log_forwarder/parent_template.json" `
+    -ResourceGroupName $ResourceGroupName `
+    -functionCode $code `
+    -apiKey $ApiKey `
+    -location $ResourceGroupLocation `
+    -eventhubNamespace $EventhubNamespace `
+    -eventHubName $EventhubName `
+    -functionAppName $FunctionAppName `
+    -functionName $FunctionName `
+    -datadogSite $DatadogSite `
+    -Verbose


### PR DESCRIPTION

### What does this PR do?

Adds script to deploy infra only - does not deploy activitiy logs diagnostic settings. This will be used for resource logs, and will be region specific, so resource groups and resources are created by default with the region in the name.

### Motivation
Automate collecting resource logs with the log forwarder

### Testing Guidelines

ran in powershell, created a resource group and all infra for westus2

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
