### PR TITLE
[VPC] Optionally support EncryptionContext

### DIFF
--- a/aws/vpc_flow_log_monitoring/lambda_function.py
+++ b/aws/vpc_flow_log_monitoring/lambda_function.py
@@ -37,10 +37,7 @@ except botocore.exceptions.ClientError:
         CiphertextBlob=b64decode(KMS_ENCRYPTED_KEYS),
     )['Plaintext']
 
-try:
-    datadog_keys = json.loads(decrypted)
-except ValueError:
-    datadog_keys = json.loads()
+datadog_keys = json.loads(decrypted)
 
 # Alternatively set datadog keys directly
 # datadog_keys = {


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Fix for issue reported in https://github.com/DataDog/datadog-serverless-functions/issues/410. Creating the `kmsEncryptedKeys` payload through the Lambda console will result in it being created with an `EncryptionContext` matching the Lambda function's name. This `EncryptionContext`, if used, must also be used when decrypting the key in the Lambda.

This PR changes the VPC Flow Logs Lambda so that it will accept `kmsEncryptedKeys` payloads encrypted with or without the `EncryptionContext`. This should be backwards compatible with any previous `kmsEncryptedKeys` used with this function.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
