### PR TITLE
Fix `function_arn` tag typo for metrics and release and installation scripts

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -648,7 +648,7 @@ def extract_metric(event):
         lambda_log_arn = lambda_log_metadata.get("arn")
 
         if lambda_log_arn:
-            metric["t"] += [f"funtion_arn:{lambda_log_arn.lower()}"]
+            metric["t"] += [f"function_arn:{lambda_log_arn.lower()}"]
 
         metric["t"] += event[DD_CUSTOM_TAGS].split(",")
         return metric

--- a/aws/logs_monitoring/release.sh
+++ b/aws/logs_monitoring/release.sh
@@ -145,4 +145,5 @@ echo
 echo "Forwarder release process complete!"
 if [ "$ACCOUNT" = "prod" ] ; then
     echo "Don't forget to add release notes in GitHub!"
-else
+fi
+

--- a/aws/logs_monitoring/tools/installation_test.sh
+++ b/aws/logs_monitoring/tools/installation_test.sh
@@ -21,9 +21,7 @@ RUN_ID=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c10)
 DD_API_KEY=RUN_ID
 
 CURRENT_VERSION="$(grep -o 'Version: \d\+\.\d\+\.\d\+' template.yaml | cut -d' ' -f2)"
-echo $CURRENT_VERSION
-echo $CURRENT_VERSION
-echo $CURRENT_VERSION
+
 # Make sure we aren't trying to do anything on Datadog's production account. We don't want our
 # integration tests to accidentally release a new version of the forwarder
 AWS_ACCOUNT="$(aws sts get-caller-identity --query Account --output text)"

--- a/aws/logs_monitoring/tools/installation_test.sh
+++ b/aws/logs_monitoring/tools/installation_test.sh
@@ -20,8 +20,10 @@ RUN_ID=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c10)
 # Since we never run the log forwarder, api key can be anything.
 DD_API_KEY=RUN_ID
 
-CURRENT_VERSION="$(grep -o 'Version: \d\+\.\d\+\.\d\+' template.yaml | cut -d' ' -f2)-staging-${RUN_ID}"
-
+CURRENT_VERSION="$(grep -o 'Version: \d\+\.\d\+\.\d\+' template.yaml | cut -d' ' -f2)"
+echo $CURRENT_VERSION
+echo $CURRENT_VERSION
+echo $CURRENT_VERSION
 # Make sure we aren't trying to do anything on Datadog's production account. We don't want our
 # integration tests to accidentally release a new version of the forwarder
 AWS_ACCOUNT="$(aws sts get-caller-identity --query Account --output text)"
@@ -31,7 +33,7 @@ if [ "$AWS_ACCOUNT" = "464622532012" ] ; then
 fi
 
 # Run script in this process. This gives us TEMPLATE_URL and FORWARDER_SOURCE_URL env vars
-. release.sh datadog-cloudformation-template-staging $CURRENT_VERSION
+. release.sh $CURRENT_VERSION sandbox
 
 function param {
     KEY=$1

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_lambda_invocation.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_lambda_invocation.json~snapshot
@@ -990,7 +990,7 @@
               "cold_start:false",
               "memorysize:128",
               "runtime:nodejs12.x",
-              "funtion_arn:arn:aws:lambda:us-east-1:0000000000:function:hello-dog-node-dev-hello12x",
+              "function_arn:arn:aws:lambda:us-east-1:0000000000:function:hello-dog-node-dev-hello12x",
               "forwardername:test",
               "forwarder_memorysize:1536",
               "forwarder_version:<redacted from snapshot>",
@@ -1011,7 +1011,7 @@
             "points": "<redacted from snapshot>",
             "tags": [
               "dd_lambda_layer:datadog-nodev12.14.1",
-              "funtion_arn:arn:aws:lambda:us-east-1:0000000000:function:hello-dog-node-dev-hello12x",
+              "function_arn:arn:aws:lambda:us-east-1:0000000000:function:hello-dog-node-dev-hello12x",
               "forwardername:test",
               "forwarder_memorysize:1536",
               "forwarder_version:<redacted from snapshot>",


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Fixes `function_arn` tag for metrics, release and installation scripts

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [X] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [X] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [X] This PR passes the integration tests (ask a Datadog member to run the tests)
- [X] This PR passes the unit tests 
- [X] This PR passes the installation tests (ask a Datadog member to run the tests)
