### PR TITLE
[azure] Preserve original log fields in split logs in eventhub log forwarder

### DIFF
--- a/azure/activity_logs_monitoring/README.md
+++ b/azure/activity_logs_monitoring/README.md
@@ -62,6 +62,7 @@ To scrub PII from your logs, uncomment the SCRUBBER_RULE_CONFIG code. If you'd l
 - **Log Splitting**
 
 To split array-type fields in your logs into individual logs, you can add sections to the DD_LOG_SPLITTING_CONFIG map in the code or by setting the DD_LOG_SPLITTING_CONFIG env variable (which must be a json string in the same format).
+This will create an attribute in your logs called "parsed_arrays", which contains the fields in the format of the original log with the split log value.
 
 An example of an azure.datafactory use case is provided in the code and commented out. The format is as follows:
 ```

--- a/azure/activity_logs_monitoring/README.md
+++ b/azure/activity_logs_monitoring/README.md
@@ -68,6 +68,7 @@ An example of an azure.datafactory use case is provided in the code and commente
 {
   source_type:
     paths: [list of [list of fields in the log payload to iterate through to find the one to split]],
-    keep_original_log: bool, if you'd like to preserve the original log in addition to the split ones or not
+    keep_original_log: bool, if you'd like to preserve the original log in addition to the split ones or not,
+    preserve_fields: bool, whether or not to keep the original log fields in the new split logs
 }
 ```

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -281,13 +281,18 @@ class EventhubLogHandler {
                             } catch (err) {}
                         }
                         var formattedSplitRecord = {};
