### PR TITLE
Use the latest version of datadog-lambda

### DIFF
--- a/aws/logs_monitoring/setup.py
+++ b/aws/logs_monitoring/setup.py
@@ -17,7 +17,7 @@ setup(
     ],
     keywords="datadog aws lambda layer",
     python_requires=">=3.7, <3.9",
-    install_requires=["datadog-lambda==2.16.0", "requests-futures==1.0.0"],
+    install_requires=["datadog-lambda==3.31.0", "requests-futures==1.0.0"],
     extras_require={
         "dev": ["nose2==0.9.1", "flake8==3.7.9", "requests==2.22.0", "boto3==1.10.33"]
     },

--- a/aws/logs_monitoring/tools/build_bundle.sh
+++ b/aws/logs_monitoring/tools/build_bundle.sh
@@ -22,7 +22,7 @@ else
     VERSION=$1
 fi
 
-PYTHON_VERSION="3.7"
+PYTHON_VERSION="${PYTHON_VERSION:-3.7}"
 FORWARDER_PREFIX="aws-dd-forwarder"
 FORWARDER_DIR="../.forwarder"
 

--- a/aws/logs_monitoring/tools/integration_tests/integration_tests.sh
+++ b/aws/logs_monitoring/tools/integration_tests/integration_tests.sh
@@ -85,7 +85,7 @@ fi
 if ! [ $SKIP_FORWARDER_BUILD == true ]; then
 	cd $INTEGRATION_TESTS_DIR
 	cd ../
-	./build_bundle.sh 0.0.0
+	PYTHON_VERSION=${PYTHON_VERSION#python} ./build_bundle.sh 0.0.0
 	cd ../.forwarder
 	unzip aws-dd-forwarder-0.0.0 -d aws-dd-forwarder-0.0.0
 fi

--- a/aws/logs_monitoring/tools/integration_tests/recorder/recorder.py
+++ b/aws/logs_monitoring/tools/integration_tests/recorder/recorder.py
@@ -2,6 +2,7 @@
 from http.server import BaseHTTPRequestHandler, HTTPServer
 import json
 import os
+import zlib
 
 from google.protobuf.json_format import MessageToDict
 import pb.trace_payload_pb2 as TracePayloadProtobuf
@@ -35,6 +36,8 @@ class RecorderHandler(BaseHTTPRequestHandler):
             if self.headers["Content-Length"] != None:
                 contents = self.rfile.read(int(self.headers["Content-Length"]))
                 if self.headers["Content-Type"] == "application/json":
+                    if self.headers["Content-Encoding"] == "deflate":
+                        contents = zlib.decompress(contents)
                     try:
                         data = json.loads(contents.decode())
                     except:


### PR DESCRIPTION
### What does this PR do?

- Bump the `datadog-lambda` version to pick up the latest improvements (specifically https://github.com/DataDog/datadog-lambda-python/pull/120 and https://github.com/DataDog/datadog-lambda-python/pull/86).
- Update integration test to decompress payload because of https://github.com/DataDog/datadog-lambda-python/pull/86
- Fix the integration test script to build the forwarder bundle against the correct python version. Previously the bundle was always built in a python 3.7 docker image, which breaks the python3.8 integration tests.

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

- [x] The testing forwarder still works

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [x] This PR passes the installation tests (ask a Datadog member to run the tests)
