### PR TITLE
[azure log forwarder] Add support for AzureGovernment accounts

### DIFF
--- a/azure/eventhub_log_forwarder/activity_logs_deploy.ps1
+++ b/azure/eventhub_log_forwarder/activity_logs_deploy.ps1
@@ -16,7 +16,7 @@ if (-Not ($SubscriptionId -And $ApiKey)) { Throw "`SubscriptionId` and `ApiKey` 
 
 Set-AzContext -SubscriptionId $SubscriptionId
 
-$code = (New-Object System.Net.WebClient).DownloadString("https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/claudia/support-environment-suffixes-azure/azure/activity_logs_monitoring/index.js")
+$code = (New-Object System.Net.WebClient).DownloadString("https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/master/azure/activity_logs_monitoring/index.js")
 
 New-AzResourceGroup -Name $ResourceGroupName -Location $ResourceGroupLocation
 
@@ -25,7 +25,7 @@ $endpointSuffix = $environment.StorageEndpointSuffix
 
 try {
 New-AzResourceGroupDeployment `
-    -TemplateUri "https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/master/azure/eventhub_log_forwarder/parent_template.json" `
+    -TemplateUri "https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/claudia/support-environment-suffixes-azure/azure/eventhub_log_forwarder/parent_template.json" `
     -ResourceGroupName $ResourceGroupName `
     -functionCode $code `
     -apiKey $ApiKey `

--- a/azure/eventhub_log_forwarder/activity_logs_deploy.ps1
+++ b/azure/eventhub_log_forwarder/activity_logs_deploy.ps1
@@ -8,7 +8,8 @@ param (
     $FunctionAppName = "datadog-functionapp",
     $FunctionName = "datadog-function",
     $DiagnosticSettingName = "datadog-activity-logs-diagnostic-setting",
-    $DatadogSite = "datadoghq.com"
+    $DatadogSite = "datadoghq.com",
+    $Environment = "AzureCloud"
 )
 
 if (-Not ($SubscriptionId -And $ApiKey)) { Throw "`SubscriptionId` and `ApiKey` are required." }
@@ -18,6 +19,9 @@ Set-AzContext -SubscriptionId $SubscriptionId
 $code = (New-Object System.Net.WebClient).DownloadString("https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/master/azure/activity_logs_monitoring/index.js")
 
 New-AzResourceGroup -Name $ResourceGroupName -Location $ResourceGroupLocation
+
+$environment = Get-AzEnvironment -Name $Environment
+$endpointSuffix = $environment.StorageEndpointSuffix
 
 try {
 New-AzResourceGroupDeployment `
@@ -31,6 +35,7 @@ New-AzResourceGroupDeployment `
     -functionAppName $FunctionAppName `
     -functionName $FunctionName `
     -datadogSite $DatadogSite `
+    -endpointSuffix $endpointSuffix `
     -Verbose `
     -ErrorAction Stop
 } catch {

--- a/azure/eventhub_log_forwarder/activity_logs_deploy.ps1
+++ b/azure/eventhub_log_forwarder/activity_logs_deploy.ps1
@@ -16,7 +16,7 @@ if (-Not ($SubscriptionId -And $ApiKey)) { Throw "`SubscriptionId` and `ApiKey` 
 
 Set-AzContext -SubscriptionId $SubscriptionId
 
-$code = (New-Object System.Net.WebClient).DownloadString("https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/master/azure/activity_logs_monitoring/index.js")
+$code = (New-Object System.Net.WebClient).DownloadString("https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/claudia/support-environment-suffixes-azure/azure/activity_logs_monitoring/index.js")
 
 New-AzResourceGroup -Name $ResourceGroupName -Location $ResourceGroupLocation
 

--- a/azure/eventhub_log_forwarder/activity_logs_deploy.ps1
+++ b/azure/eventhub_log_forwarder/activity_logs_deploy.ps1
@@ -25,7 +25,7 @@ $endpointSuffix = $environment.StorageEndpointSuffix
 
 try {
 New-AzResourceGroupDeployment `
-    -TemplateUri "https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/claudia/support-environment-suffixes-azure/azure/eventhub_log_forwarder/parent_template.json" `
+    -TemplateUri "https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/master/azure/eventhub_log_forwarder/parent_template.json" `
     -ResourceGroupName $ResourceGroupName `
     -functionCode $code `
     -apiKey $ApiKey `

--- a/azure/eventhub_log_forwarder/function_template.json
+++ b/azure/eventhub_log_forwarder/function_template.json
@@ -67,8 +67,7 @@
   "variables": {
     "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'storageacct')]",
     "connectionStringKey": "[concat('Datadog-',parameters('eventhubNamespace'),'-AccessKey')]",
-    "authRule": "[resourceId('Microsoft.EventHub/namespaces/authorizationRules', parameters('eventhubNamespace'),'RootManageSharedAccessKey')]",
-    "connectionString": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2018-11-01').keys[0].value,';','EndpointSuffix=',parameters('endpointSuffix'),';')]"
+    "authRule": "[resourceId('Microsoft.EventHub/namespaces/authorizationRules', parameters('eventhubNamespace'),'RootManageSharedAccessKey')]"
   },
   "resources": [
     {
@@ -114,7 +113,7 @@
             },
             {
               "name": "AzureWebJobsStorage",
-              "value": "[variables('connectionString')]"
+              "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2018-11-01').keys[0].value,';','EndpointSuffix=',parameters('endpointSuffix'),';')]"
             },
             {
               "name": "FUNCTIONS_WORKER_RUNTIME",
@@ -126,7 +125,7 @@
             },
             {
               "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
-              "value": "[variables('connectionString')]"
+              "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2018-11-01').keys[0].value,';','EndpointSuffix=',parameters('endpointSuffix'),';')]"
             },
             {
               "name": "WEBSITE_CONTENTSHARE",

--- a/azure/eventhub_log_forwarder/function_template.json
+++ b/azure/eventhub_log_forwarder/function_template.json
@@ -113,7 +113,7 @@
             },
             {
               "name": "AzureWebJobsStorage",
-              "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2018-11-01').keys[0].value,';','EndpointSuffix=',parameters(endpointSuffix),';')]"
+              "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2018-11-01').keys[0].value,';','EndpointSuffix=',parameters('endpointSuffix'),';')]"
             },
             {
               "name": "FUNCTIONS_WORKER_RUNTIME",
@@ -125,7 +125,7 @@
             },
             {
               "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
-              "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2018-11-01').keys[0].value,';','EndpointSuffix=',parameters(endpointSuffix),';')]"
+              "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2018-11-01').keys[0].value,';','EndpointSuffix=',parameters('endpointSuffix'),';')]"
             },
             {
               "name": "WEBSITE_CONTENTSHARE",

--- a/azure/eventhub_log_forwarder/function_template.json
+++ b/azure/eventhub_log_forwarder/function_template.json
@@ -55,6 +55,13 @@
       "metadata": {
         "description": "Datadog site to send logs"
       }
+    },
+    "endpointSuffix": {
+     "type": "string",
+      "defaultValue": "core.windows.net",
+      "metadata": {
+        "description": "Endpoint suffix for storage account"
+      }
     }
   },
   "variables": {
@@ -106,7 +113,7 @@
             },
             {
               "name": "AzureWebJobsStorage",
-              "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2018-11-01').keys[0].value,';')]"
+              "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2018-11-01').keys[0].value,';','EndpointSuffix=',variables(endpointSuffix),';')]"
             },
             {
               "name": "FUNCTIONS_WORKER_RUNTIME",
@@ -118,7 +125,7 @@
             },
             {
               "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
-              "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2018-11-01').keys[0].value,';')]"
+              "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2018-11-01').keys[0].value,';','EndpointSuffix=',variables(endpointSuffix),';')]"
             },
             {
               "name": "WEBSITE_CONTENTSHARE",

--- a/azure/eventhub_log_forwarder/function_template.json
+++ b/azure/eventhub_log_forwarder/function_template.json
@@ -113,7 +113,7 @@
             },
             {
               "name": "AzureWebJobsStorage",
-              "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2018-11-01').keys[0].value,';','EndpointSuffix=',variables(endpointSuffix),';')]"
+              "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2018-11-01').keys[0].value,';','EndpointSuffix=',parameters(endpointSuffix),';')]"
             },
             {
               "name": "FUNCTIONS_WORKER_RUNTIME",
@@ -125,7 +125,7 @@
             },
             {
               "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
-              "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2018-11-01').keys[0].value,';','EndpointSuffix=',variables(endpointSuffix),';')]"
+              "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2018-11-01').keys[0].value,';','EndpointSuffix=',parameters(endpointSuffix),';')]"
             },
             {
               "name": "WEBSITE_CONTENTSHARE",

--- a/azure/eventhub_log_forwarder/function_template.json
+++ b/azure/eventhub_log_forwarder/function_template.json
@@ -67,7 +67,8 @@
   "variables": {
     "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'storageacct')]",
     "connectionStringKey": "[concat('Datadog-',parameters('eventhubNamespace'),'-AccessKey')]",
-    "authRule": "[resourceId('Microsoft.EventHub/namespaces/authorizationRules', parameters('eventhubNamespace'),'RootManageSharedAccessKey')]"
+    "authRule": "[resourceId('Microsoft.EventHub/namespaces/authorizationRules', parameters('eventhubNamespace'),'RootManageSharedAccessKey')]",
+    "connectionString": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2018-11-01').keys[0].value,';','EndpointSuffix=',parameters('endpointSuffix'),';')]"
   },
   "resources": [
     {
@@ -113,7 +114,7 @@
             },
             {
               "name": "AzureWebJobsStorage",
-              "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2018-11-01').keys[0].value,';','EndpointSuffix=',parameters('endpointSuffix'),';')]"
+              "value": "[variables('connectionString')]"
             },
             {
               "name": "FUNCTIONS_WORKER_RUNTIME",
@@ -125,7 +126,7 @@
             },
             {
               "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
-              "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2018-11-01').keys[0].value,';','EndpointSuffix=',parameters('endpointSuffix'),';')]"
+              "value": "[variables('connectionString')]"
             },
             {
               "name": "WEBSITE_CONTENTSHARE",

--- a/azure/eventhub_log_forwarder/parent_template.json
+++ b/azure/eventhub_log_forwarder/parent_template.json
@@ -66,7 +66,7 @@
   },
   "variables": {
     "eventHubTemplateLink": "https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/master/azure/eventhub_log_forwarder/event_hub.json",
-    "functionAppTemplateLink": "https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/master/azure/eventhub_log_forwarder/function_template.json"
+    "functionAppTemplateLink": "https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/claudia/support-environment-suffixes-azure/azure/eventhub_log_forwarder/function_template.json"
   },
   "resources": [
     {

--- a/azure/eventhub_log_forwarder/parent_template.json
+++ b/azure/eventhub_log_forwarder/parent_template.json
@@ -66,7 +66,7 @@
   },
   "variables": {
     "eventHubTemplateLink": "https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/master/azure/eventhub_log_forwarder/event_hub.json",
-    "functionAppTemplateLink": "https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/claudia/support-environment-suffixes-azure/azure/eventhub_log_forwarder/function_template.json"
+    "functionAppTemplateLink": "https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/master/azure/eventhub_log_forwarder/function_template.json"
   },
   "resources": [
     {

--- a/azure/eventhub_log_forwarder/parent_template.json
+++ b/azure/eventhub_log_forwarder/parent_template.json
@@ -55,6 +55,13 @@
       "metadata": {
         "description": "Datadog site to send logs"
       }
+    },
+    "endpointSuffix": {
+     "type": "string",
+      "defaultValue": "core.windows.net",
+      "metadata": {
+        "description": "Endpoint suffix for storage account"
+      }
     }
   },
   "variables": {
@@ -119,6 +126,9 @@
           },
           "datadogSite": {
             "value": "[parameters('datadogSite')]"
+          },
+          "endpointSuffix": {
+            "value": "parameters('endpointSuffix)"
           }
         }
       },

--- a/azure/eventhub_log_forwarder/parent_template.json
+++ b/azure/eventhub_log_forwarder/parent_template.json
@@ -57,7 +57,7 @@
       }
     },
     "endpointSuffix": {
-     "type": "string",
+      "type": "string",
       "defaultValue": "core.windows.net",
       "metadata": {
         "description": "Endpoint suffix for storage account"
@@ -128,7 +128,7 @@
             "value": "[parameters('datadogSite')]"
           },
           "endpointSuffix": {
-            "value": "parameters('endpointSuffix)"
+            "value": "[parameters('endpointSuffix')]"
           }
         }
       },

--- a/azure/eventhub_log_forwarder/resource_deploy.ps1
+++ b/azure/eventhub_log_forwarder/resource_deploy.ps1
@@ -7,7 +7,9 @@ param (
     $EventhubName = "datadog-eventhub-" + $ResourceGroupLocation,
     $FunctionAppName = "datadog-functionapp-" + $ResourceGroupLocation,
     $FunctionName = "datadog-function-" + $ResourceGroupLocation,
-    $DatadogSite = "datadoghq.com"
+    $DatadogSite = "datadoghq.com",
+    $Environment = "AzureCloud"
+
 )
 
 if (-Not ($SubscriptionId -And $ApiKey)) { Throw "`SubscriptionId` and `ApiKey` are required." }

--- a/azure/eventhub_log_forwarder/resource_deploy.ps1
+++ b/azure/eventhub_log_forwarder/resource_deploy.ps1
@@ -9,7 +9,6 @@ param (
     $FunctionName = "datadog-function-" + $ResourceGroupLocation,
     $DatadogSite = "datadoghq.com",
     $Environment = "AzureCloud"
-
 )
 
 if (-Not ($SubscriptionId -And $ApiKey)) { Throw "`SubscriptionId` and `ApiKey` are required." }
@@ -25,7 +24,7 @@ $endpointSuffix = $environment.StorageEndpointSuffix
 
 try {
 New-AzResourceGroupDeployment `
-    -TemplateUri "https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/claudia/support-environment-suffixes-azure/azure/eventhub_log_forwarder/parent_template.json" `
+    -TemplateUri "https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/master/azure/eventhub_log_forwarder/parent_template.json" `
     -ResourceGroupName $ResourceGroupName `
     -functionCode $code `
     -apiKey $ApiKey `

--- a/azure/eventhub_log_forwarder/resource_deploy.ps1
+++ b/azure/eventhub_log_forwarder/resource_deploy.ps1
@@ -18,6 +18,9 @@ $code = (New-Object System.Net.WebClient).DownloadString("https://raw.githubuser
 
 New-AzResourceGroup -Name $ResourceGroupName -Location $ResourceGroupLocation
 
+$environment = Get-AzEnvironment -Name $Environment
+$endpointSuffix = $environment.StorageEndpointSuffix
+
 try {
 New-AzResourceGroupDeployment `
     -TemplateUri "https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/master/azure/eventhub_log_forwarder/parent_template.json" `
@@ -30,6 +33,7 @@ New-AzResourceGroupDeployment `
     -functionAppName $FunctionAppName `
     -functionName $FunctionName `
     -datadogSite $DatadogSite `
+    -endpointSuffix $endpointSuffix `
     -Verbose `
     -ErrorAction Stop
 } catch {

--- a/azure/eventhub_log_forwarder/resource_deploy.ps1
+++ b/azure/eventhub_log_forwarder/resource_deploy.ps1
@@ -23,7 +23,7 @@ $endpointSuffix = $environment.StorageEndpointSuffix
 
 try {
 New-AzResourceGroupDeployment `
-    -TemplateUri "https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/master/azure/eventhub_log_forwarder/parent_template.json" `
+    -TemplateUri "https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/claudia/support-environment-suffixes-azure/azure/eventhub_log_forwarder/parent_template.json" `
     -ResourceGroupName $ResourceGroupName `
     -functionCode $code `
     -apiKey $ApiKey `


### PR DESCRIPTION
### What does this PR do?

Supports Azure Government accounts by adding an `-Environment` parameter to the resource deploy and activity deploy scripts. With the environment param we can get the endpoint suffix we need to create the connection strings to the storage accounts. This seems to be the main difference between gov and non-gov accounts for the infra that we deploy.

Related docs:
- https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string#create-a-connection-string-with-an-endpoint-suffix
- https://docs.microsoft.com/en-us/azure/storage/common/storage-powershell-independent-clouds#get-endpoint-using-get-azenvironment
- https://docs.microsoft.com/en-us/azure/azure-government/compare-azure-government-global-azure#guidance-for-developers

### Motivation
Allow Azure gov customers to use the automation scripts.

### Testing Guidelines
I tested both scripts in our account (non-gov) with the default environment parameter, and confirmed the function still works with the regular endpoint suffix (core.windows.net). I also tried to run by passing in AzureGovernment for the Environement parameter but ran into the same error that the customer is seeing but in reverse.

The main testing of these changes need to be done by the customer since we don't have our own azure government account.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
