### PR TITLE
[azure] Handle provider-only resource IDs in log forwarder

### DIFF
--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -285,6 +285,7 @@ class EventhubLogForwarder {
     }
 
     createResourceIdArray(record) {
+        // Convert the resource ID in the record to an array, handling beginning/ending slashes
         var resourceId = record.resourceId.toLowerCase().split('/');
         if (resourceId[0] === '') {
             resourceId = resourceId.slice(1);
@@ -296,6 +297,7 @@ class EventhubLogForwarder {
     }
 
     isSource(resourceIdPart) {
+        // Determine if a section of a resource ID counts as a "source," in our case it means it starts with 'microsoft.'
         return resourceIdPart.startsWith('microsoft.') ? true : false;
     }
 
@@ -327,6 +329,7 @@ class EventhubLogForwarder {
                     resourceId[2] === 'providers' &&
                     this.isSource(resourceId[3])
                 ) {
+                    // handle provider-only resource IDs
                     metadata.source = this.formatSourceType(resourceId[3]);
                 } else {
                     metadata.tags.push('resource_group:' + resourceId[3]);

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -5,7 +5,7 @@
 
 var https = require('https');
 
-const VERSION = '0.2.0';
+const VERSION = '0.2.1';
 
 const STRING = 'string'; // example: 'some message'
 const STRING_ARRAY = 'string-array'; // example: ['one message', 'two message', ...]
@@ -298,7 +298,7 @@ class EventhubLogForwarder {
 
     isSource(resourceIdPart) {
         // Determine if a section of a resource ID counts as a "source," in our case it means it starts with 'microsoft.'
-        return resourceIdPart.startsWith('microsoft.') ? true : false;
+        return resourceIdPart.startsWith('microsoft.')
     }
 
     formatSourceType(sourceType) {

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -298,7 +298,7 @@ class EventhubLogForwarder {
 
     isSource(resourceIdPart) {
         // Determine if a section of a resource ID counts as a "source," in our case it means it starts with 'microsoft.'
-        return resourceIdPart.startsWith('microsoft.')
+        return resourceIdPart.startsWith('microsoft.');
     }
 
     formatSourceType(sourceType) {

--- a/azure/test/client.test.js
+++ b/azure/test/client.test.js
@@ -292,6 +292,22 @@ describe('Azure Log Monitoring', function() {
                 this.forwarder.extractMetadataFromResource(record)
             );
         });
+         it('should correctly parse provider-only resource ids', function() {
+            record = {
+                resourceId:
+                    '/SUBSCRIPTIONS/12345678-1234-ABCD-1234-1234567890AB/PROVIDERS/MICROSOFT.RECOVERYSERVICES/SOMETHING/SOMETHINGELSE'
+            };
+            expectedMetadata = {
+                tags: [
+                    'subscription_id:12345678-1234-abcd-1234-1234567890ab',
+                ],
+                source: 'azure.recoveryservices'
+            };
+            assert.deepEqual(
+                expectedMetadata,
+                this.forwarder.extractMetadataFromResource(record)
+            );
+        });
     });
 
     function testHandleJSONLogs(forwarder, logs, expected) {
@@ -439,11 +455,6 @@ describe('Azure Log Monitoring', function() {
         it('should replace microsoft with azure', function() {
             expected = 'azure.bleh';
             actual = this.forwarder.formatSourceType('microsoft.bleh');
-            assert.equal(actual, expected);
-        });
-        it('should return empty source', function() {
-            expected = '';
-            actual = this.forwarder.formatSourceType('something');
             assert.equal(actual, expected);
         });
     });

--- a/azure/test/client.test.js
+++ b/azure/test/client.test.js
@@ -292,15 +292,13 @@ describe('Azure Log Monitoring', function() {
                 this.forwarder.extractMetadataFromResource(record)
             );
         });
-         it('should correctly parse provider-only resource ids', function() {
+        it('should correctly parse provider-only resource ids', function() {
             record = {
                 resourceId:
                     '/SUBSCRIPTIONS/12345678-1234-ABCD-1234-1234567890AB/PROVIDERS/MICROSOFT.RECOVERYSERVICES/SOMETHING/SOMETHINGELSE'
             };
             expectedMetadata = {
-                tags: [
-                    'subscription_id:12345678-1234-abcd-1234-1234567890ab',
-                ],
+                tags: ['subscription_id:12345678-1234-abcd-1234-1234567890ab'],
                 source: 'azure.recoveryservices'
             };
             assert.deepEqual(


### PR DESCRIPTION
### What does this PR do?
Adds logic to parse resource IDs that just have the 'providers' section, without a resource group. This seems to only be a problem for azure.recoveryservices sources, and currently they fall back to the 'azure' source if they don't work but this change makes these logs more consistent.

### Motivation
Improving azure log forwarder

### Testing Guidelines
Tested by sending a test request with a resource ID that I'd expect to be parsed and confirmed that it parsed correctly. Also updated and ran unit tests.

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
