### PR TITLE
[azure] Handle different JSON string log types in blob storage log forwarder

### DIFF
--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -180,8 +180,10 @@ class EventhubLogForwarder {
                 promises = this.handleJSONArrayLogs(logs, JSON_STRING_ARRAY);
                 break;
             case INVALID:
+                this.context.log.error('Log format is invalid: ', logs);
+                break;
             default:
-                this.context.log.warn('logs format is invalid');
+                this.context.log.error('Log format is invalid: ', logs);
                 break;
         }
         return promises;

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -5,7 +5,7 @@
 
 var https = require('https');
 
-const VERSION = '0.2.2';
+const VERSION = '0.2.3';
 
 const STRING = 'string'; // example: 'some message'
 const STRING_ARRAY = 'string-array'; // example: ['one message', 'two message', ...]

--- a/azure/blobs_logs_monitoring/index.js
+++ b/azure/blobs_logs_monitoring/index.js
@@ -5,7 +5,7 @@
 
 var tls = require('tls');
 
-const VERSION = '0.1.2';
+const VERSION = '0.2.2';
 
 const STRING = 'string'; // example: 'some message'
 const STRING_ARRAY = 'string-array'; // example: ['one message', 'two message', ...]

--- a/azure/blobs_logs_monitoring/index.js
+++ b/azure/blobs_logs_monitoring/index.js
@@ -5,7 +5,7 @@
 
 var tls = require('tls');
 
-const VERSION = '0.2.2';
+const VERSION = '0.2.0';
 
 const STRING = 'string'; // example: 'some message'
 const STRING_ARRAY = 'string-array'; // example: ['one message', 'two message', ...]


### PR DESCRIPTION
### What does this PR do?
Adds support for JSON string logs to the blob storage log forwarder function for Azure. Right now logs that are valid json are being sent as strings, instead of being parsed into JSON objects. 
Also adds explicit error logging when log types are invalid for both the event hub and blob storage versions.

<!--- A brief description of the change being made with this pull request. --->

### Motivation
Fix logs for customers using the blob storage function

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
Ran in a test function with different log formats:
- JSON string log
- JSON string log with records field
- Array of JSON string logs
- Array of JSON string logs with records fields

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
