### PR TITLE
[azure] Scrub PII in azure log forwarder

### DIFF
--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -73,7 +73,6 @@ class Scrubber {
             }
         }
         this.rules = rules;
-        this.context = context;
     }
 
     scrub(record) {

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -5,7 +5,7 @@
 
 var https = require('https');
 
-const VERSION = '0.1.2';
+const VERSION = '0.2.0';
 
 const STRING = 'string'; // example: 'some message'
 const STRING_ARRAY = 'string-array'; // example: ['one message', 'two message', ...]

--- a/azure/test/client.test.js
+++ b/azure/test/client.test.js
@@ -468,7 +468,7 @@ describe('Azure Log Monitoring', function() {
                 fakeContext(),
                 DEFAULT_TEST_SCRUBBER_RULES
             );
-            actual = scrubber.scrub('sender_email: cdadamo@datadoghq.com');
+            actual = scrubber.scrub('sender_email: hello@test.com');
             assert.equal(actual, expected);
         });
         it('should scrub ip address from record', function() {
@@ -487,7 +487,7 @@ describe('Azure Log Monitoring', function() {
                 DEFAULT_TEST_SCRUBBER_RULES
             );
             actual = scrubber.scrub(
-                'client_ip: 12.123.23.12, email: cdadamo@datadoghq.com'
+                'client_ip: 12.123.23.12, email: hello@test.com'
             );
             assert.equal(actual, expected);
         });
@@ -511,7 +511,7 @@ describe('Azure Log Monitoring', function() {
                 DEFAULT_TEST_SCRUBBER_RULES
             );
             actual = scrubber.scrub(
-                'client_ip: 12.123.23.12, client_ip2: 122.123.213.112 email: cdadamo@datadoghq.com email2: claudia@datadoghq.com'
+                'client_ip: 12.123.23.12, client_ip2: 122.123.213.112 email: hello@test.com email2: hello2@test.com'
             );
             assert.equal(actual, expected);
         });
@@ -530,10 +530,10 @@ describe('Azure Log Monitoring', function() {
             // if there are no rules, then the log should be the same before and after
             test_rules = {};
             expected =
-                'client_ip: 12.123.23.12, client_ip2: 122.123.213.112 email: cdadamo@datadoghq.com email2: claudia@datadoghq.com';
+                'client_ip: 12.123.23.12, client_ip2: 122.123.213.112 email: hello@test.com email2: hello2@test.com';
             scrubber = new client.Scrubber(fakeContext(), test_rules);
             actual = scrubber.scrub(
-                'client_ip: 12.123.23.12, client_ip2: 122.123.213.112 email: cdadamo@datadoghq.com email2: claudia@datadoghq.com'
+                'client_ip: 12.123.23.12, client_ip2: 122.123.213.112 email: hello@test.com email2: hello2@test.com'
             );
             assert.equal(actual, expected);
         });

--- a/azure/test/client.test.js
+++ b/azure/test/client.test.js
@@ -436,4 +436,53 @@ describe('Azure Log Monitoring', function() {
             assert.equal(actual, expected);
         });
     });
+    describe('#scrubPII', function() {
+        it('should set up configs correctly', function() {
+            test_rules = {'REDACT_IP' : {'pattern': '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}', 'replacement': 'xxx.xxx.xxx.xxx'}}
+            var scrubber = new client.Scrubber(fakeContext(), test_rules, true);
+            rule = scrubber.rules[0];
+            assert.equal(rule instanceof client.ScrubberRule, true);
+            assert.equal(rule.name, 'REDACT_IP');
+            assert.equal(rule.regexp instanceof RegExp, true);
+            assert.equal(rule.replacement, 'xxx.xxx.xxx.xxx');
+        });
+        it('should scrub email from record', function() {
+            expected = 'sender_email: xxxxx@xxxxx.com';
+            var scrubber = new client.Scrubber(fakeContext(), constants.SCRUBBER_RULE_CONFIGS, true);
+            actual = scrubber.scrub('sender_email: cdadamo@datadoghq.com');
+            assert.equal(actual, expected);
+
+        });
+        it('should scrub ip address from record', function() {
+            expected = 'client_ip: xxx.xxx.xxx.xxx';
+            var scrubber = new client.Scrubber(fakeContext(), constants.SCRUBBER_RULE_CONFIGS, true);
+            actual = scrubber.scrub('client_ip: 12.123.23.12');
+            assert.equal(actual, expected);
+
+        });
+        it('should scrub ip address and email from record', function() {
+            expected = 'client_ip: xxx.xxx.xxx.xxx, email: xxxxx@xxxxx.com';
+            var scrubber = new client.Scrubber(fakeContext(), constants.SCRUBBER_RULE_CONFIGS, true);
+            actual = scrubber.scrub('client_ip: 12.123.23.12, email: cdadamo@datadoghq.com');
+            assert.equal(actual, expected);
+        });
+        it('should scrub multiple ip address from string', function() {
+            expected = 'client_ip: xxx.xxx.xxx.xxx, client_ip2: xxx.xxx.xxx.xxx';
+            var scrubber = new client.Scrubber(fakeContext(), constants.SCRUBBER_RULE_CONFIGS, true);
+            actual = scrubber.scrub('client_ip: 12.123.23.12, client_ip2: 122.123.213.112');
+            assert.equal(actual, expected);
+        });
+        it('should scrub multiple ip address and email from string', function() {
+            expected = 'client_ip: xxx.xxx.xxx.xxx, client_ip2: xxx.xxx.xxx.xxx email: xxxxx@xxxxx.com email2: xxxxx@xxxxx.com';
+            var scrubber = new client.Scrubber(fakeContext(), constants.SCRUBBER_RULE_CONFIGS, true);
+            actual = scrubber.scrub('client_ip: 12.123.23.12, client_ip2: 122.123.213.112 email: cdadamo@datadoghq.com email2: claudia@datadoghq.com');
+            assert.equal(actual, expected);
+        });
+       it('should handle malformed regexp correctly', function() {
+            // we don't want to break if we have a malformed regex, just want to skip it until the user fixes it
+            test_rules = {'REDACT_SOMETHING' : {'pattern': '[2-', 'replacement': 'xxx.xxx.xxx.xxx'}}
+            var scrubber = new client.Scrubber(fakeContext(), test_rules, true);
+            assert.equal(scrubber.rules.length, 0);
+        });
+    })
 });

