### PR TITLE
[azure] Enable batching of requests in log forwarder and optional TCP support

### DIFF
--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -231,7 +231,7 @@ class TCPClient {
         for (var i = 0; i < batches.length; i++) {
             if (!this.send(socket, batches[i])) {
                 // Retry once
-                socket = getSocket(this.context);
+                socket = this.getSocket(this.context);
                 this.send(socket, batches[i]);
             }
         }

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -93,7 +93,8 @@ class Batcher {
         var batch = [];
         var sizeBytes = 0;
         var sizeCount = 0;
-        items.forEach(item => {
+        for (var i = 0; i < items.length; i++) {
+            var item = items[i];
             var itemSizeBytes = this.getSizeInBytes(item);
             if (
                 sizeCount > 0 &&
@@ -111,7 +112,7 @@ class Batcher {
                 sizeBytes += itemSizeBytes;
                 sizeCount += 1;
             }
-        });
+        }
 
         if (sizeCount > 0) {
             batches.push(batch);

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -128,7 +128,7 @@ class Batcher {
         if (typeof string !== 'string') {
             string = JSON.stringify(string);
         }
-        return string.length;
+        return Buffer.byteLength(string, 'utf8');
     }
 }
 
@@ -154,10 +154,9 @@ class HTTPClient {
     }
 
     async sendAll() {
-        var results = await Promise.all(
+        return await Promise.all(
             this.promises.map(p => p.catch(e => context.log.error(e)))
         );
-        return results;
     }
 
     sendWithRetry(record) {
@@ -551,7 +550,7 @@ module.exports = async function(context, eventHubMessages) {
         var handler = new EventhubLogHandler(context);
         var parsedLogs = handler.handleLogs(eventHubMessages);
     } catch (err) {
-        context.log.error('Error raised when parsing logs', err);
+        context.log.error('Error raised when parsing logs: ', err);
         throw err;
     }
     if (USE_TCP) {
@@ -579,7 +578,7 @@ module.exports = async function(context, eventHubMessages) {
 
         if (results.every(v => v === true) !== true) {
             context.log.error(
-                'some messages were unable to be sent. See other logs for more details.'
+                'Some messages were unable to be sent. See other logs for details.'
             );
         }
     }

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -4,8 +4,9 @@
 // Copyright 2021 Datadog, Inc.
 
 var https = require('https');
+var tls = require('tls');
 
-const VERSION = '0.3.0';
+const VERSION = '0.4.0';
 
 const STRING = 'string'; // example: 'some message'
 const STRING_ARRAY = 'string-array'; // example: ['one message', 'two message', ...]
@@ -21,12 +22,15 @@ const STRING_TYPE = 'string';
 
 const DD_API_KEY = process.env.DD_API_KEY || '<DATADOG_API_KEY>';
 const DD_SITE = process.env.DD_SITE || 'datadoghq.com';
-const DD_URL = process.env.DD_URL || 'http-intake.logs.' + DD_SITE;
-const DD_PORT = process.env.DD_PORT || 443;
+const DD_HTTP_URL = process.env.DD_HTTP_URL || 'http-intake.logs.' + DD_SITE;
+const DD_HTTP_PORT = process.env.DD_HTTP_PORT || 443;
+const DD_TCP_URL = process.env.DD_TCP_URL || 'functions-intake.logs.' + DD_SITE;
+const DD_TCP_PORT = DD_SITE === 'datadoghq.eu' ? 443 : 10516;
 const DD_TAGS = process.env.DD_TAGS || ''; // Replace '' by your comma-separated list of tags
 const DD_SERVICE = process.env.DD_SERVICE || 'azure';
 const DD_SOURCE = process.env.DD_SOURCE || 'azure';
 const DD_SOURCE_CATEGORY = process.env.DD_SOURCE_CATEGORY || 'azure';
+const USE_TCP = process.env.DD_USE_TCP || false;
 
 /*
 To scrub PII from your logs, uncomment the applicable configs below. If you'd like to scrub more than just
@@ -77,6 +81,162 @@ class ScrubberRule {
     }
 }
 
+class Batcher {
+    constructor(
+        context,
+        max_item_size_bytes,
+        max_batch_size_bytes,
+        max_items_count
+    ) {
+        this.max_item_size_bytes = max_item_size_bytes;
+        this.max_batch_size_bytes = max_batch_size_bytes;
+        this.max_items_count = max_items_count;
+    }
+
+    batch(items) {
+        var batches = [];
+        var batch = [];
+        var size_bytes = 0;
+        var size_count = 0;
+        items.forEach(item => {
+            var item_size_bytes = this.getSizeInBytes(item);
+            if (
+                size_count > 0 &&
+                (size_count >= this.max_items_count ||
+                    size_bytes + item_size_bytes > this.max_batch_size_bytes)
+            ) {
+                batches.push(batch);
+                batch = [];
+                size_bytes = 0;
+                size_count = 0;
+            }
+            // all items exceeding max_item_size_bytes are dropped here
+            if (item_size_bytes <= this.max_item_size_bytes) {
+                batch.push(item);
+                size_bytes += item_size_bytes;
+                size_count += 1;
+            }
+        });
+
+        if (size_count > 0) {
+            batches.push(batch);
+        }
+        return batches;
+    }
+
+    getSizeInBytes(string) {
+        if (typeof string !== 'string') {
+            string = JSON.stringify(string);
+        }
+        return string.length;
+    }
+}
+
+class HTTPClient {
+    constructor(context) {
+        this.context = context;
+        this.httpOptions = {
+            hostname: DD_HTTP_URL,
+            port: DD_HTTP_PORT,
+            path: '/v1/input',
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'DD-API-KEY': DD_API_KEY
+            }
+        };
+        this.scrubber = new Scrubber(this.context, SCRUBBER_RULE_CONFIGS);
+        this.promises = [];
+    }
+
+    handle(record) {
+        this.promises.push(this.sendWithRetry(record));
+    }
+
+    async sendAll() {
+        var results = await Promise.all(
+            this.promises.map(p => p.catch(e => context.log.error(e)))
+        );
+        return results;
+    }
+
+    sendWithRetry(record) {
+        return new Promise((resolve, reject) => {
+            return this.send(record)
+                .then(res => {
+                    resolve(true);
+                })
+                .catch(err => {
+                    this.send(record)
+                        .then(res => {
+                            resolve(true);
+                        })
+                        .catch(err => {
+                            reject(
+                                `unable to send request after 2 tries, err: ${err}`
+                            );
+                        });
+                });
+        });
+    }
+
+    send(record) {
+        return new Promise((resolve, reject) => {
+            const req = https
+                .request(this.httpOptions, resp => {
+                    if (resp.statusCode < 200 || resp.statusCode > 299) {
+                        reject(`invalid status code ${resp.statusCode}`);
+                    } else {
+                        resolve(true);
+                    }
+                })
+                .on('error', error => {
+                    reject(error);
+                });
+            req.write(this.scrubber.scrub(JSON.stringify(record)));
+            req.end();
+        });
+    }
+}
+
+class TCPClient {
+    constructor(context) {
+        this.context = context;
+        this.tcpOptions = { port: DD_TCP_PORT, host: DD_TCP_URL };
+        this.scrubber = new Scrubber(this.context, SCRUBBER_RULE_CONFIGS);
+    }
+
+    getSocket(context) {
+        var socket = tls.connect(this.tcpOptions);
+        socket.on('error', err => {
+            this.context.log.error(err.toString());
+            socket.end();
+        });
+
+        return socket;
+    }
+    send(socket, record) {
+        return socket.write(
+            DD_API_KEY +
+                ' ' +
+                this.scrubber.scrub(JSON.stringify(record[0])) +
+                '\n'
+        );
+    }
+
+    sendBatches(batches) {
+        var socket = this.getSocket(this.context);
+        for (var i = 0; i < batches.length; i++) {
+            if (!this.send(socket, batches[i])) {
+                // Retry once
+                socket = getSocket(this.context);
+                this.send(socket, batches[i]);
+            }
+        }
+        socket.end();
+    }
+}
+
 class Scrubber {
     constructor(context, configs) {
         var rules = [];
@@ -111,23 +271,11 @@ class Scrubber {
     }
 }
 
-class EventhubLogForwarder {
+class EventhubLogHandler {
     constructor(context) {
         this.context = context;
-        this.options = {
-            hostname: DD_URL,
-            port: 443,
-            path: '/v1/input',
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'DD-API-KEY': DD_API_KEY
-            },
-            timeout: 2000
-        };
-        this.scrubber = new Scrubber(this.context, SCRUBBER_RULE_CONFIGS);
-        this.promises = [];
         this.logSplittingConfig = getLogSplittingConfig();
+        this.records = [];
     }
 
     findSplitRecords(record, fields) {
@@ -141,14 +289,14 @@ class EventhubLogForwarder {
                 this.context.log.error(
                     'unable to split log based on log config, falling back to sending existing log.'
                 );
-                this.promises.push(this.sendWithRetry(record));
+                this.records.push(record);
                 return null;
             }
         }
         return tempRecord;
     }
 
-    formatLogAndSend(messageType, record) {
+    formatLog(messageType, record) {
         if (messageType == JSON_TYPE) {
             var originalRecord = this.addTagsToJsonLog(record);
             var source = originalRecord['ddsource'];
@@ -157,7 +305,7 @@ class EventhubLogForwarder {
                 var fields = config.path;
 
                 if (config.keep_original_log) {
-                    this.promises.push(this.sendWithRetry(originalRecord));
+                    this.records.push(originalRecord);
                 }
 
                 var recordsToSplit = this.findSplitRecords(record, fields);
@@ -181,71 +329,32 @@ class EventhubLogForwarder {
                         tags: originalRecord['tags']
                     };
                     Object.assign(newRecord, splitRecord);
-                    this.promises.push(this.sendWithRetry(newRecord));
+                    this.records.push(newRecord);
                 }
             } else {
-                this.promises.push(this.sendWithRetry(originalRecord));
+                this.records.push(originalRecord);
             }
         } else {
             record = this.addTagsToStringLog(record);
-            this.promises.push(this.sendWithRetry(record));
+            this.records.push(record);
         }
-    }
-
-    sendWithRetry(record) {
-        return new Promise((resolve, reject) => {
-            return this.send(record)
-                .then(res => {
-                    resolve();
-                })
-                .catch(err => {
-                    setTimeout(() => {
-                        this.send(record)
-                            .then(resolve)
-                            .catch(err => {
-                                this.context.log.error(
-                                    `unable to send request after 2 tries, err: ${err}`
-                                );
-                                reject();
-                            });
-                    }, 1000);
-                });
-        });
-    }
-
-    send(record) {
-        return new Promise((resolve, reject) => {
-            const req = https
-                .request(this.options, resp => {
-                    if (resp.statusCode < 200 || resp.statusCode > 299) {
-                        reject(`invalid status code ${resp.statusCode}`);
-                    } else {
-                        resolve();
-                    }
-                })
-                .on('error', error => {
-                    reject(error);
-                });
-            req.write(this.scrubber.scrub(JSON.stringify(record)));
-            req.end();
-        });
     }
 
     handleLogs(logs) {
         var logsType = this.getLogFormat(logs);
         switch (logsType) {
             case STRING:
-                this.formatLogAndSend(STRING_TYPE, logs);
+                this.formatLog(STRING_TYPE, logs);
                 break;
             case JSON_STRING:
                 logs = JSON.parse(logs);
-                this.formatLogAndSend(JSON_TYPE, logs);
+                this.formatLog(JSON_TYPE, logs);
                 break;
             case JSON_OBJECT:
-                this.formatLogAndSend(JSON_TYPE, logs);
+                this.formatLog(JSON_TYPE, logs);
                 break;
             case STRING_ARRAY:
-                logs.forEach(log => this.formatLogAndSend(STRING_TYPE, log));
+                logs.forEach(log => this.formatLog(STRING_TYPE, log));
                 break;
             case JSON_ARRAY:
                 this.handleJSONArrayLogs(logs, JSON_ARRAY);
@@ -263,7 +372,7 @@ class EventhubLogForwarder {
                 this.context.log.error('Log format is invalid: ', logs);
                 break;
         }
-        return this.promises;
+        return this.records;
     }
 
     handleJSONArrayLogs(logs, logsType) {
@@ -276,7 +385,7 @@ class EventhubLogForwarder {
                     this.context.log.warn(
                         'log is malformed json, sending as string'
                     );
-                    this.formatLogAndSend(STRING_TYPE, message);
+                    this.formatLog(STRING_TYPE, message);
                     continue;
                 }
             }
@@ -288,16 +397,16 @@ class EventhubLogForwarder {
                     this.context.log.warn(
                         'log is malformed json, sending as string'
                     );
-                    this.formatLogAndSend(STRING_TYPE, message.toString());
+                    this.formatLog(STRING_TYPE, message.toString());
                     continue;
                 }
             }
             if (message.records != undefined) {
                 message.records.forEach(message =>
-                    this.formatLogAndSend(JSON_TYPE, message)
+                    this.formatLog(JSON_TYPE, message)
                 );
             } else {
-                this.formatLogAndSend(JSON_TYPE, message);
+                this.formatLog(JSON_TYPE, message);
             }
         }
     }
@@ -438,17 +547,49 @@ module.exports = async function(context, eventHubMessages) {
         );
         return;
     }
-    var promises = new EventhubLogForwarder(context).handleLogs(
-        eventHubMessages
-    );
+    try {
+        var handler = new EventhubLogHandler(context);
+        var parsedLogs = handler.handleLogs(eventHubMessages);
+    } catch (err) {
+        context.log.error('Error raised when parsing logs', err);
+        throw err;
+    }
+    if (USE_TCP) {
+        var batches = new Batcher(
+            this.context,
+            256 * 1000,
+            256 * 1000,
+            1
+        ).batch(parsedLogs);
+        new TCPClient(this.context).sendBatches(batches);
+    } else {
+        var batches = new Batcher(
+            this.context,
+            256 * 1000,
+            4 * 1000 * 1000,
+            400
+        ).batch(parsedLogs);
 
-    return Promise.all(promises.map(p => p.catch(e => e)));
+        var client = new HTTPClient(context);
+        for (i = 0; i < batches.length; i++) {
+            client.handle(batches[i]);
+        }
+
+        var results = await client.sendAll();
+
+        if (results.every(v => v === true) !== true) {
+            context.log.error(
+                'some messages were unable to be sent. See other logs for more details.'
+            );
+        }
+    }
 };
 
 module.exports.forTests = {
-    EventhubLogForwarder,
+    EventhubLogHandler,
     Scrubber,
     ScrubberRule,
+    Batcher,
     constants: {
         STRING,
         STRING_ARRAY,

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -84,41 +84,41 @@ class ScrubberRule {
 class Batcher {
     constructor(
         context,
-        max_item_size_bytes,
-        max_batch_size_bytes,
-        max_items_count
+        maxItemSizeBytes,
+        maxBatchSizeBytes,
+        maxItemsCount
     ) {
-        this.max_item_size_bytes = max_item_size_bytes;
-        this.max_batch_size_bytes = max_batch_size_bytes;
-        this.max_items_count = max_items_count;
+        this.maxItemSizeBytes = maxItemSizeBytes;
+        this.maxBatchSizeBytes = maxBatchSizeBytes;
+        this.maxItemsCount = maxItemsCount;
     }
 
     batch(items) {
         var batches = [];
         var batch = [];
-        var size_bytes = 0;
-        var size_count = 0;
+        var sizeBytes = 0;
+        var sizeCount = 0;
         items.forEach(item => {
-            var item_size_bytes = this.getSizeInBytes(item);
+            var itemSizeBytes = this.getSizeInBytes(item);
             if (
-                size_count > 0 &&
-                (size_count >= this.max_items_count ||
-                    size_bytes + item_size_bytes > this.max_batch_size_bytes)
+                sizeCount > 0 &&
+                (sizeCount >= this.maxItemsCount ||
+                    sizeBytes + itemSizeBytes > this.maxBatchSizeBytes)
             ) {
                 batches.push(batch);
                 batch = [];
-                size_bytes = 0;
-                size_count = 0;
+                sizeBytes = 0;
+                sizeCount = 0;
             }
-            // all items exceeding max_item_size_bytes are dropped here
-            if (item_size_bytes <= this.max_item_size_bytes) {
+            // all items exceeding maxItemSizeBytes are dropped here
+            if (itemSizeBytes <= this.maxItemSizeBytes) {
                 batch.push(item);
-                size_bytes += item_size_bytes;
-                size_count += 1;
+                sizeBytes += itemSizeBytes;
+                sizeCount += 1;
             }
         });
 
-        if (size_count > 0) {
+        if (sizeCount > 0) {
             batches.push(batch);
         }
         return batches;

--- a/azure/test/client.test.js
+++ b/azure/test/client.test.js
@@ -571,6 +571,20 @@ describe('Batching', function() {
             expected = [[{ hi: 'bye' }], ['bleh']];
             assert.deepEqual(actual, expected);
         });
+        it('should return two batches because of batch size bytes', function() {
+            batcher = new client.Batcher(5, 12, 10);
+            logs = [{ hi: 'bye' }, 'bleh'];
+            actual = batcher.batch(logs);
+            expected = [[{ hi: 'bye' }], ['bleh']];
+            assert.deepEqual(actual, expected);
+        });
+        it('should drop message based on message bytes size', function() {
+            batcher = new client.Batcher(5, 5, 1);
+            logs = [{ hi: 'bye' }, 'bleh'];
+            actual = batcher.batch(logs);
+            expected = [['bleh']];
+            assert.deepEqual(actual, expected);
+        });
     });
     describe('#getSizeInBytes', function() {
         it('should return 5 for string', function() {

--- a/azure/test/client.test.js
+++ b/azure/test/client.test.js
@@ -14,8 +14,7 @@ function fakeContext() {
 }
 
 function setUp() {
-    var forwarder = new client.EventhubLogForwarder(fakeContext());
-    forwarder.sendWithRetry = sinon.spy();
+    var forwarder = new client.EventhubLogHandler(fakeContext());
 
     forwarder.addTagsToJsonLog = x => {
         return Object.assign({ ddsource: 'none' }, x);
@@ -314,23 +313,13 @@ describe('Azure Log Monitoring', function() {
     });
 
     function testHandleJSONLogs(forwarder, logs, expected) {
-        forwarder.handleLogs(logs);
-        expected.forEach(message => {
-            sinon.assert.calledWith(
-                forwarder.sendWithRetry,
-                forwarder.addTagsToJsonLog(message)
-            );
-        });
+        actual = forwarder.handleLogs(logs);
+        assert.deepEqual(actual, expected);
     }
 
     function testHandleStringLogs(forwarder, logs, expected) {
-        forwarder.handleLogs(logs);
-        expected.forEach(message => {
-            sinon.assert.calledWith(
-                forwarder.sendWithRetry,
-                forwarder.addTagsToStringLog(message)
-            );
-        });
+        actual = forwarder.handleLogs(logs);
+        assert.deepEqual(actual, expected);
     }
 
     describe('#handleLogs', function() {
@@ -340,14 +329,14 @@ describe('Azure Log Monitoring', function() {
 
         it('should handle string properly', function() {
             log = 'hello';
-            expected = ['hello'];
+            expected = [{ ddsource: 'none', message: 'hello' }];
             assert.equal(this.forwarder.getLogFormat(log), constants.STRING);
             testHandleStringLogs(this.forwarder, log, expected);
         });
 
         it('should handle json-string properly', function() {
             log = '{"hello": "there"}';
-            expected = [{ hello: 'there' }];
+            expected = [{ ddsource: 'none', hello: 'there' }];
             assert.equal(
                 this.forwarder.getLogFormat(log),
                 constants.JSON_STRING
@@ -357,7 +346,7 @@ describe('Azure Log Monitoring', function() {
 
         it('should handle json-object properly', function() {
             log = { hello: 'there' };
-            expected = [{ hello: 'there' }];
+            expected = [{ ddsource: 'none', hello: 'there' }];
             assert.equal(
                 this.forwarder.getLogFormat(log),
                 constants.JSON_OBJECT
@@ -367,7 +356,10 @@ describe('Azure Log Monitoring', function() {
 
         it('should handle string-array properly', function() {
             log = ['one message', 'two message'];
-            expected = ['one message', 'two message'];
+            expected = [
+                { ddsource: 'none', message: 'one message' },
+                { ddsource: 'none', message: 'two message' }
+            ];
             assert.equal(
                 this.forwarder.getLogFormat(log),
                 constants.STRING_ARRAY
@@ -377,7 +369,10 @@ describe('Azure Log Monitoring', function() {
 
         it('should handle json-records properly', function() {
             log = [{ records: [{ hello: 'there' }, { goodbye: 'now' }] }];
-            expected = [{ hello: 'there' }, { goodbye: 'now' }];
+            expected = [
+                { ddsource: 'none', hello: 'there' },
+                { ddsource: 'none', goodbye: 'now' }
+            ];
             assert.equal(
                 this.forwarder.getLogFormat(log),
                 constants.JSON_ARRAY
@@ -387,7 +382,10 @@ describe('Azure Log Monitoring', function() {
 
         it('should handle json-array properly', function() {
             log = [{ hello: 'there' }, { goodbye: 'now' }];
-            expected = [{ hello: 'there' }, { goodbye: 'now' }];
+            expected = [
+                { ddsource: 'none', hello: 'there' },
+                { ddsource: 'none', goodbye: 'now' }
+            ];
             assert.equal(
                 this.forwarder.getLogFormat(log),
                 constants.JSON_ARRAY
@@ -397,7 +395,7 @@ describe('Azure Log Monitoring', function() {
 
         it('should handle buffer array properly', function() {
             log = [Buffer.from('{"records": [{ "test": "testing"}]}')];
-            expected = [{ test: 'testing' }];
+            expected = [{ ddsource: 'none', test: 'testing' }];
             assert.equal(
                 this.forwarder.getLogFormat(log),
                 constants.BUFFER_ARRAY
@@ -407,7 +405,7 @@ describe('Azure Log Monitoring', function() {
 
         it('should handle buffer array without records properly', function() {
             log = [Buffer.from('{ "test": "example"}')];
-            expected = [{ test: 'example' }];
+            expected = [{ ddsource: 'none', test: 'example' }];
             assert.equal(
                 this.forwarder.getLogFormat(log),
                 constants.BUFFER_ARRAY
@@ -417,7 +415,7 @@ describe('Azure Log Monitoring', function() {
 
         it('should handle buffer array with malformed string', function() {
             log = [Buffer.from('{"time": "xy')];
-            expected = ['{"time": "xy'];
+            expected = [{ ddsource: 'none', message: '{"time": "xy' }];
             assert.equal(
                 this.forwarder.getLogFormat(log),
                 constants.BUFFER_ARRAY
@@ -427,7 +425,10 @@ describe('Azure Log Monitoring', function() {
 
         it('should handle json-string-array properly records', function() {
             log = ['{"records": [{ "time": "xyz"}, {"time": "abc"}]}'];
-            expected = [{ time: 'xyz' }];
+            expected = [
+                { ddsource: 'none', time: 'xyz' },
+                { ddsource: 'none', time: 'abc' }
+            ];
             assert.equal(
                 this.forwarder.getLogFormat(log),
                 constants.JSON_STRING_ARRAY
@@ -437,7 +438,7 @@ describe('Azure Log Monitoring', function() {
 
         it('should handle json-string-array properly no records', function() {
             log = ['{"time": "xyz"}'];
-            expected = [{ time: 'xyz' }];
+            expected = [{ ddsource: 'none', time: 'xyz' }];
             assert.equal(
                 this.forwarder.getLogFormat(log),
                 constants.JSON_STRING_ARRAY
@@ -447,13 +448,14 @@ describe('Azure Log Monitoring', function() {
 
         it('should handle json-string-array with malformed string', function() {
             log = ['{"time": "xyz"}', '{"time": "xy'];
-            expected = ['{"time": "xy'];
+            expected = [
+                { ddsource: 'none', time: 'xyz' },
+                { ddsource: 'none', message: '{"time": "xy' }
+            ];
             assert.equal(
                 this.forwarder.getLogFormat(log),
                 constants.JSON_STRING_ARRAY
             );
-            // just assert that the string method is called for the second message,
-            // we don't care about the first one for this test
             testHandleStringLogs(this.forwarder, log, expected);
         });
     });
@@ -555,6 +557,35 @@ describe('Azure Log Monitoring', function() {
             actual = scrubber.scrub(
                 'client_ip: 12.123.23.12, client_ip2: 122.123.213.112 email: hello@test.com email2: hello2@test.com'
             );
+            assert.equal(actual, expected);
+        });
+    });
+});
+
+describe('Batching', function() {
+    describe('#batch', function() {
+        it('should return two batches because of size', function() {
+            batcher = new client.Batcher(15, 15, 1);
+            logs = [{ hi: 'bye' }, 'bleh'];
+            actual = batcher.batch(logs);
+            expected = [[{ hi: 'bye' }], ['bleh']];
+            assert.deepEqual(actual, expected);
+        });
+    });
+    describe('#getSizeInBytes', function() {
+        it('should return 5 for string', function() {
+            batcher = new client.Batcher(15, 15, 1);
+            log = 'aaaaa';
+            actual = batcher.getSizeInBytes(log);
+            expected = 5;
+            assert.equal(actual, expected);
+        });
+
+        it('should return 7 for object', function() {
+            batcher = new client.Batcher(15, 15, 1);
+            log = { a: 2 };
+            actual = batcher.getSizeInBytes(log);
+            expected = 7;
             assert.equal(actual, expected);
         });
     });


### PR DESCRIPTION

### What does this PR do?
Adds in batching for the HTTP requests, to group together logs instead of send logs individually as separate HTTP requests. These requests should be executing in parallel anyway (since using Promise.all) but it should hopefully help a bit to group them all into fewer requests overall.

Also adds in optional TCP support with all of the new logic that's been added since it was moved to only work with HTTP. TCP is much faster than HTTP because the data is streamed, versus with HTTP the data gets persisted and a 200 response means that we've acknowledged and stored the log data on our end. The tradeoff is that with TCP you don't have guarantees that we've received the message.

### Motivation

Try to speed up the HTTP log forwarder, as well as allow customers to use TCP if they want

### Testing Guidelines

Tested with my own version of the forwarder, made sure that logs are flowing in with both versions. Also updated unit tests for some of the batching logic.

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
