### PR TITLE
Split SH events into separate events based on findings

### DIFF
--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -7,6 +7,7 @@ import base64
 import gzip
 import json
 import os
+import copy
 
 import boto3
 import botocore
@@ -525,6 +526,48 @@ def cwevent_handler(event, metadata):
     metadata[DD_SERVICE] = metadata[DD_SOURCE]
 
     yield data
+
+
+def separate_security_hub_findings(event):
+    """Replace Security Hub event with series of events based on findings
+
+    Each event should contain one finding only.
+    This prevents having an unparsable array of objects in the final log.
+    """
+    if event.get(DD_SOURCE) != "securityhub" or not event.get("detail", {}).get(
+        "findings"
+    ):
+        return None
+    events = []
+    event_copy = copy.deepcopy(event)
+    # Copy findings before separating
+    findings = event_copy.get("detail", {}).get("findings")
+    if findings:
+        # Remove findings from the original event once we have a copy
+        del event_copy["detail"]["findings"]
+        # For each finding create a separate log event
+        for index, item in enumerate(findings):
+            # Copy the original event with source and other metadata
+            new_event = copy.deepcopy(event_copy)
+            current_finding = findings[index]
+            # Get the resources array from the current finding
+            resources = current_finding.get("Resources", {})
+            new_event["detail"]["finding"] = current_finding
+            new_event["detail"]["finding"]["resources"] = {}
+            # Separate objects in resources array into distinct attributes
+            if resources:
+                # Remove from current finding once we have a copy
+                del current_finding["Resources"]
+                for item in resources:
+                    current_resource = item
+                    # Capture the type and use it as the distinguishing key
+                    resource_type = current_resource.get("Type", {})
+                    del current_resource["Type"]
+                    new_event["detail"]["finding"]["resources"][
+                        resource_type
+                    ] = current_resource
+            events.append(new_event)
+    return events
 
 
 # Handle Sns events

--- a/aws/logs_monitoring/tests/test_parsing.py
+++ b/aws/logs_monitoring/tests/test_parsing.py
@@ -12,7 +12,7 @@ sys.modules["requests_futures.sessions"] = MagicMock()
 
 env_patch = patch.dict(os.environ, {"DD_API_KEY": "11111111111111111111111111111111"})
 env_patch.start()
-from parsing import parse_event_source
+from parsing import parse_event_source, separate_security_hub_findings
 
 env_patch.stop()
 
@@ -231,6 +231,151 @@ class TestParseEventSource(unittest.TestCase):
 
     def test_s3_source_if_none_found(self):
         self.assertEqual(parse_event_source({"Records": ["logs-from-s3"]}, ""), "s3")
+
+
+class TestParseSecurityHubEvents(unittest.TestCase):
+    def test_security_hub_no_findings(self):
+        event = {"ddsource": "securityhub"}
+        self.assertEqual(
+            separate_security_hub_findings(event),
+            None,
+        )
+
+    def test_security_hub_one_finding_no_resources(self):
+        event = {
+            "ddsource": "securityhub",
+            "detail": {"findings": [{"myattribute": "somevalue"}]},
+        }
+        self.assertEqual(
+            separate_security_hub_findings(event),
+            [
+                {
+                    "ddsource": "securityhub",
+                    "detail": {
+                        "finding": {"myattribute": "somevalue", "resources": {}}
+                    },
+                }
+            ],
+        )
+
+    def test_security_hub_two_findings_one_resource_each(self):
+        event = {
+            "ddsource": "securityhub",
+            "detail": {
+                "findings": [
+                    {
+                        "myattribute": "somevalue",
+                        "Resources": [
+                            {"Region": "us-east-1", "Type": "AwsEc2SecurityGroup"}
+                        ],
+                    },
+                    {
+                        "myattribute": "somevalue",
+                        "Resources": [
+                            {"Region": "us-east-1", "Type": "AwsEc2SecurityGroup"}
+                        ],
+                    },
+                ]
+            },
+        }
+        self.assertEqual(
+            separate_security_hub_findings(event),
+            [
+                {
+                    "ddsource": "securityhub",
+                    "detail": {
+                        "finding": {
+                            "myattribute": "somevalue",
+                            "resources": {
+                                "AwsEc2SecurityGroup": {"Region": "us-east-1"}
+                            },
+                        }
+                    },
+                },
+                {
+                    "ddsource": "securityhub",
+                    "detail": {
+                        "finding": {
+                            "myattribute": "somevalue",
+                            "resources": {
+                                "AwsEc2SecurityGroup": {"Region": "us-east-1"}
+                            },
+                        }
+                    },
+                },
+            ],
+        )
+
+    def test_security_hub_multiple_findings_multiple_resources(self):
+        event = {
+            "ddsource": "securityhub",
+            "detail": {
+                "findings": [
+                    {
+                        "myattribute": "somevalue",
+                        "Resources": [
+                            {"Region": "us-east-1", "Type": "AwsEc2SecurityGroup"}
+                        ],
+                    },
+                    {
+                        "myattribute": "somevalue",
+                        "Resources": [
+                            {"Region": "us-east-1", "Type": "AwsEc2SecurityGroup"},
+                            {"Region": "us-east-1", "Type": "AwsOtherSecurityGroup"},
+                        ],
+                    },
+                    {
+                        "myattribute": "somevalue",
+                        "Resources": [
+                            {"Region": "us-east-1", "Type": "AwsEc2SecurityGroup"},
+                            {"Region": "us-east-1", "Type": "AwsOtherSecurityGroup"},
+                            {"Region": "us-east-1", "Type": "AwsAnotherSecurityGroup"},
+                        ],
+                    },
+                ]
+            },
+        }
+        self.assertEqual(
+            separate_security_hub_findings(event),
+            [
+                {
+                    "ddsource": "securityhub",
+                    "detail": {
+                        "finding": {
+                            "myattribute": "somevalue",
+                            "resources": {
+                                "AwsEc2SecurityGroup": {"Region": "us-east-1"}
+                            },
+                        }
+                    },
+                },
+                {
+                    "ddsource": "securityhub",
+                    "detail": {
+                        "finding": {
+                            "myattribute": "somevalue",
+                            "resources": {
+                                "AwsEc2SecurityGroup": {"Region": "us-east-1"},
+                                "AwsOtherSecurityGroup": {"Region": "us-east-1"},
+                            },
+                        }
+                    },
+                },
+                {
+                    "ddsource": "securityhub",
+                    "detail": {
+                        "finding": {
+                            "myattribute": "somevalue",
+                            "resources": {
+                                "AwsEc2SecurityGroup": {"Region": "us-east-1"},
+                                "AwsOtherSecurityGroup": {"Region": "us-east-1"},
+                                "AwsAnotherSecurityGroup": {"Region": "us-east-1"},
+                            },
+                        }
+                    },
+                },
+            ],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What does this PR do?

Splits the findings array in Security Hub events and creates a separate log for each element in findings.

### Motivation

Currently the findings attribute in Security Hub logs comes in as an array of objects which can't be parsed out on the logs side. Since this attribute contains a lot of the most relevant information about these logs we need to convert it from an array of objects into a series of single objects spread across multiple logs.

### Testing Guidelines

Tested on Datadog by sending Security Hub logs through the Lambda Function (triggered by an event rule).

### Additional Notes

Unit tests need to be added pending review.

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
