### PR TITLE
issue426-timeout-no-error - add boto3 timeout

### DIFF
--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -7,6 +7,7 @@ import base64
 import os
 
 import boto3
+import botocore.config
 import logging
 import re
 
@@ -181,23 +182,27 @@ SCRUBBING_RULE_CONFIGS = [
 INCLUDE_AT_MATCH = get_env_var("INCLUDE_AT_MATCH", default=None)
 EXCLUDE_AT_MATCH = get_env_var("EXCLUDE_AT_MATCH", default=None)
 
+# Set boto3 timeout
+boto3_config = botocore.config.Config(
+    connect_timeout=5, read_timeout=5, retries={"max_attempts": 2}
+)
 # DD API Key
 if "DD_API_KEY_SECRET_ARN" in os.environ:
     SECRET_ARN = os.environ["DD_API_KEY_SECRET_ARN"]
     logger.debug(f"Fetching the Datadog API key from SecretsManager: {SECRET_ARN}")
-    DD_API_KEY = boto3.client("secretsmanager").get_secret_value(SecretId=SECRET_ARN)[
-        "SecretString"
-    ]
+    DD_API_KEY = boto3.client("secretsmanager", config=boto3_config).get_secret_value(
+        SecretId=SECRET_ARN
+    )["SecretString"]
 elif "DD_API_KEY_SSM_NAME" in os.environ:
     SECRET_NAME = os.environ["DD_API_KEY_SSM_NAME"]
     logger.debug(f"Fetching the Datadog API key from SSM: {SECRET_NAME}")
-    DD_API_KEY = boto3.client("ssm").get_parameter(
+    DD_API_KEY = boto3.client("ssm", config=boto3_config).get_parameter(
         Name=SECRET_NAME, WithDecryption=True
     )["Parameter"]["Value"]
 elif "DD_KMS_API_KEY" in os.environ:
     ENCRYPTED = os.environ["DD_KMS_API_KEY"]
     logger.debug(f"Fetching the Datadog API key from KMS: {ENCRYPTED}")
-    DD_API_KEY = boto3.client("kms").decrypt(
+    DD_API_KEY = boto3.client("kms", config=boto3_config).decrypt(
         CiphertextBlob=base64.b64decode(ENCRYPTED)
     )["Plaintext"]
     if type(DD_API_KEY) is bytes:


### PR DESCRIPTION
settings.py add boto3 timeouts for aws info lookups

<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
<!--- A brief description of the change being made with this pull request. --->
Add boto3 timeout, in settings.py
This will throw a timeout error with the url used, rather that just sitting for the max lambda runtime and be killed by aws with no log output, when an aws endpoint is unreachable.

### Motivation
<!--- What inspired you to submit this pull request? --->
hard to debug datadog-serverless-function timeout issue, due to Private VPC aws endpoint being unreachable.



### Testing Guidelines
<!--- How did you test this pull request? --->
built it and deployed to aws.

### Additional Notes
<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ x ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [  x ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
