### PR TITLE
Add debug logs for the logs filtering feature

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -292,6 +292,8 @@ The Datadog Forwarder is signed by Datadog. If you would like to verify the inte
 - `IncludeAtMatch` - Only send logs matching the supplied regular expression and not excluded by
   ExcludeAtMatch. Note, using inefficient regular expression, such as `.*`, may slow down the Lambda function.
 
+**Note:** To debug these regular expressions against your logs, turn on [debug logs](#troubleshooting).
+
 ### Advanced (Optional)
 
 - `SourceZipUrl` - DO NOT CHANGE unless you know what you are doing. Override the default location of

--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -286,13 +286,13 @@ The Datadog Forwarder is signed by Datadog. If you would like to verify the inte
 ### Log Filtering (Optional)
 
 - `ExcludeAtMatch` - DO NOT send logs matching the supplied regular expression. If a log matches both
-  the ExcludeAtMatch and IncludeAtMatch, it is excluded. Filtering rules are applied to the full
-  JSON-formatted log, including any metadata that is automatically added by the function. Note, using
-  inefficient regular expression, such as `.*`, may slow down the Lambda function.
+  the ExcludeAtMatch and IncludeAtMatch, it is excluded.
 - `IncludeAtMatch` - Only send logs matching the supplied regular expression and not excluded by
-  ExcludeAtMatch. Note, using inefficient regular expression, such as `.*`, may slow down the Lambda function.
+  ExcludeAtMatch.
 
-**Note:** To debug these regular expressions against your logs, turn on [debug logs](#troubleshooting).
+Filtering rules are applied to the full JSON-formatted log, including any metadata that is automatically
+added by the Forwarder. Using an inefficient regular expression, such as `.*`, may slow down the Forwarder.
+To debug these regular expressions against your logs, turn on [debug logs](#troubleshooting).
 
 ### Advanced (Optional)
 

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -684,20 +684,25 @@ def filter_logs(logs):
     If no filtering rules exist, return all the logs.
     """
     if INCLUDE_AT_MATCH is None and EXCLUDE_AT_MATCH is None:
-        # convert to strings
         return logs
     # Add logs that should be sent to logs_to_send
     logs_to_send = []
-    # Test each log for exclusion and inclusion, if the criteria exist
     for log in logs:
+        if EXCLUDE_AT_MATCH is not None or INCLUDE_AT_MATCH is not None:
+            logger.debug("Filtering log event:")
+            logger.debug(log)
         try:
             if EXCLUDE_AT_MATCH is not None:
                 # if an exclude match is found, do not add log to logs_to_send
+                logger.debug(f"Applying EXCLUDE_AT_MATCH: {exclude_regex}")
                 if re.search(exclude_regex, log):
+                    logger.debug("Exclude regex matched, excluding log event")
                     continue
             if INCLUDE_AT_MATCH is not None:
                 # if no include match is found, do not add log to logs_to_send
+                logger.debug(f"Applying INCLUDE_AT_MATCH: {include_regex}")
                 if not re.search(include_regex, log):
+                    logger.debug("Include regex did not match, excluding log event")
                     continue
             logs_to_send.append(log)
         except ScrubbingException:

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -694,13 +694,13 @@ def filter_logs(logs):
         try:
             if EXCLUDE_AT_MATCH is not None:
                 # if an exclude match is found, do not add log to logs_to_send
-                logger.debug(f"Applying EXCLUDE_AT_MATCH: {exclude_regex}")
+                logger.debug(f"Applying EXCLUDE_AT_MATCH: {EXCLUDE_AT_MATCH}")
                 if re.search(exclude_regex, log):
                     logger.debug("Exclude regex matched, excluding log event")
                     continue
             if INCLUDE_AT_MATCH is not None:
                 # if no include match is found, do not add log to logs_to_send
-                logger.debug(f"Applying INCLUDE_AT_MATCH: {include_regex}")
+                logger.debug(f"Applying INCLUDE_AT_MATCH: {INCLUDE_AT_MATCH}")
                 if not re.search(include_regex, log):
                     logger.debug("Include regex did not match, excluding log event")
                     continue


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Add debug logs for the logs filtering feature.

There is already a debug log line that logs the incoming event payload. However, the event payload goes through many processing steps before it is checked by the logs filtering logic. For example, CloudWatch logs arrive gzipped and base64 encoded. Before we filter the logs, we un-gzip them, base64 decode them, convert them to JSON, enrich them with numerous additional attributes, and convert them back to a string. So, the existing debug statement is not useful for testing the logs filtering feature.

### Motivation

Some customers have had difficulty finding a regular expression that works to filter their logs. This task is made more difficult by being unable to see exactly what is being tested against the regular expression.

### Testing Guidelines

I used the integration test suite.


### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
