### PR TITLE
[azure] Support multiple fields to split on in one source

### DIFF
--- a/azure/activity_logs_monitoring/README.md
+++ b/azure/activity_logs_monitoring/README.md
@@ -67,7 +67,7 @@ An example of an azure.datafactory use case is provided in the code and commente
 ```
 {
   source_type:
-    path: [list of fields in the log payload to iterate through to find the one to split],
+    paths: [list of [list of fields in the log payload to iterate through to find the one to split]],
     keep_original_log: bool, if you'd like to preserve the original log in addition to the split ones or not
 }
 ```

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -290,9 +290,9 @@ class EventhubLogHandler {
                         this.records.push(newRecord);
                     }
                 }
-                if (splitFieldFound !== true || config.keep_original_log) {
-                    // keep the original log if we didn't actually split any fields, or if we've set
-                    // keep_original_log to preserve the full log when we split
+                if (config.keep_original_log || splitFieldFound !== true) {
+                    // keep the original log if it is set in the config
+                    // if it is false in the config, we should still write the log when we don't split
                     this.records.push(originalRecord);
                 }
             } else {

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -257,7 +257,7 @@ class EventhubLogHandler {
             var source = originalRecord['ddsource'];
             var config = this.logSplittingConfig[source];
             if (config !== undefined) {
-                var logSplit = false;
+                var splitFieldFound = false;
 
                 for (var i = 0; i < config.paths.length; i++) {
                     var fields = config.paths[i];
@@ -266,7 +266,7 @@ class EventhubLogHandler {
                         continue;
                     }
 
-                    logSplit = true;
+                    splitFieldFound = true;
                     for (var j = 0; j < recordsToSplit.length; j++) {
                         var splitRecord = recordsToSplit[j];
                         if (typeof splitRecord === 'string') {
@@ -290,7 +290,7 @@ class EventhubLogHandler {
                         this.records.push(newRecord);
                     }
                 }
-                if (logSplit !== true || config.keep_original_log) {
+                if (splitFieldFound !== true || config.keep_original_log) {
                     // keep the original log if we didn't actually split any fields, or if we've set
                     // keep_original_log to preserve the full log when we split
                     this.records.push(originalRecord);

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -5,7 +5,7 @@
 
 var https = require('https');
 
-const VERSION = '0.5.1';
+const VERSION = '0.5.2';
 
 const STRING = 'string'; // example: 'some message'
 const STRING_ARRAY = 'string-array'; // example: ['one message', 'two message', ...]

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -264,7 +264,7 @@ class EventhubLogHandler {
                     var recordsToSplit = this.findSplitRecords(record, fields);
                     if (
                         recordsToSplit === null ||
-                        recordsToSplit instanceof Array !== true
+                        !(recordsToSplit instanceof Array)
                     ) {
                         // if we were unable find the field or if the field isn't an array, skip it
                         continue;
@@ -280,7 +280,7 @@ class EventhubLogHandler {
                             }
                         }
 
-                        if (splitRecord instanceof Map === false) {
+                        if (!(splitRecord instanceof Map)) {
                             // if it's not a map, then just send as a string
                             splitRecord = {
                                 message: JSON.stringify(splitRecord)

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -55,10 +55,10 @@ a potential use case with azure.datafactory is there to show the format:
 You can also set the DD_LOG_SPLITTING_CONFIG env var with a JSON string in this format.
 */
 const DD_LOG_SPLITTING_CONFIG = {
-//     'azure.datafactory': {
-//         paths: [['properties', 'Output', 'value'], ...],
-//         keep_original_log: true
-//     }
+    // 'azure.datafactory': {
+    //     paths: [['properties', 'Output', 'value']],
+    //     keep_original_log: true
+    // }
 };
 
 function getLogSplittingConfig() {
@@ -258,16 +258,15 @@ class EventhubLogHandler {
             var config = this.logSplittingConfig[source];
             if (config !== undefined) {
                 var logSplit = false;
-                var paths = config.paths;
 
-                for (var i = 0; i < paths.length; i++) {
-                    var fields = paths[i]
+                for (var i = 0; i < config.paths.length; i++) {
+                    var fields = config.paths[i];
                     var recordsToSplit = this.findSplitRecords(record, fields);
                     if (recordsToSplit === null) {
                         continue;
                     }
-                    logSplit = true;
 
+                    logSplit = true;
                     for (var j = 0; j < recordsToSplit.length; j++) {
                         var splitRecord = recordsToSplit[j];
                         if (typeof splitRecord === 'string') {
@@ -279,17 +278,21 @@ class EventhubLogHandler {
                         }
                         var newRecord = {
                             ddsource: source,
-                            ddsourcecategory: originalRecord['ddsourcecategory'],
+                            ddsourcecategory:
+                                originalRecord['ddsourcecategory'],
                             service: originalRecord['service'],
-                            ddtags: originalRecord['ddtags'],
-                            time: originalRecord['time']
+                            ddtags: originalRecord['ddtags']
                         };
+                        if (originalRecord['time'] !== undefined) {
+                            newRecord['time'] = originalRecord['time'];
+                        }
                         Object.assign(newRecord, splitRecord);
                         this.records.push(newRecord);
                     }
-
                 }
                 if (logSplit !== true || config.keep_original_log) {
+                    // keep the original log if we didn't actually split any fields, or if we've set
+                    // keep_original_log to preserve the full log when we split
                     this.records.push(originalRecord);
                 }
             } else {

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -262,10 +262,13 @@ class EventhubLogHandler {
                 for (var i = 0; i < config.paths.length; i++) {
                     var fields = config.paths[i];
                     var recordsToSplit = this.findSplitRecords(record, fields);
-                    if (recordsToSplit === null) {
+                    if (
+                        recordsToSplit === null ||
+                        recordsToSplit instanceof Array !== true
+                    ) {
+                        // if we were unable find the field or if the field isn't an array, skip it
                         continue;
                     }
-
                     splitFieldFound = true;
                     for (var j = 0; j < recordsToSplit.length; j++) {
                         var splitRecord = recordsToSplit[j];
@@ -275,6 +278,13 @@ class EventhubLogHandler {
                             } catch (err) {
                                 splitRecord = { message: splitRecord };
                             }
+                        }
+
+                        if (splitRecord instanceof Map === false) {
+                            // if it's not a map, then just send as a string
+                            splitRecord = {
+                                message: JSON.stringify(splitRecord)
+                            };
                         }
                         var newRecord = {
                             ddsource: source,


### PR DESCRIPTION
### What does this PR do?

Allows customers using the eventhub log forwarder to split on different field paths for the same source type. For example, if some azure.datafactory logs come in with different fields and they want to split out both.

### Motivation
Support more custom split cases in the eventhub log forwarder

### Testing Guidelines
Tested in test environment, sent in a log with multiple array fields and multiple paths, as well as individual paths and confirmed that logs were split out and that the original log was sent

### Additional Notes

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
