### PR TITLE
Do not hard code s3 ARN

### DIFF
--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -607,8 +607,8 @@ Resources:
               - s3:*
             Effect: Deny
             Resource:
-              - !Sub "arn:aws:s3:::${ForwarderBucket}"
-              - !Sub "arn:aws:s3:::${ForwarderBucket}/*"
+              - !Sub "${ForwarderBucket.Arn}"
+              - !Sub "${ForwarderBucket.Arn}/*"
             Condition:
               Bool:
                 "aws:SecureTransport": "false"


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

The hard-coded s3 bucket ARNs do not work for GovCloud AWS accounts. Instead, we should let CloudFormation resolve the correct ARN value on its own.

### Motivation

Support the forwarder installation in GovCloud AWS accounts.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [x] This PR passes the installation tests (ask a Datadog member to run the tests)
