### PR TITLE
Support for secret manager partial ARNs

### DIFF
--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -527,7 +527,7 @@ Resources:
                 Fn::If:
                   - CreateDdApiKeySecret
                   - Ref: DdApiKeySecret
-                  - Ref: DdApiKeySecretArn
+                  - !Sub "${DdApiKeySecretArn}*"
             - !If
               - SetDdFetchLambdaTags
               - Effect: Allow


### PR DESCRIPTION
### What does this PR do?

This PR loosens the IAM policy to support [secret manager partial ARNs](https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html#SecretsManager-GetSecretValue-request-SecretId). Secrets manager randomly adds six characters to the ARN of a secret.

In a multi region deployment, each secret ARN gets a random six character suffix. The same input ARN cannot be used across regions.

### Motivation

We deploy the datadog forwarder via CloudFormation Stack Sets. We have the datadog key in a centralised account, and have to host the datadog template locally, because the `DdApiKeySecretArn` can't use short form. This PR would fix this, so we can use the datadog provided template.

```
AWSTemplateFormatVersion: "2010-09-09"
Description: Add lambda monitoring to datadog. Designed to be used via CloudFormation stack sets.
Parameters:
  DataDogTags:
    Type: String
    Description: Tags
    Default: ""
  DataDogExcludeRegex:
    Type: String
    Description: Regex to exclude logs
Resources:
  DataDogStack:
    Type: "AWS::CloudFormation::Stack"
    Properties:
      TemplateURL: "./templates/datadog.yml"
      Parameters:
        FunctionName: DatadogForwarder
        DdApiKey: "None"
        DdApiKeySecretArn: !Sub "arn:aws:secretsmanager:${AWS::Region}:HIDDEN:secret:DATADOG_KEY"
        DdTags: !Ref DataDogTags
        ExcludeAtMatch: !Ref DataDogExcludeRegex
        DdFetchLambdaTags: True
```

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [X] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
