### PR TITLE
Add postgresql source for RDS logs

### DIFF
--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -241,10 +241,14 @@ def parse_event_source(event, key):
 def find_cloudwatch_source(log_group):
     # e.g. /aws/rds/instance/my-mariadb/error
     if log_group.startswith("/aws/rds"):
-        for engine in ["mariadb", "mysql"]:
-            if engine in log_group:
-                return engine
-        return "rds"
+        return next(
+            (
+                engine
+                for engine in ["mariadb", "mysql", "postgresql"]
+                if engine in log_group
+            ),
+            "rds",
+        )
 
     if log_group.startswith(
         (
@@ -441,16 +445,13 @@ def awslogs_handler(event, context, metadata):
 
     # When parsing rds logs, use the cloudwatch log group name to derive the
     # rds instance name, and add the log name of the stream ingested
-    if metadata[DD_SOURCE] in ["rds", "mariadb", "mysql"]:
+    if metadata[DD_SOURCE] in ["rds", "mariadb", "mysql", "postgresql"]:
         match = rds_regex.match(logs["logGroup"])
         if match is not None:
             metadata[DD_HOST] = match.group("host")
             metadata[DD_CUSTOM_TAGS] = (
                 metadata[DD_CUSTOM_TAGS] + ",logname:" + match.group("name")
             )
-            # We can intuit the sourcecategory in some cases
-            if match.group("name") == "postgresql":
-                metadata[DD_CUSTOM_TAGS] + ",sourcecategory:" + match.group("name")
 
     # For Lambda logs we want to extract the function name,
     # then rebuild the arn of the monitored lambda using that name.

--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -241,14 +241,10 @@ def parse_event_source(event, key):
 def find_cloudwatch_source(log_group):
     # e.g. /aws/rds/instance/my-mariadb/error
     if log_group.startswith("/aws/rds"):
-        return next(
-            (
-                engine
-                for engine in ["mariadb", "mysql", "postgresql"]
-                if engine in log_group
-            ),
-            "rds",
-        )
+        for engine in ["mariadb", "mysql", "postgresql"]:
+            if engine in log_group:
+                return engine
+        return "rds"
 
     if log_group.startswith(
         (

--- a/aws/logs_monitoring/tests/test_parsing.py
+++ b/aws/logs_monitoring/tests/test_parsing.py
@@ -1,3 +1,6 @@
+import base64
+import gzip
+import json
 from unittest.mock import MagicMock, patch
 import os
 import sys
@@ -12,7 +15,7 @@ sys.modules["requests_futures.sessions"] = MagicMock()
 
 env_patch = patch.dict(os.environ, {"DD_API_KEY": "11111111111111111111111111111111"})
 env_patch.start()
-from parsing import parse_event_source, separate_security_hub_findings
+from parsing import awslogs_handler, parse_event_source, separate_security_hub_findings
 
 env_patch.stop()
 
@@ -55,6 +58,14 @@ class TestParseEventSource(unittest.TestCase):
         self.assertEqual(
             parse_event_source({"awslogs": "logs"}, "/aws/rds/mySQL-instance/error"),
             "mysql",
+        )
+
+    def test_postgresql_event(self):
+        self.assertEqual(
+            parse_event_source(
+                {"awslogs": "logs"}, "/aws/rds/instance/datadog/postgresql"
+            ),
+            "postgresql",
         )
 
     def test_lambda_event(self):
@@ -375,6 +386,65 @@ class TestParseSecurityHubEvents(unittest.TestCase):
                     },
                 },
             ],
+        )
+
+
+class TestAWSLogsHandler(unittest.TestCase):
+    def test_awslogs_handler_rds_postgresql(self):
+        event = {
+            "awslogs": {
+                "data": base64.b64encode(
+                    gzip.compress(
+                        bytes(
+                            json.dumps(
+                                {
+                                    "owner": "123456789012",
+                                    "logGroup": "/aws/rds/instance/datadog/postgresql",
+                                    "logStream": "datadog.0",
+                                    "logEvents": [
+                                        {
+                                            "id": "31953106606966983378809025079804211143289615424298221568",
+                                            "timestamp": 1609556645000,
+                                            "message": "2021-01-02 03:04:05 UTC::@:[5306]:LOG:  database system is ready to accept connections",
+                                        }
+                                    ],
+                                }
+                            ),
+                            "utf-8",
+                        )
+                    )
+                )
+            }
+        }
+        context = None
+        metadata = {"ddsource": "postgresql", "ddtags": "env:dev"}
+
+        self.assertEqual(
+            [
+                {
+                    "aws": {
+                        "awslogs": {
+                            "logGroup": "/aws/rds/instance/datadog/postgresql",
+                            "logStream": "datadog.0",
+                            "owner": "123456789012",
+                        }
+                    },
+                    "id": "31953106606966983378809025079804211143289615424298221568",
+                    "message": "2021-01-02 03:04:05 UTC::@:[5306]:LOG:  database system is ready "
+                    "to accept connections",
+                    "timestamp": 1609556645000,
+                }
+            ],
+            list(awslogs_handler(event, context, metadata)),
+        )
+        self.assertEqual(
+            {
+                "ddsource": "postgresql",
+                "ddtags": "env:dev,logname:postgresql",
+                "host": "datadog",
+                "service": "postgresql",
+            },
+            metadata,
         )
 
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

It adds `postgresql` as `source` tag, if it is a RDS PostgreSQL Log Group.

### Motivation

If the `source` is `postgresql` a the preset Log Pipeline will be used.

### Testing Guidelines

Wrote tests and tried it out.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
