### PR TITLE
[RDS EH] Add more options for passing in API key

### DIFF
--- a/aws/rds_enhanced_monitoring/README.md
+++ b/aws/rds_enhanced_monitoring/README.md
@@ -196,6 +196,8 @@ d. **Not Recommended**: Plaintext
 
    - Set the relevant environment variable with the API key payload you generated in step 1.
 
+   - If you use Datadog's EU platform, set the environment variable `DD_SITE` to `datadoghq.eu`
+
 2. Subscribe to the appropriate log stream.
 
 # How to update the zip file for the AWS Serverless Apps

--- a/aws/rds_enhanced_monitoring/README.md
+++ b/aws/rds_enhanced_monitoring/README.md
@@ -133,14 +133,35 @@ Process a RDS enhanced monitoring DATA_MESSAGE, coming from CLOUDWATCH LOGS
 
 # Setup
 
-1. Create a KMS key for the Datadog API key and app key
-   - Create a KMS key. Refer to the [AWS KMS Creating Keys][1] documentation for step by step instructions.
-   - Encrypt the token using the AWS CLI. `aws kms encrypt --key-id alias/<KMS key name> --plaintext '{"api_key":"<dd_api_key>", "app_key":"<dd_app_key>"}'`
-   - Make sure to save the base-64 encoded, encrypted key (`CiphertextBlob`). This is used for the `KMS_ENCRYPTED_KEYS` variable in all lambda functions.
-   - Optional: set the environment variable `DD_SITE` to `datadoghq.eu` to automatically forward data to your EU platform.
+#### Encrypt Your Datadog API Key
 
