### PR TITLE
Allow invocation from CW events and SNS

### DIFF
--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -569,6 +569,24 @@ Resources:
       Action: lambda:InvokeFunction
       Principal: "s3.amazonaws.com"
       SourceAccount: !Ref "AWS::AccountId"
+  SNSPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref "Forwarder"
+      Action: lambda:InvokeFunction
+      Principal: "sns.amazonaws.com"
+      SourceAccount: !Ref "AWS::AccountId"
+  CloudWatchEventsPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref "Forwarder"
+      Action: lambda:InvokeFunction
+      Principal:
+        Fn::If:
+          - IsAWSChina
+          - "events.amazonaws.com.cn"
+          - "events.amazonaws.com"
+      SourceAccount: !Ref "AWS::AccountId"
   LogGroup:
     Type: AWS::Logs::LogGroup
     Properties:


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Add the permission to allow invocations from any SNS topic or CloudWatch events rule, similar to the existing permissions that allow invocations from s3 and CloudWatch logs. 

### Motivation

Today to send logs from SNS and CW events, you have to create a subscription and _add a permission on the forwarder Lambda to allow the invocation from SNS or CW events_. With this PR, the customer only needs to create the subscription (trigger) of the forwarder onto the log source, and no longer need to worry about adding the permission to allow the source to invoke the forwarder. Another benefit is that because the forwarder is managed by CloudFormation, adding the permission out of the CFN introduces drifts and risks losing the permissions when updating/recreating the stack.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
