### PR TITLE
Send logs concurrently

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -8,6 +8,7 @@ import gzip
 import json
 import os
 from collections import defaultdict
+from concurrent.futures import as_completed
 
 import boto3
 import botocore
@@ -19,6 +20,8 @@ import ssl
 import logging
 from io import BytesIO, BufferedReader
 import time
+from requests_futures.sessions import FuturesSession
+
 from datadog_lambda.wrapper import datadog_lambda_wrapper
 from datadog_lambda.metric import lambda_stats
 from datadog import api
@@ -52,6 +55,7 @@ from settings import (
     DD_FORWARDER_VERSION,
     DD_ADDITIONAL_TARGET_LAMBDAS,
     DD_USE_VPC,
+    DD_MAX_WORKERS,
 )
 
 
@@ -253,6 +257,7 @@ class DatadogHTTPClient(object):
         self._timeout = timeout
         self._session = None
         self._ssl_validation = not skip_ssl_validation
+        self._futures = []
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(
                 f"Initialized http client for logs intake: "
@@ -261,10 +266,17 @@ class DatadogHTTPClient(object):
             )
 
     def _connect(self):
-        self._session = requests.Session()
+        self._session = FuturesSession(max_workers=DD_MAX_WORKERS)
         self._session.headers.update(self._HEADERS)
 
     def _close(self):
+        # Resolve all the futures and log exceptions if any
+        for future in as_completed(self._futures):
+            try:
+                future.result()
+            except Exception:
+                logger.exception("Exception while forwarding logs")
+
         self._session.close()
 
     def send(self, logs):
@@ -277,26 +289,12 @@ class DatadogHTTPClient(object):
             raise Exception("could not scrub the payload")
         if DD_USE_COMPRESSION:
             data = compress_logs(data, DD_COMPRESSION_LEVEL)
-        try:
-            resp = self._session.post(
-                self._url, data, timeout=self._timeout, verify=self._ssl_validation
-            )
-        except Exception:
-            # most likely a network error
-            raise RetriableException()
-        if resp.status_code >= 500:
-            # server error
-            raise RetriableException()
-        elif resp.status_code >= 400:
-            # client error
-            raise Exception(
-                "client error, status: {}, reason {}".format(
-                    resp.status_code, resp.reason
-                )
-            )
-        else:
-            # success
-            return
+
+        # FuturesSession returns immediately with a future object
+        future = self._session.post(
+            self._url, data, timeout=self._timeout, verify=self._ssl_validation
+        )
+        self._futures.append(future)
 
     def __enter__(self):
         self._connect()
@@ -418,7 +416,7 @@ def forward_logs(logs):
         batcher = DatadogBatcher(256 * 1000, 256 * 1000, 1)
         cli = DatadogTCPClient(DD_URL, DD_PORT, DD_NO_SSL, DD_API_KEY, scrubber)
     else:
-        batcher = DatadogBatcher(256 * 1000, 2 * 1000 * 1000, 200)
+        batcher = DatadogBatcher(256 * 1000, 4 * 1000 * 1000, 400)
         cli = DatadogHTTPClient(
             DD_URL, DD_PORT, DD_NO_SSL, DD_SKIP_SSL_VALIDATION, DD_API_KEY, scrubber
         )

--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -102,6 +102,9 @@ DD_SITE = get_env_var("DD_SITE", default="datadoghq.com")
 #
 DD_TAGS = get_env_var("DD_TAGS", "")
 
