### PR TITLE
Add elasticsearch to source identification

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -1096,7 +1096,7 @@ def find_cloudwatch_source(log_group):
         "fargate",
         "cloudtrail",
         "msk",
-        "elasticsearch"
+        "elasticsearch",
     ]:
         if source in log_group:
             return source

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -1096,6 +1096,7 @@ def find_cloudwatch_source(log_group):
         "fargate",
         "cloudtrail",
         "msk",
+        "elasticsearch"
     ]:
         if source in log_group:
             return source

--- a/aws/logs_monitoring/tests/test_parse_event_source.py
+++ b/aws/logs_monitoring/tests/test_parse_event_source.py
@@ -198,7 +198,8 @@ class TestParseEventSource(unittest.TestCase):
 
     def test_elasticsearch_event(self):
         self.assertEqual(
-            parse_event_source({"awslogs": "logs"}, "/elasticsearch/domain"), "elasticsearch"
+            parse_event_source({"awslogs": "logs"}, "/elasticsearch/domain"),
+            "elasticsearch",
         )
 
     def test_msk_event(self):

--- a/aws/logs_monitoring/tests/test_parse_event_source.py
+++ b/aws/logs_monitoring/tests/test_parse_event_source.py
@@ -196,6 +196,11 @@ class TestParseEventSource(unittest.TestCase):
             "eks",
         )
 
+    def test_elasticsearch_event(self):
+        self.assertEqual(
+            parse_event_source({"awslogs": "logs"}, "/elasticsearch/domain"), "elasticsearch"
+        )
+
     def test_msk_event(self):
         self.assertEqual(
             parse_event_source(


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adds support for identifying the source of elasticsearch logs from Cloudwatch log groups

### Motivation

If forwarded to Datadog, the source identification for these currently defaults to `cloudwatch`

### Testing Guidelines

A new test for this case has been added.

### Additional Notes

Streaming logs from Elasticsearch to Cloudwatch requires the user creating the log group. This may change in the future if AWS creates it with the standard naming convention for log groups, e.g. `/aws/elasticsearch/domain` or `/aws/es/domain`

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
