### PR TITLE
add DatadogForwarderZipCopierArn output to aws log_monitoring

### DIFF
--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -726,6 +726,15 @@ Outputs:
     Export:
       Name:
         Fn::Sub: ${AWS::StackName}-ForwarderArn
+  DatadogForwarderZipCopierArn:
+    Description: Datadog Forwarder Zip Copier Lambda Function ARN
+    Value:
+      Fn::GetAtt:
+        - ForwarderZipCopier
+        - Arn
+    Export:
+      Name:
+        Fn::Sub: ${AWS::StackName}-ForwarderZipCopierArn
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

This adds a `DatadogForwarderZipCopierArn` output to match the existing `DatadogForwarderArn`

### Motivation

I'm currently setting up a terraform role with cloudtrail and it would be _amazing_ if I didn't have to manually setup the trigger.

### Testing Guidelines

I did not test this.

### Additional Notes

I wrote this in GitHub editor online, _but_ it looks right.

### Types of changes

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [X] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
