### PR TITLE
Bugfix: Don't strip digits from tag values

### DIFF
--- a/aws/logs_monitoring/enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/enhanced_lambda_metrics.py
@@ -281,7 +281,9 @@ def get_dd_tag_string_from_aws_dict(aws_key_value_tag_dict):
             ex: "creator:swf"
     """
     key = sanitize_aws_tag_string(aws_key_value_tag_dict["Key"], remove_colons=True)
-    value = sanitize_aws_tag_string(aws_key_value_tag_dict.get("Value"), remove_initial_digit=False)
+    value = sanitize_aws_tag_string(
+        aws_key_value_tag_dict.get("Value"), remove_initial_digit=False
+    )
     # Value is optional in DD and AWS
     if not value:
         return key
@@ -332,9 +334,7 @@ def send_forwarder_internal_metrics(name, additional_tags=[]):
     """Send forwarder's internal metrics to DD"""
     prefix, tags = get_forwarder_telemetry_prefix_and_tags()
     lambda_stats.distribution(
-        "{}.{}".format(prefix, name),
-        1,
-        tags=tags + additional_tags,
+        "{}.{}".format(prefix, name), 1, tags=tags + additional_tags,
     )
 
 
@@ -679,8 +679,7 @@ def create_timeout_enhanced_metric(log_line):
         return []
 
     dd_metric = DatadogMetricPoint(
-        f"{ENHANCED_METRICS_NAMESPACE_PREFIX}.{TIMEOUTS_METRIC_NAME}",
-        1.0,
+        f"{ENHANCED_METRICS_NAMESPACE_PREFIX}.{TIMEOUTS_METRIC_NAME}", 1.0,
     )
     return [dd_metric]
 
@@ -703,7 +702,6 @@ def create_out_of_memory_enhanced_metric(log_line):
         return []
 
     dd_metric = DatadogMetricPoint(
-        f"{ENHANCED_METRICS_NAMESPACE_PREFIX}.{OUT_OF_MEMORY_METRIC_NAME}",
-        1.0,
+        f"{ENHANCED_METRICS_NAMESPACE_PREFIX}.{OUT_OF_MEMORY_METRIC_NAME}", 1.0,
     )
     return [dd_metric]

--- a/aws/logs_monitoring/enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/enhanced_lambda_metrics.py
@@ -239,7 +239,7 @@ Dedupe = re.compile(r"_+", re.UNICODE).sub
 FixInit = re.compile(r"^[_\d]*", re.UNICODE).sub
 
 
-def sanitize_aws_tag_string(tag, remove_colons=False, remove_initial_digit=True):
+def sanitize_aws_tag_string(tag, remove_colons=False, remove_leading_digits=True):
     """Convert characters banned from DD but allowed in AWS tags to underscores"""
     global Sanitize, Dedupe, FixInit
 
@@ -261,7 +261,7 @@ def sanitize_aws_tag_string(tag, remove_colons=False, remove_initial_digit=True)
     if remove_colons:
         tag = tag.replace(":", "_")
     tag = Dedupe("_", Sanitize("_", tag.lower()))
-    if remove_initial_digit:
+    if remove_leading_digits:
         first_char = tag[0]
         if first_char == "_" or "0" <= first_char <= "9":
             tag = FixInit("", tag)