+## @param DD_MAX_WORKERS - Max number of workers sending logs concurrently
+DD_MAX_WORKERS = int(os.getenv("DD_MAX_WORKERS", 20))
+
 ## @param DD_API_URL - Url to use for  validating the the api key.
 DD_API_URL = get_env_var(
     "DD_API_URL",

--- a/aws/logs_monitoring/setup.py
+++ b/aws/logs_monitoring/setup.py
@@ -17,7 +17,7 @@ setup(
     ],
     keywords="datadog aws lambda layer",
     python_requires=">=3.7, <3.9",
-    install_requires=["datadog-lambda==2.16.0"],
+    install_requires=["datadog-lambda==2.16.0", "requests-futures==1.0.0"],
     extras_require={
         "dev": ["nose2==0.9.1", "flake8==3.7.9", "requests==2.22.0", "boto3==1.10.33"]
     },

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -166,7 +166,11 @@ Parameters:
     Type: Number
     Default: 6
     AllowedValues: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-    Description: Set the compression level from 0 (no compression) to 9 (best compression).
+    Description: Set the compression level from 0 (no compression) to 9 (best compression) when sending logs.
+  DdMaxWorkers:
+    Type: Number
+    Default: 20
+    Description: Set the max number of workers sending logs concurrently.
   PermissionsBoundaryArn:
     Type: String
     Default: ""
@@ -295,6 +299,11 @@ Conditions:
       - Fn::Equals:
           - Ref: DdCompressionLevel
           - 6
+  SetDdMaxWorkers:
+    Fn::Not:
+      - Fn::Equals:
+          - Ref: DdMaxWorkers
+          - 20
   SetPermissionsBoundary:
     Fn::Not:
       - Fn::Equals:
@@ -357,6 +366,8 @@ Resources:
               - Ref: ForwarderBucket
               - Ref: AWS::NoValue
           DD_SITE:
+            Ref: DdSite
+          DD_:
             Ref: DdSite
           DD_TAGS:
             Fn::If:
@@ -444,6 +455,11 @@ Resources:
             Fn::If:
               - SetDdCompressionLevel
               - Ref: DdCompressionLevel
+              - Ref: AWS::NoValue
+          DD_MAX_WORKERS:
+            Fn::If:
+              - SetDdMaxWorkers
+              - Ref: DdMaxWorkers
               - Ref: AWS::NoValue
           DD_USE_PRIVATE_LINK:
             Fn::If:
@@ -738,6 +754,7 @@ Metadata:
           - DdSkipSslValidation
           - DdUseCompression
           - DdCompressionLevel
+          - DdMaxWorkers
           - DdForwardLog
       - Label:
           default: Log Scrubbing (Optional)

--- a/aws/logs_monitoring/tests/test_extract_metric.py
+++ b/aws/logs_monitoring/tests/test_extract_metric.py
@@ -8,6 +8,7 @@ sys.modules["datadog_lambda.wrapper"] = MagicMock()
 sys.modules["datadog_lambda.metric"] = MagicMock()
 sys.modules["datadog"] = MagicMock()
 sys.modules["requests"] = MagicMock()
+sys.modules["requests_futures.sessions"] = MagicMock()
 
 env_patch = patch.dict(
     os.environ,

--- a/aws/logs_monitoring/tests/test_invoke_additional_target_lambdas.py
+++ b/aws/logs_monitoring/tests/test_invoke_additional_target_lambdas.py
@@ -11,6 +11,7 @@ sys.modules["datadog_lambda.wrapper"] = MagicMock()
 sys.modules["datadog_lambda.metric"] = MagicMock()
 sys.modules["datadog"] = MagicMock()
 sys.modules["requests"] = MagicMock()
+sys.modules["requests_futures.sessions"] = MagicMock()
 
 env_patch = patch.dict(
     os.environ,

--- a/aws/logs_monitoring/tests/test_parse_event_source.py
+++ b/aws/logs_monitoring/tests/test_parse_event_source.py
@@ -8,6 +8,7 @@ sys.modules["datadog_lambda.wrapper"] = MagicMock()
 sys.modules["datadog_lambda.metric"] = MagicMock()
 sys.modules["datadog"] = MagicMock()
 sys.modules["requests"] = MagicMock()
+sys.modules["requests_futures.sessions"] = MagicMock()
 
 env_patch = patch.dict(os.environ, {"DD_API_KEY": "11111111111111111111111111111111"})
 env_patch.start()


### PR DESCRIPTION
### What does this PR do?

Send AWS logs concurrently for better performance over handling larger log files (e.g., vpc log files from s3). Also increased the batch size to reduce # of batches.

CFN parameter `DdMaxWorkers` can be used to fine control the concurrency.

### Motivation

Forwarder may time out when handling large log files.

### Testing Guidelines

For a large vpc log file containing 800k log lines, duration reduced by more than 10X while memory usage remained the same

**Before:**
REPORT RequestId: XXX Duration: 650270.61 ms Billed Duration: 650300 ms Memory Size: 3008 MB Max Memory Used: 1454 MB

**After:**
REPORT RequestId: XXX Duration: 42998.54 ms	Billed Duration: 43000 ms Memory Size: 3008 MB Max Memory Used: 1503 MB

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [x] This PR passes the installation tests (ask a Datadog member to run the tests)
