### PR TITLE
DO NOT import requests from botocore

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -20,6 +20,7 @@ import ssl
 import logging
 from io import BytesIO, BufferedReader
 import time
+import requests
 from requests_futures.sessions import FuturesSession
 
 from datadog_lambda.wrapper import datadog_lambda_wrapper
@@ -62,17 +63,6 @@ from settings import (
 logger = logging.getLogger()
 logger.setLevel(logging.getLevelName(os.environ.get("DD_LOG_LEVEL", "INFO").upper()))
 
-try:
-    import requests
-except ImportError:
-    logger.error(
-        "Could not import the 'requests' package, please ensure the Datadog "
-        "Lambda Layer is installed. https://dtdg.co/forwarder-layer"
-    )
-    # Fallback to the botocore vendored version of requests, while ensuring
-    # customers have the Datadog Lambda Layer installed. The vendored version
-    # of requests is removed in botocore 1.13.x.
-    from botocore.vendored import requests
 
 # DD_API_KEY must be set
 if DD_API_KEY == "<YOUR_DATADOG_API_KEY>" or DD_API_KEY == "":


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Remove the fallback way to import requests from botocore. 

The Datadog Forwarder no longer depends on the `requests` module from `botocore.vendored` since `v2.3.2`, but the import statement was kept as a fallback to help customers upgrade their forwarders by copying the source code (that used to be the easiest way to upgrade until CloudFormation was adopted, see this [PR](https://github.com/DataDog/datadog-serverless-functions/pull/173)).

That fallback import statement will soon become [obsolete](https://aws.amazon.com/blogs/compute/upcoming-changes-to-the-python-sdk-in-aws-lambda/), and it probably triggered the communications (false alarms, since it's only a fallback) from AWS to customers.

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [x] This PR passes the installation tests (ask a Datadog member to run the tests)