@@ -282,7 +282,7 @@ def get_dd_tag_string_from_aws_dict(aws_key_value_tag_dict):
     """
     key = sanitize_aws_tag_string(aws_key_value_tag_dict["Key"], remove_colons=True)
     value = sanitize_aws_tag_string(
-        aws_key_value_tag_dict.get("Value"), remove_initial_digit=False
+        aws_key_value_tag_dict.get("Value"), remove_leading_digits=False
     )
     # Value is optional in DD and AWS
     if not value:

--- a/aws/logs_monitoring/enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/enhanced_lambda_metrics.py
@@ -239,7 +239,7 @@ Dedupe = re.compile(r"_+", re.UNICODE).sub
 FixInit = re.compile(r"^[_\d]*", re.UNICODE).sub
 
 
-def sanitize_aws_tag_string(tag, remove_colons=False):
+def sanitize_aws_tag_string(tag, remove_colons=False, remove_initial_digit=True):
     """Convert characters banned from DD but allowed in AWS tags to underscores"""
     global Sanitize, Dedupe, FixInit
 
@@ -261,9 +261,10 @@ def sanitize_aws_tag_string(tag, remove_colons=False):
     if remove_colons:
         tag = tag.replace(":", "_")
     tag = Dedupe("_", Sanitize("_", tag.lower()))
-    first_char = tag[0]
-    if first_char == "_" or "0" <= first_char <= "9":
-        tag = FixInit("", tag)
+    if remove_initial_digit:
+        first_char = tag[0]
+        if first_char == "_" or "0" <= first_char <= "9":
+            tag = FixInit("", tag)
     tag = tag.rstrip("_")
     return tag
 
@@ -280,7 +281,7 @@ def get_dd_tag_string_from_aws_dict(aws_key_value_tag_dict):
             ex: "creator:swf"
     """
     key = sanitize_aws_tag_string(aws_key_value_tag_dict["Key"], remove_colons=True)
-    value = sanitize_aws_tag_string(aws_key_value_tag_dict.get("Value"))
+    value = sanitize_aws_tag_string(aws_key_value_tag_dict.get("Value"), remove_initial_digit=False)
     # Value is optional in DD and AWS
     if not value:
         return key

--- a/aws/logs_monitoring/enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/enhanced_lambda_metrics.py
@@ -281,9 +281,7 @@ def get_dd_tag_string_from_aws_dict(aws_key_value_tag_dict):
             ex: "creator:swf"
     """
     key = sanitize_aws_tag_string(aws_key_value_tag_dict["Key"], remove_colons=True)
-    value = sanitize_aws_tag_string(
-        aws_key_value_tag_dict.get("Value"), remove_initial_digit=False
-    )
+    value = sanitize_aws_tag_string(aws_key_value_tag_dict.get("Value"), remove_initial_digit=False)
     # Value is optional in DD and AWS
     if not value:
         return key
@@ -334,7 +332,9 @@ def send_forwarder_internal_metrics(name, additional_tags=[]):
     """Send forwarder's internal metrics to DD"""
     prefix, tags = get_forwarder_telemetry_prefix_and_tags()
     lambda_stats.distribution(
-        "{}.{}".format(prefix, name), 1, tags=tags + additional_tags,
+        "{}.{}".format(prefix, name),
+        1,
+        tags=tags + additional_tags,
     )
 
 
@@ -679,7 +679,8 @@ def create_timeout_enhanced_metric(log_line):
         return []
 
     dd_metric = DatadogMetricPoint(
-        f"{ENHANCED_METRICS_NAMESPACE_PREFIX}.{TIMEOUTS_METRIC_NAME}", 1.0,
+        f"{ENHANCED_METRICS_NAMESPACE_PREFIX}.{TIMEOUTS_METRIC_NAME}",
+        1.0,
     )
     return [dd_metric]
 
@@ -702,6 +703,7 @@ def create_out_of_memory_enhanced_metric(log_line):
         return []
 
     dd_metric = DatadogMetricPoint(
-        f"{ENHANCED_METRICS_NAMESPACE_PREFIX}.{OUT_OF_MEMORY_METRIC_NAME}", 1.0,
+        f"{ENHANCED_METRICS_NAMESPACE_PREFIX}.{OUT_OF_MEMORY_METRIC_NAME}",
+        1.0,
     )
     return [dd_metric]