-2. Create and configure a lambda function
-   - In the AWS Console, create a `lambda_execution` policy, with the following policy:
+Before configuring your Lambda, first choose one of the following options to encrypt your Datadog API key.
+
+a. **Recommended**: AWS KMS
+   1. Refer to the [AWS KMS Creating Keys][1] documentation for step by step instructions on creating a key.
+   2. Encrypt your API key using the AWS CLI.
+   `aws kms encrypt --key-id alias/<KMS key name> --plaintext '<dd_api_key>'`
+   3. Store the `CiphertextBlob` as the `DD_KMS_API_KEY` environment variable in the next section.
+
+b. AWS Secrets Manager
+   1. Create a plaintext secret in AWS Secrets Manager using your API key as the value
+   2. Store the ARN of the secret as the `DD_API_KEY_SECRET_ARN` environment variable
+
+c. AWS SSM
+   1.  Create a parameter in AWS SSM using your API key as the value
+   2.  Store the Name of the parameter as the `DD_API_KEY_SSM_NAME` environment variable
+
+d. **Not Recommended**: Plaintext
+   1. Set your API key in plaintext as the `DD_API_KEY` environment variable.
+   2. This flow is insecure and not recommended for production use cases.
+
+#### Create the Lambda Function
+
+1. Create and configure a lambda function
+   - In the AWS Console, create a `lambda_execution` policy, with the following policy. If
+     you chose an option other than KMS above, substitute the KMS statement with the
+     appropriate permission for the service you used.
+
      ```
      {
         "Version": "2012-10-17",
@@ -171,10 +192,11 @@ Process a RDS enhanced monitoring DATA_MESSAGE, coming from CLOUDWATCH LOGS
 
    - Create a lambda function: skip the blueprint, name it `functionname`, set the runtime to `Python 3.7`, the handle to `lambda_function.lambda_handler`, and the role to `lambda_execution`.
 
-   - Copy the content of `functionname/lambda_function.py` in the code section, and make sure to update the `KMS_ENCRYPTED_KEYS` environment variable with the encrypted key generated in step 1.
+   - Copy the content of `functionname/lambda_function.py` in the code section
 
-3. Subscribe to the appropriate log stream.
+   - Set the relevant environment variable with the API key payload you generated in step 1.
 
+2. Subscribe to the appropriate log stream.
 
 # How to update the zip file for the AWS Serverless Apps
 

--- a/aws/rds_enhanced_monitoring/lambda_function.py
+++ b/aws/rds_enhanced_monitoring/lambda_function.py
@@ -53,7 +53,7 @@ def _datadog_keys():
         DD_API_KEY = os.environ['DD_API_KEY']
         return {'api_key': DD_API_KEY}
 
-    raise ValueError("Datadog API key is not defined, see documentation for ")
+    raise ValueError("Datadog API key is not defined, see documentation for environment variable options")
 
 
 # Preload the keys so we can bail out early if they're misconfigured

--- a/aws/rds_enhanced_monitoring/lambda_function.py
+++ b/aws/rds_enhanced_monitoring/lambda_function.py
@@ -15,16 +15,48 @@ from urllib.parse import urlencode
 import boto3
 
 
-DD_SITE = os.getenv("DD_SITE", default="datadoghq.com")
+DD_SITE = os.getenv('DD_SITE', default='datadoghq.com')
 
-# retrieve datadog options from KMS
-KMS_ENCRYPTED_KEYS = os.environ['kmsEncryptedKeys']
-kms = boto3.client('kms')
-datadog_keys = json.loads(kms.decrypt(
-    CiphertextBlob=base64.b64decode(KMS_ENCRYPTED_KEYS),
-    EncryptionContext={'LambdaFunctionName': os.environ['AWS_LAMBDA_FUNCTION_NAME']}
-)['Plaintext'])
 
+def _datadog_keys():
+    if 'kmsEncryptedKeys' in os.environ:
+        KMS_ENCRYPTED_KEYS = os.environ['kmsEncryptedKeys']
+        kms = boto3.client('kms')
+        return json.loads(kms.decrypt(
+            CiphertextBlob=base64.b64decode(KMS_ENCRYPTED_KEYS),
+            EncryptionContext={'LambdaFunctionName': os.environ['AWS_LAMBDA_FUNCTION_NAME']}
+        )['Plaintext'])
+
+    if 'DD_API_KEY_SECRET_ARN' in os.environ:
+        SECRET_ARN = os.environ['DD_API_KEY_SECRET_ARN']
+        DD_API_KEY = boto3.client('secretsmanager').get_secret_value(SecretId=SECRET_ARN)['SecretString']
+        return {'api_key': DD_API_KEY}
+
+    if 'DD_API_KEY_SSM_NAME' in os.environ:
+        SECRET_NAME = os.environ['DD_API_KEY_SSM_NAME']
+        DD_API_KEY = boto3.client('ssm').get_parameter(
+            Name=SECRET_NAME, WithDecryption=True
+        )['Parameter']['Value']
+        return {'api_key': DD_API_KEY}
+
+    if 'DD_KMS_API_KEY' in os.environ:
+        ENCRYPTED = os.environ['DD_KMS_API_KEY']
+        DD_API_KEY = boto3.client('kms').decrypt(
+            CiphertextBlob=base64.b64decode(ENCRYPTED)
+        )['Plaintext']
+        if type(DD_API_KEY) is bytes:
+            DD_API_KEY = DD_API_KEY.decode('utf-8')
+        return {'api_key': DD_API_KEY}
+
+    if 'DD_API_KEY' in os.environ:
+        DD_API_KEY = os.environ['DD_API_KEY']
+        return {'api_key': DD_API_KEY}
+
+    raise ValueError("Datadog API key is not defined, see documentation for ")
+
+
+# Preload the keys so we can bail out early if they're misconfigured
+datadog_keys = _datadog_keys()
 print('INFO Lambda function initialized, ready to send metrics')
 
 

--- a/aws/rds_enhanced_monitoring/lambda_function.py
+++ b/aws/rds_enhanced_monitoring/lambda_function.py
@@ -24,7 +24,7 @@ def _datadog_keys():
         kms = boto3.client('kms')
         return json.loads(kms.decrypt(
             CiphertextBlob=base64.b64decode(KMS_ENCRYPTED_KEYS),
-            EncryptionContext={'LambdaFunctionName': os.environ['AWS_LAMBDA_FUNCTION_NAME']}
+            EncryptionContext={'LambdaFunctionName': os.environ['AWS_LAMBDA_FUNCTION_NAME']},
         )['Plaintext'])
 
     if 'DD_API_KEY_SECRET_ARN' in os.environ:
@@ -42,7 +42,8 @@ def _datadog_keys():
     if 'DD_KMS_API_KEY' in os.environ:
         ENCRYPTED = os.environ['DD_KMS_API_KEY']
         DD_API_KEY = boto3.client('kms').decrypt(
-            CiphertextBlob=base64.b64decode(ENCRYPTED)
+            CiphertextBlob=base64.b64decode(ENCRYPTED),
+            EncryptionContext={'LambdaFunctionName': os.environ['AWS_LAMBDA_FUNCTION_NAME']},
         )['Plaintext']
         if type(DD_API_KEY) is bytes:
             DD_API_KEY = DD_API_KEY.decode('utf-8')


### PR DESCRIPTION
### What does this PR do?

This is carried from a lovely contribution over in https://github.com/DataDog/datadog-serverless-functions/pull/345. 

Currently, the RDS Enhanced Monitoring Lambda can only accept the necessary Datadog API key through an encrypted payload provided under the `kmsEncryptedKeys` environment variable. This PR adds the following options, with implementation matching what's used in the log forwarder:

- `DD_API_KEY_SECRET_ARN` - an ARN in AWS Secrets Manager
- `DD_API_KEY_SSM_NAME` - a name of a secret in AWS Systems Manager
- `DD_KMS_API_KEY` - a key directly encrypted through KMS. This is differentiated from the original `kmsEncryptedKeys` payload in that this one is not wrapped in a JSON object
- `DD_API_KEY` - the key in plaintext (not recommended for production use cases)

Note that using the Secrets Manager or Systems Manager methods requires permissions that are not currently added by default through the normal setup process for this Lambda, not sure whether those should be included or left to the implementer.

### Motivation

### Testing Guidelines

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
