### PR TITLE
included note in documentation to avoid scenarios where customers are…

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -31,6 +31,8 @@ Once installed, you can subscribe the Forwarder to log sources, such as S3 bucke
 5. Set up triggers to the installed Forwarder either [automatically](https://docs.datadoghq.com/integrations/amazon_web_services/?tab=allpermissions#automatically-setup-triggers) or [manually](https://docs.datadoghq.com/integrations/amazon_web_services/?tab=allpermissions#manually-setup-triggers).
 6. Repeat the above steps in another region if you operate in multiple AWS regions.
 
+**Note:** If you had previously enabled your AWS Integration using the following [CloudFormation template](https://github.com/DataDog/cloudformation-template/tree/master/aws) from your AWS integration tile in Datadog, your account should already be provisioned with a Datadog Lambda Forwarder function.
+
 <!-- xxz tab xxx -->
 <!-- xxx tab "Terraform" xxx -->
 


### PR DESCRIPTION
… creating duplicate forwarder functions.

<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Adds a note to the documentation, about the use of multiple CloudFormation templates in Datadog. Specifically this note is aimed to address the issue where customers create multiple Datadog Forwarder functions from the CloudFormation provided in this repo and from the docs for the [AWS integration](https://docs.datadoghq.com/integrations/amazon_web_services/?tab=automaticcloudformation#setup) ([repo](https://github.com/DataDog/cloudformation-template/tree/master/aws))

### Motivation
This comes off the back of a support case raised by a customer who was seeing CloudTrail logs dropped as a result of multiple Forwarder functions present in their environment. The issue was resolved by reimplementing the customer's Datadog resources in their AWS environment.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
