### PR TITLE
Set timeout on API Key validation request

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -74,9 +74,11 @@ if len(DD_API_KEY) != 32:
         "Please confirm that your API key is correct"
     )
 # Validate the API key
+logger.debug("Validating the Datadog API key")
 validation_res = requests.get(
     "{}/api/v1/validate?api_key={}".format(DD_API_URL, DD_API_KEY),
     verify=(not DD_SKIP_SSL_VALIDATION),
+    timeout=10,
 )
 if not validation_res.ok:
     raise Exception("The API key is not valid.")
@@ -376,6 +378,7 @@ def datadog_forwarder(event, context):
     """The actual lambda function entry point"""
     if logger.isEnabledFor(logging.DEBUG):
         logger.debug(f"Received Event:{json.dumps(event)}")
+        logger.debug(f"Forwarder version: {DD_FORWARDER_VERSION}")
 
     if DD_ADDITIONAL_TARGET_LAMBDAS:
         invoke_additional_target_lambdas(event)

--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -184,22 +184,26 @@ EXCLUDE_AT_MATCH = get_env_var("EXCLUDE_AT_MATCH", default=None)
 # DD API Key
 if "DD_API_KEY_SECRET_ARN" in os.environ:
     SECRET_ARN = os.environ["DD_API_KEY_SECRET_ARN"]
+    logger.debug(f"Fetching the Datadog API key from SecretsManager: {SECRET_ARN}")
     DD_API_KEY = boto3.client("secretsmanager").get_secret_value(SecretId=SECRET_ARN)[
         "SecretString"
     ]
 elif "DD_API_KEY_SSM_NAME" in os.environ:
     SECRET_NAME = os.environ["DD_API_KEY_SSM_NAME"]
+    logger.debug(f"Fetching the Datadog API key from SSM: {SECRET_NAME}")
     DD_API_KEY = boto3.client("ssm").get_parameter(
         Name=SECRET_NAME, WithDecryption=True
     )["Parameter"]["Value"]
 elif "DD_KMS_API_KEY" in os.environ:
     ENCRYPTED = os.environ["DD_KMS_API_KEY"]
+    logger.debug(f"Fetching the Datadog API key from KMS: {ENCRYPTED}")
     DD_API_KEY = boto3.client("kms").decrypt(
         CiphertextBlob=base64.b64decode(ENCRYPTED)
     )["Plaintext"]
     if type(DD_API_KEY) is bytes:
         DD_API_KEY = DD_API_KEY.decode("utf-8")
 elif "DD_API_KEY" in os.environ:
+    logger.debug("Fetching the Datadog API key from environment variable DD_API_KEY")
     DD_API_KEY = os.environ["DD_API_KEY"]
 
 # Strip any trailing and leading whitespace from the API key


### PR DESCRIPTION
### What does this PR do?

- Set timeout (10s) on the API key validation request, otherwise it might hangs forever in case of a network issue. With the timeout, it will raise an exception and the forwarder will be retried with the event again.
- Add additional debugging logs to help troubleshoot code that only runs on initialization/cold start.

### Motivation

https://github.com/DataDog/datadog-serverless-functions/issues/426

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [x] This PR passes the installation tests (ask a Datadog member to run the tests)
