### PR TITLE
Azure Log Collection - Platform Logs - Add Host field from resourceID to Json Log

### DIFF
--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -276,11 +276,12 @@ class EventhubLogForwarder {
             ])
             .filter(Boolean)
             .join(',');
+        record['host'] = metadata.host;
         return record;
     }
 
     addTagsToStringLog(stringLog) {
-        var jsonLog = { message: stringLog };
+        var jsonLog = {message: stringLog};
         return this.addTagsToJsonLog(jsonLog);
     }
 
@@ -306,7 +307,7 @@ class EventhubLogForwarder {
     }
 
     extractMetadataFromResource(record) {
-        var metadata = { tags: [], source: '' };
+        var metadata = {tags: [], source: '', host: ''};
         if (
             record.resourceId === undefined ||
             typeof record.resourceId !== 'string'
@@ -341,6 +342,9 @@ class EventhubLogForwarder {
             }
             if (resourceId.length > 5 && this.isSource(resourceId[5])) {
                 metadata.source = this.formatSourceType(resourceId[5]);
+                const resourceName = resourceId[resourceId.length - 1];
+                metadata.host = resourceName;
+                metadata.tags.push('name:' + resourceName);
             }
         } else if (resourceId[0] === 'tenants') {
             if (resourceId.length > 3 && resourceId[3]) {
@@ -355,7 +359,7 @@ class EventhubLogForwarder {
     }
 }
 
-module.exports = async function(context, eventHubMessages) {
+module.exports = async function (context, eventHubMessages) {
     if (!DD_API_KEY || DD_API_KEY === '<DATADOG_API_KEY>') {
         context.log.error(
             'You must configure your API key before starting this function (see ## Parameters section)'


### PR DESCRIPTION
### What does this PR do?

Extract Azure resource name from resource id and add a host key with that value to the json log send to datadog.

### Motivation

Currently the Azure function script does not populate the Host field when sending the logs to datadog. Therefor in datadog logs one cannot search for a specific Azure PaaS resource, like p.e. ApplicationGateway, by name.

### Testing Guidelines

Deploy script to Azure Function App as described in https://docs.datadoghq.com/integrations/azure/?tab=azurecliv20#

### Additional Notes

### Types of changes

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [X] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