--- a/azure/test/client.test.js
+++ b/azure/test/client.test.js
@@ -22,7 +22,7 @@ function setUp() {
     return forwarder;
 }
 
-DEFAULT_TEST_SCRUBBER_RULES = {
+const DEFAULT_TEST_SCRUBBER_RULES = {
     REDACT_IP: {
         pattern: /[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/,
         replacement: 'xxx.xxx.xxx.xxx'
@@ -455,7 +455,7 @@ describe('Azure Log Monitoring', function() {
                     replacement: 'xxx.xxx.xxx.xxx'
                 }
             };
-            var scrubber = new client.Scrubber(fakeContext(), test_rules);
+            scrubber = new client.Scrubber(fakeContext(), test_rules);
             rule = scrubber.rules[0];
             assert.equal(rule instanceof client.ScrubberRule, true);
             assert.equal(rule.name, 'REDACT_IP');
@@ -464,7 +464,7 @@ describe('Azure Log Monitoring', function() {
         });
         it('should scrub email from record', function() {
             expected = 'sender_email: xxxxx@xxxxx.com';
-            var scrubber = new client.Scrubber(
+            scrubber = new client.Scrubber(
                 fakeContext(),
                 DEFAULT_TEST_SCRUBBER_RULES
             );
@@ -473,7 +473,7 @@ describe('Azure Log Monitoring', function() {
         });
         it('should scrub ip address from record', function() {
             expected = 'client_ip: xxx.xxx.xxx.xxx';
-            var scrubber = new client.Scrubber(
+            scrubber = new client.Scrubber(
                 fakeContext(),
                 DEFAULT_TEST_SCRUBBER_RULES
             );
@@ -482,7 +482,7 @@ describe('Azure Log Monitoring', function() {
         });
         it('should scrub ip address and email from record', function() {
             expected = 'client_ip: xxx.xxx.xxx.xxx, email: xxxxx@xxxxx.com';
-            var scrubber = new client.Scrubber(
+            scrubber = new client.Scrubber(
                 fakeContext(),
                 DEFAULT_TEST_SCRUBBER_RULES
             );
@@ -494,7 +494,7 @@ describe('Azure Log Monitoring', function() {
         it('should scrub multiple ip address from string', function() {
             expected =
                 'client_ip: xxx.xxx.xxx.xxx, client_ip2: xxx.xxx.xxx.xxx';
-            var scrubber = new client.Scrubber(
+            scrubber = new client.Scrubber(
                 fakeContext(),
                 DEFAULT_TEST_SCRUBBER_RULES
             );
@@ -506,7 +506,7 @@ describe('Azure Log Monitoring', function() {
         it('should scrub multiple ip address and email from string', function() {
             expected =
                 'client_ip: xxx.xxx.xxx.xxx, client_ip2: xxx.xxx.xxx.xxx email: xxxxx@xxxxx.com email2: xxxxx@xxxxx.com';
-            var scrubber = new client.Scrubber(
+            scrubber = new client.Scrubber(
                 fakeContext(),
                 DEFAULT_TEST_SCRUBBER_RULES
             );
@@ -523,7 +523,7 @@ describe('Azure Log Monitoring', function() {
                     replacement: 'xxx.xxx.xxx.xxx'
                 }
             };
-            var scrubber = new client.Scrubber(fakeContext(), test_rules);
+            scrubber = new client.Scrubber(fakeContext(), test_rules);
             assert.equal(scrubber.rules.length, 0);
         });
         it('should not scrub when there are no rules defined', function() {
@@ -531,7 +531,7 @@ describe('Azure Log Monitoring', function() {
             test_rules = {};
             expected =
                 'client_ip: 12.123.23.12, client_ip2: 122.123.213.112 email: cdadamo@datadoghq.com email2: claudia@datadoghq.com';
-            var scrubber = new client.Scrubber(fakeContext(), test_rules);
+            scrubber = new client.Scrubber(fakeContext(), test_rules);
             actual = scrubber.scrub(
                 'client_ip: 12.123.23.12, client_ip2: 122.123.213.112 email: cdadamo@datadoghq.com email2: claudia@datadoghq.com'
             );


### PR DESCRIPTION
### What does this PR do?
Scrubs PII in the azure log forwarder, doing something similar to what the AWS log forwarder does: https://github.com/DataDog/datadog-serverless-functions/blob/master/aws/logs_monitoring/lambda_function.py

Leaves common rules (redact IP and redact email) commented out, and customers can uncomment them as they would like. With them commented, nothing will be scrubbed. They can also add new rules to this if they want to enable custom scrubbing.

### Motivation
Give customers more customizable control over their Azure logs

### Testing Guidelines
Confirmed that ip address and emails were scrubbed appropriately with it enabled, or left alone by default. Examples:
![image](https://user-images.githubusercontent.com/1701147/100762114-9c5d5880-33c1-11eb-9af9-09f5bc6ee251.png)
![image](https://user-images.githubusercontent.com/1701147/100762147-a67f5700-33c1-11eb-9238-0d1fb0e1d2a6.png)


### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
