### PR TITLE
Add kms encryption

### DIFF
--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -187,6 +187,10 @@ Parameters:
     Type: String
     Default: ""
     Description: The endpoint URL to forward the traces to, useful for forwarding traces through a proxy
+  DdForwarderBucketKMSEncryptionEnabled:
+    Type: String
+    Default: false
+    Description: Toggle for enabling KMS encryption on the forwarder when uploading it to s3 during installation
 Conditions:
   IsAWSChina:
     Fn::Equals:
@@ -324,6 +328,10 @@ Conditions:
       - Fn::Equals:
           - Ref: DdTraceIntakeUrl
           - ""
+  SetDdKMSEncryption:
+    Fn::Equals:
+      - Ref: DdForwarderBucketKMSEncryptionEnabled
+      - true
 Rules:
   MustSetDdApiKey:
     Assertions:
@@ -695,6 +703,7 @@ Resources:
         def copy_zip(source_zip_url, dest_zips_bucket):
             s3 = boto3.client('s3')
             s3_prelude = "s3://"
+            extra_args = {"ServerSideEncryption": "aws:kms"} if os.environ.get("DD_FORWARDER_BUCKET_KMS_ENABLED") == 'true' else {}
             filename = "aws-dd-forwarder-{}.zip".format(os.environ.get("DD_FORWARDER_VERSION"))
             if source_zip_url.startswith(s3_prelude):
                 parts = source_zip_url[len(s3_prelude):].split('/')
@@ -702,10 +711,10 @@ Resources:
                 key = '/'.join(parts[1:])
                 response = s3.get_object(Bucket=bucket, Key=key)
                 data = response["Body"]
-                s3.upload_fileobj(data, dest_zips_bucket, filename)
+                s3.upload_fileobj(data, dest_zips_bucket, filename, ExtraArgs=extra_args)
             else:
                 with urllib.request.urlopen(source_zip_url) as data:
-                    s3.upload_fileobj(data, dest_zips_bucket, filename)
+                    s3.upload_fileobj(data, dest_zips_bucket, filename, ExtraArgs=extra_args)
         def timeout(event, context):
             logging.error('Execution is about to time out, sending failure response to CloudFormation')
             send_cfn_resp(event, context, 'FAILED')
@@ -766,6 +775,11 @@ Resources:
       Environment:
         Variables:
           DD_FORWARDER_VERSION: !FindInMap [Constants, DdForwarder, Version]
+          DD_FORWARDER_BUCKET_KMS_ENABLED:
+            Fn::If:
+              - SetDdKMSEncryption
+              - true
+              - false
 Outputs:
   DatadogForwarderArn:
     Description: Datadog Forwarder Lambda Function ARN


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adds a flag to the log forwarder that encrypts the forwarder bucket object during installation.

### Motivation

<!--- What inspired you to submit this pull request? --->

An SCP deployed to our accounts prevents any s3 uploads that aren't KMS encrypted so we're unable to install the forwarder there without modifying the cloudformation template.

<!--- How did you test this pull request? --->
In our own environment, with both the flag enabled and disabled.

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
