### PR TITLE
Migrate to use py3.3 unittest.mock library

### DIFF
--- a/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
@@ -1,10 +1,10 @@
 import unittest
-import mock
 import os
 from time import time
 from botocore.exceptions import ClientError
 
 from unittest.mock import patch
+from unittest import mock
 
 from enhanced_lambda_metrics import (
     sanitize_aws_tag_string,

--- a/aws/logs_monitoring/tests/test_extract_metric.py
+++ b/aws/logs_monitoring/tests/test_extract_metric.py
@@ -1,4 +1,4 @@
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 import os
 import sys
 import unittest

--- a/aws/logs_monitoring/tests/test_invoke_additional_target_lambdas.py
+++ b/aws/logs_monitoring/tests/test_invoke_additional_target_lambdas.py
@@ -1,4 +1,4 @@
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 import os
 import sys
 import unittest

--- a/aws/logs_monitoring/tests/test_parse_event_source.py
+++ b/aws/logs_monitoring/tests/test_parse_event_source.py
@@ -1,4 +1,4 @@
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 import os
 import sys
 import unittest


### PR DESCRIPTION
### What does this PR do?

The code refers to the `mock` library which is not defined in setup.py and as merged in python 3.3 standard library.
I changeed the code to use `unittest.mock` (from the standard library) instead of depending on an additional external one(`mock`).

### Motivation

I tried running the current unittests in python 3.8 and they all failed to import errors.

### Testing Guidelines

Tests should run in a virtualenv without having to execute `pip install mock` beforehand.

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [X] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
