### PR TITLE
Support using SSM parameters in RDS SAM template

### DIFF
--- a/aws/rds_enhanced_monitoring/rds-enhanced-sam-template.yaml
+++ b/aws/rds_enhanced_monitoring/rds-enhanced-sam-template.yaml
@@ -1,27 +1,92 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: 2010-09-09
 Transform: AWS::Serverless-2016-10-31
 Description: Pushes RDS Enhanced metrics to Datadog.
 Parameters:
   KMSKeyId:
     Type: String
-    Description: The id (final part of the key's ARN) of a KMS key used to encrypt and decrypt your Datadog API and App keys. 
+    Default: ""
+    Description: The id (final part of the key's ARN) of a KMS key used to encrypt and decrypt your Datadog API and App keys.
+  DdApiKeySsmName:
+    Type: String
+    Default: ""
+    Description: The path to your Datadog API key in SSM
+  DdSite:
+    Type: String
+    Default: datadoghq.com
+    Description: Define your Datadog Site to send data to. Possible values are `datadoghq.com`, `datadoghq.eu`, `us3.datadoghq.com` and `ddog-gov.com`.
+    AllowedPattern: .+
+    ConstraintDescription: DdSite is required
+  DdTags:
+    Type: String
+    Default: ""
+    Description: Add custom tags to metrics, comma-delimited string, no trailing comma, e.g., env:prod,stack:classic
+  FunctionName:
+    Type: String
+    Default: DatadogRdsEnhancedMetrics
+    Description: The Datadog RDS Enhanced Metrics Lambda function name. DO NOT change when updating an existing CloudFormation stack, otherwise the current function will be replaced and all the triggers will be lost.
+Conditions:
+  IsKmsEnabled: !Not
+    - !Equals
+      - !Ref KMSKeyId
+      - ""
+  IsSsmEnabled: !Not
+    - !Equals
+      - !Ref DdApiKeySsmName
+      - ""
+  SetDdTags: !Not
+    - !Equals
+        - !Ref DdTags
+        - ""
 Resources:
-  rdslambdaddfunction:
-    Type: 'AWS::Serverless::Function'
+  RdsEnhancedMetricsFunction:
+    Type: AWS::Serverless::Function
     Properties:
       Description: Pushes RDS Enhanced metrics to Datadog.
+      FunctionName: !Ref FunctionName
       Environment:
         Variables:
-          kmsEncryptedKeys: 'YOUR_KEY'
+          kmsEncryptedKeys: !If
+            - IsKmsEnabled
+            - "YOUR_KEY"
+            - Ref: AWS::NoValue
+          DD_API_KEY_SSM_NAME: !If
+            - IsSsmEnabled
+            - !Ref DdApiKeySsmName
+            - !Ref AWS::NoValue
+          DD_SITE: !Ref DdSite
+          DD_TAGS: !If
+            - SetDdTags
+            - Ref: DdTags
+            - Ref: AWS::NoValue
       Handler: lambda_function.lambda_handler
       MemorySize: 128
       Policies:
-        KMSDecryptPolicy:
-          KeyId: !Ref KMSKeyId
+        - !If
+          - IsKmsEnabled
+          - KMSDecryptPolicy:
+              KeyId: !Ref KMSKeyId
+          - !Ref AWS::NoValue
+        - !If
+          - IsSsmEnabled
+          - SSMParameterReadPolicy:
+              ParameterName: !Ref DdApiKeySsmName
+          - !Ref AWS::NoValue
       Runtime: python3.7
       Timeout: 10
-      KmsKeyArn:
-        !Sub
-          - 'arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/${keyId}'
-          - {keyId: !Ref KMSKeyId}
-    Type: AWS::Serverless::Function
+      KmsKeyArn: !If
+        - IsKmsEnabled
+        - !Sub
+          - "arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/${keyId}"
+          - keyId: !Ref KMSKeyId
+        - !Ref AWS::NoValue
+Outputs:
+  RdsEnhancedMetricsFunctionArn:
+    Description: Datadog RDS Enhanced Metrics Function ARN
+    Value:
+      Fn::GetAtt:
+        - RdsEnhancedMetricsFunction
+        - Arn
+    Export:
+      Name:
+        Fn::Sub: ${AWS::StackName}-RdsEnhancedMetricsFunctionArn
+		


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

While Datadog is in the AWS Serverless Application Repository, manual intervention is required to use the RDS Enhanced Metrics function (at least), in the form of updating the template.
Ideally this stack should be deployable without modification of the template, or the created resources. This PR adds the ability to pass in CF Parameters to define an SSM Parameter name that contains an API key. Naming has been updated to follow the convention in https://github.com/DataDog/datadog-serverless-functions/blob/master/aws/logs_monitoring/template.yaml.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->
We want to be able to deploy these AWS SAR applications via code, specifically using the terraform resource [serverlessapplicationrepository_cloudformation_stack](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/serverlessapplicationrepository_cloudformation_stack). This is not possible at the moment due to the template not being suitable for unattended deployment.

### Testing Guidelines

<!--- How did you test this pull request? --->
As AWS SAR applications are essentially a CloudFormation stack, this was tested by deploying a stack with this template, and setting values for the parameters added in this MR. The lambda `CodeUri` was copied from a stack created via the [AWS SAR console](https://serverlessrepo.aws.amazon.com/applications/arn:aws:serverlessrepo:us-east-1:464622532012:applications~Datadog-RDS-Enhanced)

### Additional Notes

<!--- Anything else we should know when reviewing? --->
Due to the manual intervention required when deploying this stack, it's highly unlikely that this template is used in automation, so shouldn't cause issues with updated naming.

Setup steps showing that manual intervention is required:

```
3. Once the application is deployed, open up the newly created Lambda Function.
4. Navigate to the Environment variables section. Replace YOUR_KEY with your Datadog API and APP key in the following format: '{"api_key":"<YOUR_API_KEY>"}'
5. Open the Encryption configuration section and select Enable helpers for encryption in transit.
6. In KMS key to encrypt in transit select the same key as the one below in KMS key to encrypt at rest.
7. Press the Encrypt button next to the JSON blob you just entered.
8. Go up and press Save.
```

I'm unsure of your workflow to take this template and upload it to AWS SAR as the current template doesn't contain `CodeUri`, any of the notes visible in the AWS Console, or a release script; if there's something that needs modification please let me know.
Is the duplicate `Type: AWS::Serverless::Function` intentional?


### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [x] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
