### PR TITLE
Handle alternate API Gateway log groups

### DIFF
--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -245,8 +245,16 @@ def find_cloudwatch_source(log_group):
                 return engine
         return "rds"
 
-    # e.g. Api-Gateway-Execution-Logs_xxxxxx/dev
-    if log_group.startswith("api-gateway"):
+    if log_group.startswith(
+        (
+            # default location for rest api execution logs
+            "api-gateway",  # e.g. Api-Gateway-Execution-Logs_xxxxxx/dev
+            # default location set by serverless framework for rest api access logs
+            "/aws/api-gateway",  # e.g. /aws/api-gateway/my-project
+            # default location set by serverless framework for http api logs
+            "/aws/http-api",  # e.g. /aws/http-api/my-project
+        )
+    ):
         return "apigateway"
 
     # e.g. dms-tasks-test-instance

--- a/aws/logs_monitoring/tests/test_parsing.py
+++ b/aws/logs_monitoring/tests/test_parsing.py
@@ -69,6 +69,14 @@ class TestParseEventSource(unittest.TestCase):
             ),
             "apigateway",
         )
+        self.assertEqual(
+            parse_event_source({"awslogs": "logs"}, "/aws/api-gateway/my-project"),
+            "apigateway",
+        )
+        self.assertEqual(
+            parse_event_source({"awslogs": "logs"}, "/aws/http-api/my-project"),
+            "apigateway",
+        )
 
     def test_dms_event(self):
         self.assertEqual(


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adds handling for some alternate log group names that can be set by AWS depending on the creation method used. Fixes #438 

### Motivation

One of these alternate log groups was raised in issue #438 . However, further investigation reveals another method for setting up API Gateway using the new HTTP API.

### Testing Guidelines

Tested by deploying a lambda with the modified code and sending API Gateway logs (with all three log group formats) to a Datadog account.

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [x] This PR passes the installation tests (ask a Datadog member to run the tests)
