### PR TITLE
Add tests, docs for log filtering

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -299,8 +299,11 @@ Some examples of regular expressions that can be used for log filtering:
 - Include (or exclude) Lambda platform logs: `^(START|REPORT|END)`
 - Include CloudTrail error messages only: `errorMessage`
 - Include only logs containing an HTTP 4XX or 5XX error code: `\b[4|5][0-9][0-9]\b`
+- Include only CloudWatch logs where the `message` field contains a specific JSON key/value pair: `\\"awsRegion\\":\\"us-east-1\\"`
+  - The message field of a CloudWatch log event is encoded as a string. `{awsRegion: "us-east-1"}` is encoded as `{\"awsRegion\":\"us-east-1\"}`.
+    The pattern you provide must therefore include extra `\` escape characters.
 
-To debug these regular expressions against your logs, turn on [debug logs](#troubleshooting).
+To test different patterns against your logs, turn on [debug logs](#troubleshooting).
 
 ### Advanced (Optional)
 

--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -287,11 +287,19 @@ The Datadog Forwarder is signed by Datadog. If you would like to verify the inte
 
 - `ExcludeAtMatch` - DO NOT send logs matching the supplied regular expression. If a log matches both
   the ExcludeAtMatch and IncludeAtMatch, it is excluded.
-- `IncludeAtMatch` - Only send logs matching the supplied regular expression and not excluded by
+- `IncludeAtMatch` - ONLY send logs matching the supplied regular expression, and not excluded by
   ExcludeAtMatch.
 
-Filtering rules are applied to the full JSON-formatted log, including any metadata that is automatically
-added by the Forwarder. Using an inefficient regular expression, such as `.*`, may slow down the Forwarder.
+Filtering rules are applied to the full JSON-formatted log, including any metadata that is automatically added by the Forwarder.
+However, transformations applied by [log pipelines](https://docs.datadoghq.com/logs/processing/pipelines/),
+which occur after logs are sent to Datadog, cannot be used to filter logs in the Forwarder.
+Using an inefficient regular expression, such as `.*`, may slow down the Forwarder.
+
+Some examples of regular expressions that can be used for log filtering:
+- Include (or exclude) Lambda platform logs: `^(START|REPORT|END)`
+- Include CloudTrail error messages only: `errorMessage`
+- Include only logs containing an HTTP 4XX or 5XX error code: `\b[4|5][0-9][0-9]\b`
+
 To debug these regular expressions against your logs, turn on [debug logs](#troubleshooting).
 
 ### Advanced (Optional)

--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -300,7 +300,7 @@ Some examples of regular expressions that can be used for log filtering:
 - Include CloudTrail error messages only: `errorMessage`
 - Include only logs containing an HTTP 4XX or 5XX error code: `\b[4|5][0-9][0-9]\b`
 - Include only CloudWatch logs where the `message` field contains a specific JSON key/value pair: `\\"awsRegion\\":\\"us-east-1\\"`
-  - The message field of a CloudWatch log event is encoded as a string. `{awsRegion: "us-east-1"}` is encoded as `{\"awsRegion\":\"us-east-1\"}`.
+  - The message field of a CloudWatch log event is encoded as a string. `{"awsRegion": "us-east-1"}` is encoded as `{\"awsRegion\":\"us-east-1\"}`.
     The pattern you provide must therefore include extra `\` escape characters.
 
 To test different patterns against your logs, turn on [debug logs](#troubleshooting).

--- a/aws/logs_monitoring/logs.py
+++ b/aws/logs_monitoring/logs.py
@@ -98,6 +98,7 @@ def compileRegex(rule, pattern):
                 "could not compile {} regex with pattern: {}".format(rule, pattern)
             )
 
+
 def filter_logs(logs, include_pattern=None, exclude_pattern=None):
     """
     Applies log filtering rules.
@@ -115,14 +116,14 @@ def filter_logs(logs, include_pattern=None, exclude_pattern=None):
             if exclude_pattern is not None:
                 # if an exclude match is found, do not add log to logs_to_send
                 logger.debug(f"Applying exclude pattern: {exclude_pattern}")
-                exclude_regex = compileRegex("EXCLUDE_AT_MATCH", EXCLUDE_AT_MATCH)
+                exclude_regex = compileRegex("EXCLUDE_AT_MATCH", exclude_pattern)
                 if re.search(exclude_regex, log):
                     logger.debug("Exclude pattern matched, excluding log event")
                     continue
             if include_pattern is not None:
                 # if no include match is found, do not add log to logs_to_send
                 logger.debug(f"Applying include pattern: {include_pattern}")
-                include_regex = compileRegex("INCLUDE_AT_MATCH", INCLUDE_AT_MATCH)
+                include_regex = compileRegex("INCLUDE_AT_MATCH", include_pattern)
                 if not re.search(include_regex, log):
                     logger.debug("Include pattern did not match, excluding log event")
                     continue

--- a/aws/logs_monitoring/logs.py
+++ b/aws/logs_monitoring/logs.py
@@ -98,11 +98,6 @@ def compileRegex(rule, pattern):
                 "could not compile {} regex with pattern: {}".format(rule, pattern)
             )
 
-
-include_regex = compileRegex("INCLUDE_AT_MATCH", INCLUDE_AT_MATCH)
-exclude_regex = compileRegex("EXCLUDE_AT_MATCH", EXCLUDE_AT_MATCH)
-
-
 def filter_logs(logs, include_pattern=None, exclude_pattern=None):
     """
     Applies log filtering rules.
@@ -120,12 +115,14 @@ def filter_logs(logs, include_pattern=None, exclude_pattern=None):
             if exclude_pattern is not None:
                 # if an exclude match is found, do not add log to logs_to_send
                 logger.debug(f"Applying exclude pattern: {exclude_pattern}")
+                exclude_regex = compileRegex("EXCLUDE_AT_MATCH", EXCLUDE_AT_MATCH)
                 if re.search(exclude_regex, log):
                     logger.debug("Exclude pattern matched, excluding log event")
                     continue
             if include_pattern is not None:
                 # if no include match is found, do not add log to logs_to_send
                 logger.debug(f"Applying include pattern: {include_pattern}")
+                include_regex = compileRegex("INCLUDE_AT_MATCH", INCLUDE_AT_MATCH)
                 if not re.search(include_regex, log):
                     logger.debug("Include pattern did not match, excluding log event")
                     continue

--- a/aws/logs_monitoring/logs.py
+++ b/aws/logs_monitoring/logs.py
@@ -48,7 +48,6 @@ class ScrubbingException(Exception):
 
 def forward_logs(logs):
     """Forward logs to Datadog"""
-    print("Forwarding logs!")
     if logger.isEnabledFor(logging.DEBUG):
         logger.debug(f"Forwarding {len(logs)} logs")
     logs_to_forward = filter_logs(list(map(json.dumps, logs)))

--- a/aws/logs_monitoring/logs.py
+++ b/aws/logs_monitoring/logs.py
@@ -50,7 +50,11 @@ def forward_logs(logs):
     """Forward logs to Datadog"""
     if logger.isEnabledFor(logging.DEBUG):
         logger.debug(f"Forwarding {len(logs)} logs")
-    logs_to_forward = filter_logs(list(map(json.dumps, logs)))
+    logs_to_forward = filter_logs(
+        list(map(json.dumps, logs)),
+        include_pattern=INCLUDE_AT_MATCH,
+        exclude_pattern=EXCLUDE_AT_MATCH,
+    )
     scrubber = DatadogScrubber(SCRUBBING_RULE_CONFIGS)
     if DD_USE_TCP:
         batcher = DatadogBatcher(256 * 1000, 256 * 1000, 1)
@@ -99,32 +103,31 @@ include_regex = compileRegex("INCLUDE_AT_MATCH", INCLUDE_AT_MATCH)
 exclude_regex = compileRegex("EXCLUDE_AT_MATCH", EXCLUDE_AT_MATCH)
 
 
-# should only be called when INCLUDE_AT_MATCH and/or EXCLUDE_AT_MATCH exist
-def filter_logs(logs):
+def filter_logs(logs, include_pattern=None, exclude_pattern=None):
     """
     Applies log filtering rules.
     If no filtering rules exist, return all the logs.
     """
-    if INCLUDE_AT_MATCH is None and EXCLUDE_AT_MATCH is None:
+    if include_pattern is None and exclude_pattern is None:
         return logs
     # Add logs that should be sent to logs_to_send
     logs_to_send = []
     for log in logs:
-        if EXCLUDE_AT_MATCH is not None or INCLUDE_AT_MATCH is not None:
+        if exclude_pattern is not None or include_pattern is not None:
             logger.debug("Filtering log event:")
             logger.debug(log)
         try:
-            if EXCLUDE_AT_MATCH is not None:
+            if exclude_pattern is not None:
                 # if an exclude match is found, do not add log to logs_to_send
-                logger.debug(f"Applying EXCLUDE_AT_MATCH: {EXCLUDE_AT_MATCH}")
+                logger.debug(f"Applying exclude pattern: {exclude_pattern}")
                 if re.search(exclude_regex, log):
-                    logger.debug("Exclude regex matched, excluding log event")
+                    logger.debug("Exclude pattern matched, excluding log event")
                     continue
-            if INCLUDE_AT_MATCH is not None:
+            if include_pattern is not None:
                 # if no include match is found, do not add log to logs_to_send
-                logger.debug(f"Applying INCLUDE_AT_MATCH: {INCLUDE_AT_MATCH}")
+                logger.debug(f"Applying include pattern: {include_pattern}")
                 if not re.search(include_regex, log):
-                    logger.debug("Include regex did not match, excluding log event")
+                    logger.debug("Include pattern did not match, excluding log event")
                     continue
             logs_to_send.append(log)
         except ScrubbingException:

--- a/aws/logs_monitoring/tests/test_logs.py
+++ b/aws/logs_monitoring/tests/test_logs.py
@@ -2,9 +2,6 @@ import unittest
 import os
 from unittest.mock import patch
 
-from logs import filter_logs
-
-
 class TestFilterLogs(unittest.TestCase):
     example_logs = [
         "START RequestId: ...",
@@ -22,6 +19,7 @@ class TestFilterLogs(unittest.TestCase):
         with patch.dict(os.environ, {
             "INCLUDE_AT_MATCH": r"\b[4|5][0-9][0-9]\b",
         }):
+            from logs import filter_logs
             filtered_logs = filter_logs(http_logs)
 
         self.assertEqual(filtered_logs, [
@@ -32,6 +30,7 @@ class TestFilterLogs(unittest.TestCase):
         with patch.dict(os.environ, {
             "INCLUDE_AT_MATCH": r"^(START|END)",
         }):
+            from logs import filter_logs
             filtered_logs = filter_logs(self.example_logs)
 
         self.assertEqual(filtered_logs, [
@@ -43,6 +42,7 @@ class TestFilterLogs(unittest.TestCase):
         with patch.dict(os.environ, {
             "EXCLUDE_AT_MATCH": r"^(START|END)",
         }):
+            from logs import filter_logs
             filtered_logs = filter_logs(self.example_logs)
 
         self.assertEqual(filtered_logs, [
@@ -55,6 +55,7 @@ class TestFilterLogs(unittest.TestCase):
             "EXCLUDE_AT_MATCH": r"^END",
             "INCLUDE_AT_MATCH": r"^(START|END)",
         }):
+            from logs import filter_logs
             filtered_logs = filter_logs(self.example_logs)
 
         self.assertEqual(filtered_logs, [
@@ -62,5 +63,6 @@ class TestFilterLogs(unittest.TestCase):
         ])
 
     def test_no_filtering_rules(self):
+        from logs import filter_logs
         filtered_logs = filter_logs(self.example_logs)
         self.assertEqual(filtered_logs, self.example_logs)

--- a/aws/logs_monitoring/tests/test_logs.py
+++ b/aws/logs_monitoring/tests/test_logs.py
@@ -1,0 +1,66 @@
+import unittest
+import os
+from unittest.mock import patch
+
+from logs import filter_logs
+
+
+class TestFilterLogs(unittest.TestCase):
+    example_logs = [
+        "START RequestId: ...",
+        "This is not a REPORT log",
+        "END RequestId: ...",
+        "REPORT RequestId: ...",
+    ]
+
+    def test_http_filtering(self):
+        http_logs = [
+            "This is a 500",
+            "This is a 200",
+        ]
+
+        with patch.dict(os.environ, {
+            "INCLUDE_AT_MATCH": r"\b[4|5][0-9][0-9]\b",
+        }):
+            filtered_logs = filter_logs(http_logs)
+
+        self.assertEqual(filtered_logs, [
+            "This is a 500",
+        ])
+
+    def test_include_at_match(self):
+        with patch.dict(os.environ, {
+            "INCLUDE_AT_MATCH": r"^(START|END)",
+        }):
+            filtered_logs = filter_logs(self.example_logs)
+
+        self.assertEqual(filtered_logs, [
+            "START RequestId: ...",
+            "END RequestId: ...",
+        ])
+
+    def test_exclude_at_match(self):
+        with patch.dict(os.environ, {
+            "EXCLUDE_AT_MATCH": r"^(START|END)",
+        }):
+            filtered_logs = filter_logs(self.example_logs)
+
+        self.assertEqual(filtered_logs, [
+            "This is not a REPORT log",
+            "REPORT RequestId: ...",
+        ])
+
+    def test_exclude_overrides_include(self):
+        with patch.dict(os.environ, {
+            "EXCLUDE_AT_MATCH": r"^END",
+            "INCLUDE_AT_MATCH": r"^(START|END)",
+        }):
+            filtered_logs = filter_logs(self.example_logs)
+
+        self.assertEqual(filtered_logs, [
+            "START RequestId: ...",
+        ])
+
+    def test_no_filtering_rules(self):
+        filtered_logs = filter_logs(self.example_logs)
+        self.assertEqual(filtered_logs, self.example_logs)

--- a/aws/logs_monitoring/tests/test_logs.py
+++ b/aws/logs_monitoring/tests/test_logs.py
@@ -15,7 +15,7 @@ class TestFilterLogs(unittest.TestCase):
     def test_json_filtering(self):
         json_logs = [r"\"awsRegion\":\"us-east-1\""]
 
-        filtered_logs = filter_logs(json_logs, include_pattern=r'\\"awsRegion\\":\\"us-east-1\\"'
+        filtered_logs = filter_logs(json_logs, include_pattern=r'\\"awsRegion\\":\\"us-east-1\\"')
 
         self.assertEqual(
             filtered_logs,

--- a/aws/logs_monitoring/tests/test_logs.py
+++ b/aws/logs_monitoring/tests/test_logs.py
@@ -2,7 +2,6 @@ import unittest
 
 from logs import filter_logs
 
-# \"awsRegion\":\"us-east-1\"
 
 class TestFilterLogs(unittest.TestCase):
     example_logs = [

--- a/aws/logs_monitoring/tests/test_logs.py
+++ b/aws/logs_monitoring/tests/test_logs.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import patch
 
-
+import settings
 class TestFilterLogs(unittest.TestCase):
     example_logs = [
         "START RequestId: ...",
@@ -16,7 +16,7 @@ class TestFilterLogs(unittest.TestCase):
             "This is a 200",
         ]
 
-        with patch.multiple("settings", INCLUDE_AT_MATCH=r"\b[4|5][0-9][0-9]\b"):
+        with patch.multiple(settings, INCLUDE_AT_MATCH=r"\b[4|5][0-9][0-9]\b"):
             from logs import filter_logs
 
             filtered_logs = filter_logs(http_logs)
@@ -29,7 +29,7 @@ class TestFilterLogs(unittest.TestCase):
         )
 
     def test_include_at_match(self):
-        with patch.multiple("settings", INCLUDE_AT_MATCH=r"^(START|END)"):
+        with patch.multiple(settings, INCLUDE_AT_MATCH=r"^(START|END)"):
             from logs import filter_logs
 
             filtered_logs = filter_logs(self.example_logs)
@@ -43,7 +43,7 @@ class TestFilterLogs(unittest.TestCase):
         )
 
     def test_exclude_at_match(self):
-        with patch.multiple("settings", EXCLUDE_AT_MATCH=r"^(START|END)"):
+        with patch.multiple(settings, EXCLUDE_AT_MATCH=r"^(START|END)"):
             from logs import filter_logs
 
             filtered_logs = filter_logs(self.example_logs)
@@ -58,7 +58,7 @@ class TestFilterLogs(unittest.TestCase):
 
     def test_exclude_overrides_include(self):
         with patch.multiple(
-            "settings", EXCLUDE_AT_MATCH=r"^END", INCLUDE_AT_MATCH=r"^(START|END)"
+            settings, EXCLUDE_AT_MATCH=r"^END", INCLUDE_AT_MATCH=r"^(START|END)"
         ):
             from logs import filter_logs
 

--- a/aws/logs_monitoring/tests/test_logs.py
+++ b/aws/logs_monitoring/tests/test_logs.py
@@ -1,6 +1,6 @@
 import unittest
-import os
 from unittest.mock import patch
+
 
 class TestFilterLogs(unittest.TestCase):
     example_logs = [
@@ -16,53 +16,63 @@ class TestFilterLogs(unittest.TestCase):
             "This is a 200",
         ]
 
-        with patch.dict(os.environ, {
-            "INCLUDE_AT_MATCH": r"\b[4|5][0-9][0-9]\b",
-        }):
+        with patch.multiple("settings", INCLUDE_AT_MATCH=r"\b[4|5][0-9][0-9]\b"):
             from logs import filter_logs
+
             filtered_logs = filter_logs(http_logs)
 
-        self.assertEqual(filtered_logs, [
-            "This is a 500",
-        ])
+        self.assertEqual(
+            filtered_logs,
+            [
+                "This is a 500",
+            ],
+        )
 
     def test_include_at_match(self):
-        with patch.dict(os.environ, {
-            "INCLUDE_AT_MATCH": r"^(START|END)",
-        }):
+        with patch.multiple("settings", INCLUDE_AT_MATCH=r"^(START|END)"):
             from logs import filter_logs
+
             filtered_logs = filter_logs(self.example_logs)
 
-        self.assertEqual(filtered_logs, [
-            "START RequestId: ...",
-            "END RequestId: ...",
-        ])
+        self.assertEqual(
+            filtered_logs,
+            [
+                "START RequestId: ...",
+                "END RequestId: ...",
+            ],
+        )
 
     def test_exclude_at_match(self):
-        with patch.dict(os.environ, {
-            "EXCLUDE_AT_MATCH": r"^(START|END)",
-        }):
+        with patch.multiple("settings", EXCLUDE_AT_MATCH=r"^(START|END)"):
             from logs import filter_logs
+
             filtered_logs = filter_logs(self.example_logs)
 
-        self.assertEqual(filtered_logs, [
-            "This is not a REPORT log",
-            "REPORT RequestId: ...",
-        ])
+        self.assertEqual(
+            filtered_logs,
+            [
+                "This is not a REPORT log",
+                "REPORT RequestId: ...",
+            ],
+        )
 
     def test_exclude_overrides_include(self):
-        with patch.dict(os.environ, {
-            "EXCLUDE_AT_MATCH": r"^END",
-            "INCLUDE_AT_MATCH": r"^(START|END)",
-        }):
+        with patch.multiple(
+            "settings", EXCLUDE_AT_MATCH=r"^END", INCLUDE_AT_MATCH=r"^(START|END)"
+        ):
             from logs import filter_logs
+
             filtered_logs = filter_logs(self.example_logs)
 
-        self.assertEqual(filtered_logs, [
-            "START RequestId: ...",
-        ])
+        self.assertEqual(
+            filtered_logs,
+            [
+                "START RequestId: ...",
+            ],
+        )
 
     def test_no_filtering_rules(self):
         from logs import filter_logs
+
         filtered_logs = filter_logs(self.example_logs)
         self.assertEqual(filtered_logs, self.example_logs)

--- a/aws/logs_monitoring/tests/test_logs.py
+++ b/aws/logs_monitoring/tests/test_logs.py
@@ -12,33 +12,6 @@ class TestFilterLogs(unittest.TestCase):
         "REPORT RequestId: ...",
     ]
 
-    def test_json_filtering(self):
-        json_logs = [r"\"awsRegion\":\"us-east-1\""]
-
-        filtered_logs = filter_logs(json_logs, include_pattern=r'\\"awsRegion\\":\\"us-east-1\\"')
-
-        self.assertEqual(
-            filtered_logs,
-            [
-                r"\"awsRegion\":\"us-east-1\"",
-            ],
-        )
-
-    def test_http_filtering(self):
-        http_logs = [
-            "This is a 500",
-            "This is a 200",
-        ]
-
-        filtered_logs = filter_logs(http_logs, include_pattern=r"\b[4|5][0-9][0-9]\b")
-
-        self.assertEqual(
-            filtered_logs,
-            [
-                "This is a 500",
-            ],
-        )
-
     def test_include_at_match(self):
         filtered_logs = filter_logs(self.example_logs, include_pattern=r"^(START|END)")
 

--- a/aws/logs_monitoring/tests/test_logs.py
+++ b/aws/logs_monitoring/tests/test_logs.py
@@ -2,6 +2,7 @@ import unittest
 
 from logs import filter_logs
 
+# \"awsRegion\":\"us-east-1\"
 
 class TestFilterLogs(unittest.TestCase):
     example_logs = [
@@ -10,6 +11,18 @@ class TestFilterLogs(unittest.TestCase):
         "END RequestId: ...",
         "REPORT RequestId: ...",
     ]
+
+    def test_json_filtering(self):
+        json_logs = [r"\"awsRegion\":\"us-east-1\""]
+
+        filtered_logs = filter_logs(json_logs, include_pattern=r"\"awsRegion\":\"us-east-1\"")
+
+        self.assertEqual(
+            filtered_logs,
+            [
+                r"\"awsRegion\":\"us-east-1\"",
+            ],
+        )
 
     def test_http_filtering(self):
         http_logs = [

--- a/aws/logs_monitoring/tests/test_logs.py
+++ b/aws/logs_monitoring/tests/test_logs.py
@@ -15,7 +15,7 @@ class TestFilterLogs(unittest.TestCase):
     def test_json_filtering(self):
         json_logs = [r"\"awsRegion\":\"us-east-1\""]
 
-        filtered_logs = filter_logs(json_logs, include_pattern=r"\"awsRegion\":\"us-east-1\"")
+        filtered_logs = filter_logs(json_logs, include_pattern=r'\\"awsRegion\\":\\"us-east-1\\"'
 
         self.assertEqual(
             filtered_logs,


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

- Expand docs for log filtering, including adding some example regular expressions
- Add unit tests for log filtering. A customer having trouble with log filtering could set up their own unit test of their environment variables against a given input.
- Remove a print statement that shouldn't be in `forward_logs()`

### Motivation

We want to make it easier to set up log filtering and see common use cases.

### Testing Guidelines

Unit/integration tests.


### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
