### PR TITLE
Adding CloudFormation output with ARN of secret

### DIFF
--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -762,6 +762,14 @@ Outputs:
     Export:
       Name:
         Fn::Sub: ${AWS::StackName}-ForwarderArn
+  DdApiKeySecretArn:
+    Description: ARN of SecretsManager Secret with Datadog API Key
+    Value:
+      Ref: DdApiKeySecret
+    Export:
+      Name:
+        Fn::Sub: ${AWS::StackName}-ApiKeySecretArn
+    Condition: CreateDdApiKeySecret
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

This PR adds an output to the CloudFormation template for the Datadog Log Forwarder. The output contains the ARN of the SecretsManager secret (if created) which holds the Datadog API key.

### Motivation

The SecretsManager resource created by CloudFormation has a randomized suffix in the name. These random characters make it hard to integrate with other automation tools which require the exact ARN of the resource. Exporting the ARN allows integrations with other tools, such as Terraform, which require the secret ARN but only have access to the outputs of a stack. The template already exports the name of the Lambda function, so this change follows in a similar vein.

### Testing Guidelines
Syntax validation: run the following command inside the `aws/logs_monitoring` directory:
```
aws cloudformation validate-template --template-body file://template.yaml
```

#### New Stack & Secret
Create a new stack using the updated template in this PR, passing a dummy API key as a parameter:
```bash
aws cloudformation create-stack --stack-name datadog-log-forwarder --template-body file://template.yaml --parameters ParameterKey=DdApiKey,ParameterValue=SAMPLE_API_KEY --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND
```

Once the stack is ready, describe the stack and filter the outputs:
```bash
aws cloudformation describe-stacks --stack-name datadog-log-forwarder --query "Stacks[*].Outputs[?OutputKey=='DdApiKeySecretArn']"
```

The output shows the ARN of the newly created secret along with the remaining details (ARN redacted for security reasons):
```json
[
    {
        "OutputKey": "DdApiKeySecretArn",
        "OutputValue": "arn:aws:secretsmanager:eu-west-1:XXXXXXXXXXXX:secret:DdApiKeySecret-AAABBBCCCDDD-YYYYYY",
        "Description": "ARN of SecretsManager Secret with Datadog API Key",
        "ExportName": "datadog-log-forwarder-ApiKeySecretArn"
    }
]
```
#### New Stack, Existing Secret
Create a new stack with the template in the PR, but pass an existing SecretsManager secret as a parameter:
```bash
aws cloudformation create-stack --stack-name datadog-log-forwarder-existing-secret --template-body file://template.yaml --parameters ParameterKey=DdApiKey,ParameterValue=DUMMY ParameterKey=DdApiKeySecretArn,ParameterValue=arn:aws:secretsmanager:eu-west-1:XXXXXXXXXXXX:secret:DdApiKeySecret-AAABBBCCCDDD-YYYYYY  --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND
```

Once the stack is ready, describe the stack and attempt to filter the output for the secret. 
```bash
aws cloudformation describe-stacks --stack-name datadog-log-forwarder-existing-secret --query "Stacks[*].Outputs[?OutputKey=='DdApiKeySecretArn'][]"
```

The output shows empty because the parameter is not exported (conditional to creating the resource):
```json
[]
```

#### Updating Existing Stack
First, create (or locate) a new stack with the current published template. The stack must have created a SecretsManager secret.
```bash
aws cloudformation create-stack --stack-name datadog-log-forwarder-old --template-url https://datadog-cloudformation-template.s3.amazonaws.com/aws/forwarder/latest.yaml --parameters ParameterKey=DdApiKey,ParameterValue=SAMPLE_API_KEY --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND
```

Once the stack is created, update the stack with the template in this PR:
```bash
$ aws cloudformation update-stack --stack-name datadog-log-forwarder-old --template-body file://template.yaml --parameters ParameterKey=DdApiKey,UsePreviousValue=true --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND
```

Test for the parameter :
```bash
aws cloudformation describe-stacks --stack-name datadog-log-forwarder-old --query "Stacks[*].Outputs[?OutputKey=='DdApiKeySecretArn'][]"
```

The output:
```json
[
    {
        "OutputKey": "DdApiKeySecretArn",
        "OutputValue": "arn:aws:secretsmanager:eu-west-1:XXXXXXXXXXXX:secret:DdApiKeySecret-AAABBBCCCDDD-YYYYYY",
        "Description": "ARN of SecretsManager Secret with Datadog API Key",
        "ExportName": "datadog-log-forwarder-old-ApiKeySecretArn"
    }
]
```


### Additional Notes

Nothing else in the package has been changed in this PR.

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [x] This PR passes the installation tests (ask a Datadog member to run the tests)
