### PR TITLE
Allow DdApiKey to be empty if DdApiKeySecretArn set

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -78,7 +78,6 @@ resource "aws_cloudformation_stack" "datadog_forwarder" {
   name         = "datadog-forwarder"
   capabilities = ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
   parameters   = {
-    DdApiKey           = "this_value_is_not_used"
     DdApiKeySecretArn  = "REPLACE ME WITH THE SECRETS ARN"
     FunctionName       = "datadog-forwarder"
   }
@@ -231,7 +230,8 @@ The Datadog Forwarder is signed by Datadog. If you would like to verify the inte
 ### Required
 
 - `DdApiKey` - Your Datadog API Key. This can be found in Datadog, under Integrations > APIs > API Keys.
-  The API Key will be stored in AWS Secrets Manager.
+  The API Key will be stored in AWS Secrets Manager. If you already have Datadog API Key stored in Secrets Manager, use `DdApiKeySecretArn` instead.
+- `DdApiKeySecretArn` - The ARN of the secret storing the Datadog API key, if you already have it stored in Secrets Manager. You must store the secret as a plaintext, rather than a key-value pair.
 - `DdSite` - The Datadog site that your metrics and logs will be sent to. Possible values are `datadoghq.com`, `datadoghq.eu`, `us3.datadoghq.com` and `ddog-gov.com`.
 
 ### Lambda Function (Optional)
@@ -310,7 +310,6 @@ To test different patterns against your logs, turn on [debug logs](#troubleshoot
 - `SourceZipUrl` - DO NOT CHANGE unless you know what you are doing. Override the default location of
   the function source code.
 - `PermissionBoundaryArn` - ARN for the Permissions Boundary Policy
-- `DdApiKeySecretArn` - The ARN of the secret storing the Datadog API key, if you already have it stored in Secrets Manager. You must store the secret as a plaintext, rather than a key-value pair. You still need to set a dummy value for "DdApiKey" to satisfy the requirement, though that value won't be used.
 - `DdUsePrivateLink` - Set to true to enable sending logs and metrics via AWS PrivateLink. See
   https://dtdg.co/private-link.
 - `VPCSecurityGroupIds` - Comma separated list of VPC Security Group Ids. Used when AWS PrivateLink is

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -9,13 +9,13 @@ Parameters:
   DdApiKey:
     Type: String
     NoEcho: true
-    AllowedPattern: .+
-    Description: The Datadog API key, which can be found from the APIs page (/account/settings#api). It will be stored in AWS Secrets Manager securely. If DdApiKeySecretArn is also set, this value will not be used. This value must still be set, however.
+    Default: ""
+    Description: The Datadog API key, which can be found from the APIs page (/account/settings#api). It will be stored in AWS Secrets Manager securely. If DdApiKeySecretArn is also set, this value is ignored.
   DdApiKeySecretArn:
     Type: String
     AllowedPattern: "arn:.*:secretsmanager:.*"
     Default: "arn:aws:secretsmanager:DEFAULT"
-    Description: The ARN of the secret storing the Datadog API key, if you already have it stored in Secrets Manager. You must store the secret as a plaintext, rather than a key-value pair. You still need to set a dummy value for "DdApiKey" to satisfy the requirement, though that value won't be used.
+    Description: The ARN of the secret storing the Datadog API key, if you already have it stored in Secrets Manager. You must store the secret as a plaintext, rather than a key-value pair.
   DdSite:
     Type: String
     Default: datadoghq.com
@@ -324,6 +324,20 @@ Conditions:
       - Fn::Equals:
           - Ref: DdTraceIntakeUrl
           - ""
+Rules:
+  MustSetDdApiKey:
+    Assertions:
+      - Assert:
+          Fn::Or:
+            - Fn::Not:
+              - Fn::Equals:
+                - Ref: DdApiKey
+                - ""
+            - Fn::Not:
+              - Fn::Equals:
+                - Ref: DdApiKeySecretArn
+                - "arn:aws:secretsmanager:DEFAULT"
+        AssertDescription: DdApiKey or DdApiKeySecretArn must be set
 Resources:
   Forwarder:
     Type: AWS::Serverless::Function
@@ -777,6 +791,7 @@ Metadata:
           default: Required
         Parameters:
           - DdApiKey
+          - DdApiKeySecretArn
           - DdSite
       - Label:
           default: Lambda Function (Optional)
@@ -819,7 +834,6 @@ Metadata:
           - TagsCacheTTLSeconds
           - SourceZipUrl
           - PermissionsBoundaryArn
-          - DdApiKeySecretArn
           - DdUsePrivateLink
           - DdUseVPC
           - VPCSecurityGroupIds
@@ -830,5 +844,7 @@ Metadata:
     ParameterLabels:
       DdApiKey:
         default: "DdApiKey *"
+      DdApiKeySecretArn:
+        default: "DdApiKeySecretArn *"
       DdSite:
         default: "DdSite *"


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Addresses https://github.com/DataDog/datadog-serverless-functions/issues/439. Previously, when using `DdApiKeySecretArn`, you still need to set a dummy value for `DdApiKey` even if it's not used. Now you only need to set one of them using [CloudFormation Rules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/rules-section-structure.html).


### Motivation

https://github.com/DataDog/datadog-serverless-functions/issues/439

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [x] This PR passes the installation tests (ask a Datadog member to run the tests)
