### PR TITLE
Remove `decorator.py` file not used by the forwarder

### DIFF
--- a/aws/logs_monitoring/tools/Dockerfile_bundle
+++ b/aws/logs_monitoring/tools/Dockerfile_bundle
@@ -20,3 +20,4 @@ RUN rm -rf ./botocore*
 # These files are not directly used by the Forwarder.
 RUN rm ./ddtrace/commands/ddtrace_run.py
 RUN rm ./ddtrace/profiling/__main__.py
+RUN rm ./decorator.py


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
This PR removes from the bundle build the `decorator.py` file that is not used by the forwarder. This was brought up by a customer.

<!--- A brief description of the change being made with this pull request. --->

### Motivation
Customer request https://datadoghq.atlassian.net/browse/SLES-332
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->
- Units
- Integration
- **Manually tested this forwarder as well**

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [X] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [X] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [X] This PR passes the integration tests (ask a Datadog member to run the tests)
- [X] This PR passes the unit tests 
- [X] This PR passes the installation tests (ask a Datadog member to run the tests)
