### PR TITLE
[azure] Support custom log splitting in activity logs forwarder

### DIFF
--- a/azure/activity_logs_monitoring/README.md
+++ b/azure/activity_logs_monitoring/README.md
@@ -45,3 +45,29 @@ You have two options to add custom tags to your logs:
 - Automatically with the `DD_TAGS` environment variable
 
 Learn more about Datadog tagging in our main [Tagging documentation](https://docs.datadoghq.com/tagging/).
+
+## Customization
+
+- **Scrubbing PII**
+
+To scrub PII from your logs, uncomment the SCRUBBER_RULE_CONFIG code. If you'd like to scrub more than just emails and IP addresses, add your own config to this map in the format
+```
+{
+    NAME: {
+        pattern: <regex_pattern>,
+        replacement: <string to replace matching text with>}
+}
+```
+
+- **Log Splitting**
+
+To split array-type fields in your logs into individual logs, you can add sections to the DD_LOG_SPLITTING_CONFIG map in the code or by setting the DD_LOG_SPLITTING_CONFIG env variable (which must be a json string in the same format).
+
+An example of an azure.datafactory use case is provided in the code and commented out. The format is as follows:
+```
+{
+  source_type:
+    path: [list of fields in the log payload to iterate through to find the one to split],
+    keep_original_log: bool, if you'd like to preserve the original log in addition to the split ones or not
+}
+```


### PR DESCRIPTION


<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Allows customers to enable custom log splitting in the activity logs/eventhub log forwarder. They can now set up a config in their code or as an env var that tells us which source type logs they'd like to split, and gives us a path of fields to traverse to find the field to split into individual logs. Also cleans up the promises stuff to only save them to the list when sending, and stores the list on the eventhub forwarder to make it much cleaner.

<!--- A brief description of the change being made with this pull request. --->

### Motivation
Support for more customer use cases.
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
- tested with some example logs in the ricky-test org. Tested with logs with the datafactory resource type, some without, some string logs. Confirmed with the datafactory source type that things get split as expected and if the customer wants to keep the original log that also works.

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
