### PR TITLE
Clarify Code Signing Documentation

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -275,9 +275,7 @@ The CloudFormation Stack creates following IAM roles:
 
 ## Code Signing
 
-The Datadog Forwarder is signed by Datadog. You can verify the integrity of the Forwarder by [creating a Code Signing Configuration](https://docs.aws.amazon.com/lambda/latest/dg/configuration-codesigning.html#config-codesigning-config-console) that includes Datadog’s Signing Profile ARN (`arn:aws:signer:us-east-1:464622532012:/signing-profiles/DatadogLambdaSigningProfile/9vMI9ZAGLc`) and associating it with the Forwarder Lambda function.
-
-If you would like to verify the integrity of the Forwarder before you install it, please use the manual installation method and add the Code Signing Configuration to the Lambda function before uploading the Forwarder ZIP file. 
+The Datadog Forwarder is signed by Datadog. If you would like to verify the integrity of the Forwarder, please use the manual installation method. [Create a Code Signing Configuration](https://docs.aws.amazon.com/lambda/latest/dg/configuration-codesigning.html#config-codesigning-config-console) that includes Datadog’s Signing Profile ARN (`arn:aws:signer:us-east-1:464622532012:/signing-profiles/DatadogLambdaSigningProfile/9vMI9ZAGLc`) and associate it with the Forwarder Lambda function before uploading the Forwarder ZIP file. 
 
 ## CloudFormation Parameters
 


### PR DESCRIPTION
The previous wording implied that associating a Code Signing Configuration with the Lambda function after deploying it would verify the integrity of the Forwarder. Because code signing checks only occur at deploy time, this is not the case. The only way to verify the integrity of the Forwarder is to use the manual installation method and associate a Code Signing Configuration with the Lambda function before uploading the ZIP file.

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