+                        var tempformattedSplitRecord = formattedSplitRecord;
                         // re-create the same section with only the split log
                         for (var k = 0; k < fields.length; k++) {
                             if (k === fields.length - 1) {
                                 // if it is the last field, add the split record
-                                formattedSplitRecord[fields[k]] = splitRecord;
+                                tempformattedSplitRecord[
+                                    fields[k]
+                                ] = splitRecord;
                             } else {
-                                formattedSplitRecord[fields[k]] = {};
+                                tempformattedSplitRecord[fields[k]] = {};
+                                tempformattedSplitRecord =
+                                    tempformattedSplitRecord[fields[k]];
                             }
                         }
                         formattedSplitRecord = {

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -273,7 +273,6 @@ class EventhubLogHandler {
                     }
                     splitFieldFound = true;
 
-                    var fieldPrefix = fields.join('_');
                     for (var j = 0; j < recordsToSplit.length; j++) {
                         var splitRecord = recordsToSplit[j];
                         if (typeof splitRecord === 'string') {
@@ -281,21 +280,20 @@ class EventhubLogHandler {
                                 splitRecord = JSON.parse(splitRecord);
                             } catch (err) {}
                         }
-                        var namedSplitRecord = {};
-                        if (
-                            typeof splitRecord === 'string' ||
-                            typeof splitRecord === 'number'
-                        ) {
-                            namedSplitRecord[fieldPrefix] = splitRecord;
-                        } else {
-                            for (const [key, value] of Object.entries(
-                                splitRecord
-                            )) {
-                                namedSplitRecord[
-                                    fieldPrefix + '_' + key
-                                ] = value;
+                        var formattedSplitRecord = {};
+                        // re-create the same section with only the split log
+                        for (var k = 0; k < fields.length; k++) {
+                            if (k === fields.length - 1) {
+                                // if it is the last field, add the split record
+                                formattedSplitRecord[fields[k]] = splitRecord;
+                            } else {
+                                formattedSplitRecord[fields[k]] = {};
                             }
                         }
+                        formattedSplitRecord = {
+                            parsed_arrays: formattedSplitRecord
+                        };
+
                         if (config.preserve_fields) {
                             var newRecord = {};
                             Object.assign(newRecord, originalRecord);
@@ -311,7 +309,7 @@ class EventhubLogHandler {
                                 newRecord['time'] = originalRecord['time'];
                             }
                         }
-                        Object.assign(newRecord, namedSplitRecord);
+                        Object.assign(newRecord, formattedSplitRecord);
                         this.records.push(newRecord);
                     }
                 }

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -5,7 +5,7 @@
 
 var https = require('https');
 
-const VERSION = '0.5.2';
+const VERSION = '0.5.3';
 
 const STRING = 'string'; // example: 'some message'
 const STRING_ARRAY = 'string-array'; // example: ['one message', 'two message', ...]
@@ -50,14 +50,16 @@ a potential use case with azure.datafactory is there to show the format:
 {
   source_type:
     paths: [list of [list of fields in the log payload to iterate through to find the one to split]],
-    keep_original_log: bool, if you'd like to preserve the original log in addition to the split ones or not
+    keep_original_log: bool, if you'd like to preserve the original log in addition to the split ones or not,
+    preserve_fields: bool, whether or not to keep the original log fields in the new split logs
 }
 You can also set the DD_LOG_SPLITTING_CONFIG env var with a JSON string in this format.
 */
 const DD_LOG_SPLITTING_CONFIG = {
     // 'azure.datafactory': {
     //     paths: [['properties', 'Output', 'value']],
-    //     keep_original_log: true
+    //     keep_original_log: true,
+    //     preserve_fields: true
     // }
 };
 
@@ -270,33 +272,46 @@ class EventhubLogHandler {
                         continue;
                     }
                     splitFieldFound = true;
+
+                    var fieldPrefix = fields.join('_');
                     for (var j = 0; j < recordsToSplit.length; j++) {
                         var splitRecord = recordsToSplit[j];
                         if (typeof splitRecord === 'string') {
                             try {
                                 splitRecord = JSON.parse(splitRecord);
-                            } catch (err) {
-                                splitRecord = { message: splitRecord };
+                            } catch (err) {}
+                        }
+                        var namedSplitRecord = {};
+                        if (
+                            typeof splitRecord === 'string' ||
+                            typeof splitRecord === 'number'
+                        ) {
+                            namedSplitRecord[fieldPrefix] = splitRecord;
+                        } else {
+                            for (const [key, value] of Object.entries(
+                                splitRecord
+                            )) {
+                                namedSplitRecord[
+                                    fieldPrefix + '_' + key
+                                ] = value;
                             }
                         }
-
-                        if (!(splitRecord instanceof Map)) {
-                            // if it's not a map, then just send as a string
-                            splitRecord = {
-                                message: JSON.stringify(splitRecord)
+                        if (config.preserve_fields) {
+                            var newRecord = {};
+                            Object.assign(newRecord, originalRecord);
+                        } else {
+                            var newRecord = {
+                                ddsource: source,
+                                ddsourcecategory:
+                                    originalRecord['ddsourcecategory'],
+                                service: originalRecord['service'],
+                                ddtags: originalRecord['ddtags']
                             };
+                            if (originalRecord['time'] !== undefined) {
+                                newRecord['time'] = originalRecord['time'];
+                            }
                         }
-                        var newRecord = {
-                            ddsource: source,
-                            ddsourcecategory:
-                                originalRecord['ddsourcecategory'],
-                            service: originalRecord['service'],
-                            ddtags: originalRecord['ddtags']
-                        };
-                        if (originalRecord['time'] !== undefined) {
-                            newRecord['time'] = originalRecord['time'];
-                        }
-                        Object.assign(newRecord, splitRecord);
+                        Object.assign(newRecord, namedSplitRecord);
                         this.records.push(newRecord);
                     }
                 }

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -281,18 +281,15 @@ class EventhubLogHandler {
                             } catch (err) {}
                         }
                         var formattedSplitRecord = {};
-                        var tempformattedSplitRecord = formattedSplitRecord;
-                        // re-create the same section with only the split log
+                        var temp = formattedSplitRecord;
+                        // re-create the same nested attributes with only the split log
                         for (var k = 0; k < fields.length; k++) {
                             if (k === fields.length - 1) {
                                 // if it is the last field, add the split record
-                                tempformattedSplitRecord[
-                                    fields[k]
-                                ] = splitRecord;
+                                temp[fields[k]] = splitRecord;
                             } else {
-                                tempformattedSplitRecord[fields[k]] = {};
-                                tempformattedSplitRecord =
-                                    tempformattedSplitRecord[fields[k]];
+                                temp[fields[k]] = {};
+                                temp = temp[fields[k]];
                             }
                         }
                         formattedSplitRecord = {

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -297,8 +297,7 @@ class EventhubLogHandler {
                         };
 
                         if (config.preserve_fields) {
-                            var newRecord = {};
-                            Object.assign(newRecord, originalRecord);
+                            var newRecord = { ...originalRecord };
                         } else {
                             var newRecord = {
                                 ddsource: source,


### PR DESCRIPTION
### What does this PR do?

- Adds 'preserve_fields' option in log splitting config for whether or not to keep the fields from the original logs in the new split logs
- Adds the split log back into the log under a parsed_arrays key, with the same nesting structure as the original log. For example, with a log formatted with these fields:

```
properties:
  Predecessors: [
    {hello: goodbye, some_other: attribute},
     ... other maps
]
```

The split logs would now have this field format added, so customers can filter/add facets on the "hello" and "some_other" keys:
```
parsed_arrays:
  properties:
    Predecessors:
       hello: goodbye,
       some_other: attribute
```

### Motivation
- Better support for log splitting

### Testing Guidelines
- Tested in test environment with different test cases (maps, strings, numbers) and things work as expected.

### Additional Notes

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
