### PR TITLE
Add host for Guardduty/Route53 logs

### DIFF
--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_route53.json
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_route53.json
@@ -1,0 +1,16 @@
+{
+   "messageType":"DATA_MESSAGE",
+   "owner":"601427279990",
+   "logGroup":"/aws/route53",
+   "logStream":"vpc-34d4ae52_20210419T0940Z_i-090384b04e4e5bfd2",
+   "subscriptionFilters":[
+      "route53"
+   ],
+   "logEvents":[
+      {
+         "id":"36101011026851289935914250459116581911799633971817938944",
+         "timestamp":1618825322000,
+         "message":"{\"version\":\"1.100000\",\"account_id\":\"601427279990\",\"region\":\"us-east-1\",\"vpc_id\":\"vpc-34d4ae52\",\"query_timestamp\":\"2021-04-19T09:42:02Z\",\"query_name\":\"queue.amazonaws.com.\",\"query_type\":\"A\",\"query_class\":\"IN\",\"rcode\":\"NOERROR\",\"answers\":[{\"Rdata\":\"3.236.169.0\",\"Type\":\"A\",\"Class\":\"IN\"}],\"srcaddr\":\"172.31.26.215\",\"srcport\":\"34460\",\"transport\":\"UDP\",\"srcids\":{\"instance\":\"i-090384b04e4e5bfd2\"}}"
+      }
+   ]
+}

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_route53.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_route53.json~snapshot
@@ -1,0 +1,81 @@
+{
+  "events": [
+    {
+      "content-type": "application/json",
+      "data": [
+        {
+          "aws": {
+            "awslogs": {
+              "logGroup": "/aws/route53",
+              "logStream": "vpc-34d4ae52_20210419T0940Z_i-090384b04e4e5bfd2",
+              "owner": "601427279990"
+            },
+            "function_version": "$LATEST",
+            "invoked_function_arn": "arn:aws:lambda:us-east-1:0000000000:function:test"
+          },
+          "ddsource": "route53",
+          "ddsourcecategory": "aws",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>",
+          "host": "i-090384b04e4e5bfd2",
+          "id": "36101011026851289935914250459116581911799633971817938944",
+          "message": "{\"version\":\"1.100000\",\"account_id\":\"601427279990\",\"region\":\"us-east-1\",\"vpc_id\":\"vpc-34d4ae52\",\"query_timestamp\":\"2021-04-19T09:42:02Z\",\"query_name\":\"queue.amazonaws.com.\",\"query_type\":\"A\",\"query_class\":\"IN\",\"rcode\":\"NOERROR\",\"answers\":[{\"Rdata\":\"3.236.169.0\",\"Type\":\"A\",\"Class\":\"IN\"}],\"srcaddr\":\"172.31.26.215\",\"srcport\":\"34460\",\"transport\":\"UDP\",\"srcids\":{\"instance\":\"i-090384b04e4e5bfd2\"}}",
+          "service": "route53",
+          "timestamp": 1618825322000
+        }
+      ],
+      "path": "/v1/input/abcdefghijklmnopqrstuvwxyz012345",
+      "verb": "POST"
+    },
+    {
+      "content-type": "application/json",
+      "data": {
+        "series": [
+          {
+            "device": null,
+            "host": null,
+            "interval": 10,
+            "metric": "aws.dd_forwarder.incoming_events",
+            "points": "<redacted from snapshot>",
+            "tags": [
+              "forwardername:test",
+              "forwarder_memorysize:1536",
+              "forwarder_version:<redacted from snapshot>",
+              "event_type:awslogs"
+            ],
+            "type": "distribution"
+          },
+          {
+            "device": null,
+            "host": null,
+            "interval": 10,
+            "metric": "aws.dd_forwarder.logs_forwarded",
+            "points": "<redacted from snapshot>",
+            "tags": [
+              "forwardername:test",
+              "forwarder_memorysize:1536",
+              "forwarder_version:<redacted from snapshot>",
+              "event_type:awslogs"
+            ],
+            "type": "distribution"
+          },
+          {
+            "device": null,
+            "host": null,
+            "interval": 10,
+            "metric": "aws.dd_forwarder.metrics_forwarded",
+            "points": "<redacted from snapshot>",
+            "tags": [
+              "forwardername:test",
+              "forwarder_memorysize:1536",
+              "forwarder_version:<redacted from snapshot>",
+              "event_type:awslogs"
+            ],
+            "type": "distribution"
+          }
+        ]
+      },
+      "path": "/api/v1/distribution_points?api_key=abcdefghijklmnopqrstuvwxyz012345",
+      "verb": "POST"
+    }
+  ]
+}

--- a/aws/logs_monitoring/tools/integration_tests/tester/test_snapshots.py
+++ b/aws/logs_monitoring/tools/integration_tests/tester/test_snapshots.py
@@ -137,6 +137,11 @@ class TestForwarderSnapshots(unittest.TestCase):
         snapshot_filename = f"{input_filename}~snapshot"
         self.compare_snapshot(input_filename, snapshot_filename)
 
+    def test_cloudwatch_log_route53(self):
+        input_filename = f"{snapshot_dir}/cloudwatch_log_route53.json"
+        snapshot_filename = f"{input_filename}~snapshot"
+        self.compare_snapshot(input_filename, snapshot_filename)
+
     def test_cloudwatch_log_timeout(self):
         input_filename = f"{snapshot_dir}/cloudwatch_log_timeout.json"
         snapshot_filename = f"{input_filename}~snapshot"


### PR DESCRIPTION
### What does this PR do?

Adds a host tag to Guardduty and Route53 logs based on information already present in other attributes.

### Motivation

Currently Guardduty logs come in with no host while Rout53 logs come in with either no host tag or the LogGroup as the host. This breaks correlation with host metrics.

### Testing Guidelines

Tested on Datadog by forwarding Guardduty and Route53 logs through the forwarder to the Datadog UI.

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
