### PR TITLE
Strip out certain files from ddtrace

### DIFF
--- a/aws/logs_monitoring/tools/Dockerfile_bundle
+++ b/aws/logs_monitoring/tools/Dockerfile_bundle
@@ -14,3 +14,9 @@ RUN find . -name \*.pyc -delete
 # Remove botocore (40MB) to reduce package size. aws-xray-sdk
 # installs it, while it's already provided by the Lambda Runtime.
 RUN rm -rf ./botocore*
+
+# Remove the following files from ddtrace, because they contain code
+# like `os.execl`, which cause security scans to fail for certain customers.
+# These files are not directly used by the Forwarder.
+RUN rm ./ddtrace/commands/ddtrace_run.py
+RUN rm ./ddtrace/profiling/__main__.py


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Remove the following files from ddtrace, because they contain code like `os.execl`, which cause security scans to fail for certain customers. These files are not directly used by the Forwarder.

### Motivation

Let security scans to pass for affected customers.

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [x] This PR passes the installation tests (ask a Datadog member to run the tests)
