### PR TITLE
Add VPC DNS Query logging from S3

### DIFF
--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -306,6 +306,10 @@ def find_s3_source(key):
     if "vpcflowlogs" in key:
         return "vpc"
 
+    # e.g. AWSLogs/123456779121/vpcdnsquerylogs/vpc-********/2021/05/11/vpc-********_vpcdnsquerylogs_********_20210511T0910Z_71584702.log.gz
+    if "vpcdnsquerylogs" in key:
+        return "route53"
+    
     # e.g. 2020/10/02/21/aws-waf-logs-testing-1-2020-10-02-21-25-30-x123x-x456x
     if "aws-waf-logs" in key:
         return "waf"

--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -309,7 +309,7 @@ def find_s3_source(key):
     # e.g. AWSLogs/123456779121/vpcdnsquerylogs/vpc-********/2021/05/11/vpc-********_vpcdnsquerylogs_********_20210511T0910Z_71584702.log.gz
     if "vpcdnsquerylogs" in key:
         return "route53"
-    
+
     # e.g. 2020/10/02/21/aws-waf-logs-testing-1-2020-10-02-21-25-30-x123x-x456x
     if "aws-waf-logs" in key:
         return "waf"

--- a/aws/logs_monitoring/tests/test_parsing.py
+++ b/aws/logs_monitoring/tests/test_parsing.py
@@ -177,6 +177,15 @@ class TestParseEventSource(unittest.TestCase):
             "route53",
         )
 
+    def test_vpcdnsquerylogs_event(self):
+        self.assertEqual(
+            parse_event_source(
+                {"Records": ["logs-from-s3"]},
+                "AWSLogs/123456779121/vpcdnsquerylogs/vpc-********/2021/05/11/vpc-********_vpcdnsquerylogs_********_20210511T0910Z_71584702.log.gz",
+            ),
+            "route53",
+        )
+
     def test_fargate_event(self):
         self.assertEqual(
             parse_event_source(


### PR DESCRIPTION
Hi,

### What does this PR do?
Small change for handling VPC DNS Query logs stored in S3

### Additional Notes
This change works on my side

### Types of changes

- [ ] Bug fix
- [ X] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
