### PR TITLE
Upgrade datadog-lambda to 3.36.0 to fix a metric forwarding issue.

### DIFF
--- a/aws/logs_monitoring/setup.py
+++ b/aws/logs_monitoring/setup.py
@@ -17,7 +17,7 @@ setup(
     ],
     keywords="datadog aws lambda layer",
     python_requires=">=3.7, <3.9",
-    install_requires=["datadog-lambda==3.31.0", "requests-futures==1.0.0"],
+    install_requires=["datadog-lambda==3.36.0", "requests-futures==1.0.0"],
     extras_require={
         "dev": ["nose2==0.9.1", "flake8==3.7.9", "requests==2.22.0", "boto3==1.10.33"]
     },

--- a/aws/logs_monitoring/tools/Dockerfile_bundle
+++ b/aws/logs_monitoring/tools/Dockerfile_bundle
@@ -19,5 +19,4 @@ RUN rm -rf ./botocore*
 # like `os.execl`, which cause security scans to fail for certain customers.
 # These files are not directly used by the Forwarder.
 RUN rm ./ddtrace/commands/ddtrace_run.py
-RUN rm ./ddtrace/profiling/__main__.py
 RUN rm ./decorator.py


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

See details https://github.com/DataDog/datadog-lambda-python/pull/138

### Motivation

Fix a metric forwarding issue by retrying submission over `RemoteDisconnected` errors.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [x] This PR passes the installation tests (ask a Datadog member to run the tests)