--- a/aws/logs_monitoring/enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/enhanced_lambda_metrics.py
@@ -281,7 +281,9 @@ def get_dd_tag_string_from_aws_dict(aws_key_value_tag_dict):
             ex: "creator:swf"
     """
     key = sanitize_aws_tag_string(aws_key_value_tag_dict["Key"], remove_colons=True)
-    value = sanitize_aws_tag_string(aws_key_value_tag_dict.get("Value"), remove_initial_digit=False)
+    value = sanitize_aws_tag_string(
+        aws_key_value_tag_dict.get("Value"), remove_initial_digit=False
+    )
     # Value is optional in DD and AWS
     if not value:
         return key

--- a/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
@@ -59,6 +59,8 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
         # Convert to lower
         self.assertEqual(sanitize_aws_tag_string("serVerLess"), "serverless")
         self.assertEqual(sanitize_aws_tag_string(""), "")
+        self.assertEqual(sanitize_aws_tag_string("6.6.6"), ".6.6")
+        self.assertEqual(sanitize_aws_tag_string("6.6.6", remove_initial_digit=False), "6.6.6")
 
     def test_get_dd_tag_string_from_aws_dict(self):
         # Sanitize the key and value, combine them into a string

--- a/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
@@ -60,9 +60,7 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
         self.assertEqual(sanitize_aws_tag_string("serVerLess"), "serverless")
         self.assertEqual(sanitize_aws_tag_string(""), "")
         self.assertEqual(sanitize_aws_tag_string("6.6.6"), ".6.6")
-        self.assertEqual(
-            sanitize_aws_tag_string("6.6.6", remove_initial_digit=False), "6.6.6"
-        )
+        self.assertEqual(sanitize_aws_tag_string("6.6.6", remove_initial_digit=False), "6.6.6")
 
     def test_get_dd_tag_string_from_aws_dict(self):
         # Sanitize the key and value, combine them into a string
@@ -150,25 +148,37 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
             [
                 {
                     "name": "aws.lambda.enhanced.duration",
-                    "tags": ["memorysize:128", "cold_start:false",],
+                    "tags": [
+                        "memorysize:128",
+                        "cold_start:false",
+                    ],
                     "value": 0.00062,
                     "timestamp": None,
                 },
                 {
                     "name": "aws.lambda.enhanced.billed_duration",
-                    "tags": ["memorysize:128", "cold_start:false",],
+                    "tags": [
+                        "memorysize:128",
+                        "cold_start:false",
+                    ],
                     "value": 0.1000,
                     "timestamp": None,
                 },
                 {
                     "name": "aws.lambda.enhanced.max_memory_used",
-                    "tags": ["memorysize:128", "cold_start:false",],
+                    "tags": [
+                        "memorysize:128",
+                        "cold_start:false",
+                    ],
                     "value": 51.0,
                     "timestamp": None,
                 },
                 {
                     "name": "aws.lambda.enhanced.estimated_cost",
-                    "tags": ["memorysize:128", "cold_start:false",],
+                    "tags": [
+                        "memorysize:128",
+                        "cold_start:false",
+                    ],
                     "timestamp": None,
                     "value": 4.0833375e-07,
                 },
@@ -181,31 +191,46 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
             [
                 {
                     "name": "aws.lambda.enhanced.duration",
-                    "tags": ["memorysize:128", "cold_start:true",],
+                    "tags": [
+                        "memorysize:128",
+                        "cold_start:true",
+                    ],
                     "value": 0.0008100000000000001,
                     "timestamp": None,
                 },
                 {
                     "name": "aws.lambda.enhanced.billed_duration",
-                    "tags": ["memorysize:128", "cold_start:true",],
+                    "tags": [
+                        "memorysize:128",
+                        "cold_start:true",
+                    ],
                     "value": 0.1000,
                     "timestamp": None,
                 },
                 {
                     "name": "aws.lambda.enhanced.max_memory_used",
-                    "tags": ["memorysize:128", "cold_start:true",],
+                    "tags": [
+                        "memorysize:128",
+                        "cold_start:true",
+                    ],
                     "value": 90.0,
                     "timestamp": None,
                 },
                 {
                     "name": "aws.lambda.enhanced.init_duration",
-                    "tags": ["memorysize:128", "cold_start:true",],
+                    "tags": [
+                        "memorysize:128",
+                        "cold_start:true",
+                    ],
                     "value": 1.234,
                     "timestamp": None,
                 },
                 {
                     "name": "aws.lambda.enhanced.estimated_cost",
-                    "tags": ["memorysize:128", "cold_start:true",],
+                    "tags": [
+                        "memorysize:128",
+                        "cold_start:true",
+                    ],
                     "timestamp": None,
                     "value": 4.0833375e-07,
                 },
@@ -217,25 +242,37 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
             [
                 {
                     "name": "aws.lambda.enhanced.duration",
-                    "tags": ["memorysize:128", "cold_start:false",],
+                    "tags": [
+                        "memorysize:128",
+                        "cold_start:false",
+                    ],
                     "timestamp": None,
                     "value": 1.71187,
                 },
                 {
                     "name": "aws.lambda.enhanced.billed_duration",
-                    "tags": ["memorysize:128", "cold_start:false",],
+                    "tags": [
+                        "memorysize:128",
+                        "cold_start:false",
+                    ],
                     "timestamp": None,
                     "value": 1.8,
                 },
                 {
                     "name": "aws.lambda.enhanced.max_memory_used",
-                    "tags": ["memorysize:128", "cold_start:false",],
+                    "tags": [
+                        "memorysize:128",
+                        "cold_start:false",
+                    ],
                     "timestamp": None,
                     "value": 98.0,
                 },
                 {
                     "name": "aws.lambda.enhanced.estimated_cost",
-                    "tags": ["memorysize:128", "cold_start:false",],
+                    "tags": [
+                        "memorysize:128",
+                        "cold_start:false",
+                    ],
                     "timestamp": None,
                     "value": 3.9500075e-06,
                 },

--- a/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
@@ -60,7 +60,9 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
         self.assertEqual(sanitize_aws_tag_string("serVerLess"), "serverless")
         self.assertEqual(sanitize_aws_tag_string(""), "")
         self.assertEqual(sanitize_aws_tag_string("6.6.6"), ".6.6")
-        self.assertEqual(sanitize_aws_tag_string("6.6.6", remove_initial_digit=False), "6.6.6")
+        self.assertEqual(
+            sanitize_aws_tag_string("6.6.6", remove_initial_digit=False), "6.6.6"
+        )
 
     def test_get_dd_tag_string_from_aws_dict(self):
         # Sanitize the key and value, combine them into a string

--- a/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
@@ -61,7 +61,7 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
         self.assertEqual(sanitize_aws_tag_string(""), "")
         self.assertEqual(sanitize_aws_tag_string("6.6.6"), ".6.6")
         self.assertEqual(
-            sanitize_aws_tag_string("6.6.6", remove_initial_digit=False), "6.6.6"
+            sanitize_aws_tag_string("6.6.6", remove_leading_digits=False), "6.6.6"
         )
 
     def test_get_dd_tag_string_from_aws_dict(self):

--- a/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
@@ -60,7 +60,9 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
         self.assertEqual(sanitize_aws_tag_string("serVerLess"), "serverless")
         self.assertEqual(sanitize_aws_tag_string(""), "")
         self.assertEqual(sanitize_aws_tag_string("6.6.6"), ".6.6")
-        self.assertEqual(sanitize_aws_tag_string("6.6.6", remove_initial_digit=False), "6.6.6")
+        self.assertEqual(
+            sanitize_aws_tag_string("6.6.6", remove_initial_digit=False), "6.6.6"
+        )
 
     def test_get_dd_tag_string_from_aws_dict(self):
         # Sanitize the key and value, combine them into a string
@@ -148,37 +150,25 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
             [
                 {
                     "name": "aws.lambda.enhanced.duration",
-                    "tags": [
-                        "memorysize:128",
-                        "cold_start:false",
-                    ],
+                    "tags": ["memorysize:128", "cold_start:false",],
                     "value": 0.00062,
                     "timestamp": None,
                 },
                 {
                     "name": "aws.lambda.enhanced.billed_duration",
-                    "tags": [
-                        "memorysize:128",
-                        "cold_start:false",
-                    ],
+                    "tags": ["memorysize:128", "cold_start:false",],
                     "value": 0.1000,
                     "timestamp": None,
                 },
                 {
                     "name": "aws.lambda.enhanced.max_memory_used",
-                    "tags": [
-                        "memorysize:128",
-                        "cold_start:false",
-                    ],
+                    "tags": ["memorysize:128", "cold_start:false",],
                     "value": 51.0,
                     "timestamp": None,
                 },
                 {
                     "name": "aws.lambda.enhanced.estimated_cost",
-                    "tags": [
-                        "memorysize:128",
-                        "cold_start:false",
-                    ],
+                    "tags": ["memorysize:128", "cold_start:false",],
                     "timestamp": None,
                     "value": 4.0833375e-07,
                 },
@@ -191,46 +181,31 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
             [
                 {
                     "name": "aws.lambda.enhanced.duration",
-                    "tags": [
-                        "memorysize:128",
-                        "cold_start:true",
-                    ],
+                    "tags": ["memorysize:128", "cold_start:true",],
                     "value": 0.0008100000000000001,
                     "timestamp": None,
                 },
                 {
                     "name": "aws.lambda.enhanced.billed_duration",
-                    "tags": [
-                        "memorysize:128",
-                        "cold_start:true",
-                    ],
+                    "tags": ["memorysize:128", "cold_start:true",],
                     "value": 0.1000,
                     "timestamp": None,
                 },
                 {
                     "name": "aws.lambda.enhanced.max_memory_used",
-                    "tags": [
-                        "memorysize:128",
-                        "cold_start:true",
-                    ],
+                    "tags": ["memorysize:128", "cold_start:true",],
                     "value": 90.0,
                     "timestamp": None,
                 },
                 {
                     "name": "aws.lambda.enhanced.init_duration",
-                    "tags": [
-                        "memorysize:128",
-                        "cold_start:true",
-                    ],
+                    "tags": ["memorysize:128", "cold_start:true",],
                     "value": 1.234,
                     "timestamp": None,
                 },
                 {
                     "name": "aws.lambda.enhanced.estimated_cost",
-                    "tags": [
-                        "memorysize:128",
-                        "cold_start:true",
-                    ],
+                    "tags": ["memorysize:128", "cold_start:true",],
                     "timestamp": None,
                     "value": 4.0833375e-07,
                 },
@@ -242,37 +217,25 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
             [
                 {
                     "name": "aws.lambda.enhanced.duration",
-                    "tags": [
-                        "memorysize:128",
-                        "cold_start:false",
-                    ],
+                    "tags": ["memorysize:128", "cold_start:false",],
                     "timestamp": None,
                     "value": 1.71187,
                 },
                 {
                     "name": "aws.lambda.enhanced.billed_duration",
-                    "tags": [
-                        "memorysize:128",
-                        "cold_start:false",
-                    ],
+                    "tags": ["memorysize:128", "cold_start:false",],
                     "timestamp": None,
                     "value": 1.8,
                 },
                 {
                     "name": "aws.lambda.enhanced.max_memory_used",
-                    "tags": [
-                        "memorysize:128",
-                        "cold_start:false",
-                    ],
+                    "tags": ["memorysize:128", "cold_start:false",],
                     "timestamp": None,
                     "value": 98.0,
                 },
                 {
                     "name": "aws.lambda.enhanced.estimated_cost",
-                    "tags": [
-                        "memorysize:128",
-                        "cold_start:false",
-                    ],
+                    "tags": ["memorysize:128", "cold_start:false",],
                     "timestamp": None,
                     "value": 3.9500075e-06,
                 },


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
This PR fixes bug where we strip digits from tag **VALUES**

<!--- A brief description of the change being made with this pull request. --->

### Motivation
Support issue came through about this.
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
Units + integration
<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [X] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [X] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [X] This PR passes the integration tests (ask a Datadog member to run the tests)
- [X] This PR passes the unit tests 
- [X] This PR passes the installation tests (ask a Datadog member to run the tests)
