### PR TITLE
Slim cloudformation install flow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,10 @@ jobs:
           pip install black
           black --check ./aws/logs_monitoring
 
-      - name: Lint CloudFormation template with cfn-lint
-        uses: scottbrenner/cfn-lint-action@master
-        with:
-          args: "aws/logs_monitoring/template.yaml"
+      - name: Setup Cloud Formation Linter with Latest Version
+        uses: scottbrenner/cfn-lint-action@v2
+
+      - name: Print the Cloud Formation Linter Version & run Linter.
+        run: |
+          cfn-lint --version
+          cfn-lint -t aws/logs_monitoring/template.yaml

--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -365,8 +365,8 @@ To test different patterns against your logs, turn on [debug logs](#troubleshoot
 
 `AdditionalTargetLambdaARNs`
 : Comma separated list of Lambda ARNs that will get called asynchronously with the same `event` the Datadog Forwarder receives.
-`InstallFromLayer`
-: Disable to use legacy installation flow, (via Github), for regions where Lambda layers aren't supported, such as regions in China. Defaults to true.
+`InstallAsLayer`
+: Whether to use the layer based installation flow. Set to false to use our legacy installation flow, which installs a second function that copies the forwarder code from Github to an S3 bucket. Disable this option if installing into AWS China regions, where we don't publish layers. Defaults to true.
 `LayerARN`
 : ARN for the layer containing the forwarder code. If empty, the script will use the version of the layer the forwarder was published with. Defaults to empty.
 

--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -366,7 +366,7 @@ To test different patterns against your logs, turn on [debug logs](#troubleshoot
 `AdditionalTargetLambdaARNs`
 : Comma separated list of Lambda ARNs that will get called asynchronously with the same `event` the Datadog Forwarder receives.
 `InstallAsLayer`
-: Whether to use the layer based installation flow. Set to false to use our legacy installation flow, which installs a second function that copies the forwarder code from Github to an S3 bucket. Disable this option if installing into AWS China regions, where we don't publish layers. Defaults to true.
+: Whether to use the layer-based installation flow. Set to false to use our legacy installation flow, which installs a second function that copies the forwarder code from Github to an S3 bucket. Defaults to true.
 `LayerARN`
 : ARN for the layer containing the forwarder code. If empty, the script will use the version of the layer the forwarder was published with. Defaults to empty.
 

--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -365,6 +365,10 @@ To test different patterns against your logs, turn on [debug logs](#troubleshoot
 
 `AdditionalTargetLambdaARNs`
 : Comma separated list of Lambda ARNs that will get called asynchronously with the same `event` the Datadog Forwarder receives.
+`InstallFromLayer`
+: Disable to use legacy installation flow, (via Github), for regions where Lambda layers aren't supported, such as regions in China. Defaults to true.
+`LayerARN`
+: ARN for the layer containing the forwarder code. If empty, the script will use the version of the layer the forwarder was published with. Defaults to empty.
 
 ## Permissions
 

--- a/aws/logs_monitoring/release.sh
+++ b/aws/logs_monitoring/release.sh
@@ -81,7 +81,7 @@ if [ "$ACCOUNT" = "prod" ] ; then
 
     # Confirm to proceed
     echo
-    read -p "About to bump the version from ${CURRENT_VERSION} to ${FORWARDER_VERSION}, create a release aws-dd-forwarder-${FORWARDER_VERSION} on GitHub and upload the template.yaml to s3://${BUCKET}/aws/forwarder/${FORWARDER_VERSION}.yaml. Continue (y/n)?" CONT
+    read -p "About to bump the version from ${CURRENT_VERSION} to ${FORWARDER_VERSION}, create a release of aws-dd-forwarder-${FORWARDER_VERSION} on GitHub, upload the template.yaml to s3://${BUCKET}/aws/forwarder/${FORWARDER_VERSION}.yaml and create lambda layer version ${LAYER_VERSION}. Continue (y/n)?" CONT
     if [ "$CONT" != "y" ]; then
         echo "Exiting..."
         exit 1

--- a/aws/logs_monitoring/release.sh
+++ b/aws/logs_monitoring/release.sh
@@ -17,10 +17,10 @@ elif [[ ! $1 =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
     echo "ERROR: You must use a semantic version (e.g. 3.1.4)"
     exit 1
 else
-    VERSION=$1
+    FORWARDER_VERSION=$1
 fi
 
-BUNDLE_PATH=".forwarder/aws-dd-forwarder-${VERSION}.zip"
+BUNDLE_PATH=".forwarder/aws-dd-forwarder-${FORWARDER_VERSION}.zip"
 
 # Check account parameter
 VALID_ACCOUNTS=("sandbox" "prod")
@@ -54,11 +54,11 @@ get_max_layer_version() {
 aws sts get-caller-identity
 
 CURRENT_ACCOUNT="$(aws sts get-caller-identity --query Account --output text)"
-CURRENT_VERSION=$(get_max_layer_version)
-NEXT_LAYER_VERSION=$(($CURRENT_VERSION +1))
+CURRENT_LAYER_VERSION=$(get_max_layer_version)
+LAYER_VERSION=$(($CURRENT_LAYER_VERSION +1))
 
 echo
-echo "Current layer version is $CURRENT_VERSION, next layer version is $NEXT_LAYER_VERSION"
+echo "Current layer version is $CURRENT_LAYER_VERSION, next layer version is $LAYER_VERSION"
 
 # Validate the template
 echo
@@ -67,7 +67,7 @@ aws cloudformation validate-template --template-body file://template.yaml
 
 if [ "$ACCOUNT" = "prod" ] ; then
 
-    if [[ ! $(./tools/semver.sh "$VERSION" "$CURRENT_VERSION") > 0 ]]; then
+    if [[ ! $(./tools/semver.sh "$FORWARDER_VERSION" "$CURRENT_VERSION") > 0 ]]; then
         echo "Must use a version greater than the current ($CURRENT_VERSION)"
         exit 1
     fi
@@ -81,7 +81,7 @@ if [ "$ACCOUNT" = "prod" ] ; then
 
     # Confirm to proceed
     echo
-    read -p "About to bump the version from ${CURRENT_VERSION} to ${VERSION}, create a release aws-dd-forwarder-${VERSION} on GitHub and upload the template.yaml to s3://${BUCKET}/aws/forwarder/${VERSION}.yaml. Continue (y/n)?" CONT
+    read -p "About to bump the version from ${CURRENT_VERSION} to ${FORWARDER_VERSION}, create a release aws-dd-forwarder-${FORWARDER_VERSION} on GitHub and upload the template.yaml to s3://${BUCKET}/aws/forwarder/${FORWARDER_VERSION}.yaml. Continue (y/n)?" CONT
     if [ "$CONT" != "y" ]; then
         echo "Exiting..."
         exit 1
@@ -91,21 +91,21 @@ if [ "$ACCOUNT" = "prod" ] ; then
     git pull origin master
 
     # Bump version number in settings.py and template.yml
-    echo "Bumping the version number to ${VERSION}..."
-    perl -pi -e "s/DD_FORWARDER_VERSION = \"[0-9\.]+/DD_FORWARDER_VERSION = \"${VERSION}/g" settings.py
-    perl -pi -e "s/Version: [0-9\.]+/Version: ${VERSION}/g" template.yaml
-    perl -pi -e "s/LayerVersion: [0-9\.]+/LayerVersion: ${NEXT_LAYER_VERSION}/g" template.yaml
+    echo "Bumping the version number to ${FORWARDER_VERSION}..."
+    perl -pi -e "s/DD_FORWARDER_VERSION = \"[0-9\.]+/DD_FORWARDER_VERSION = \"${FORWARDER_VERSION}/g" settings.py
+    perl -pi -e "s/Version: [0-9\.]+/Version: ${FORWARDER_VERSION}/g" template.yaml
+    perl -pi -e "s/LayerVersion: [0-9\.]+/LayerVersion: ${LAYER_VERSION}/g" template.yaml
 
     # Commit version number changes to git
     echo "Committing version number change..."
     git add settings.py template.yaml
-    git commit -m "Bump version from ${CURRENT_VERSION} to ${VERSION}"
+    git commit -m "Bump version from ${CURRENT_VERSION} to ${FORWARDER_VERSION}"
     git push origin master
 
     # Build the bundle
     echo
     echo "Building the Forwarder bundle..."
-    ./tools/build_bundle.sh "${VERSION}"
+    ./tools/build_bundle.sh "${FORWARDER_VERSION}"
 
     # Sign the bundle
     echo
@@ -114,23 +114,23 @@ if [ "$ACCOUNT" = "prod" ] ; then
 
     # Create a GitHub release
     echo
-    echo "Releasing aws-dd-forwarder-${VERSION} to GitHub..."
+    echo "Releasing aws-dd-forwarder-${FORWARDER_VERSION} to GitHub..."
     go get github.com/github/hub
-    hub release create -a $BUNDLE_PATH -m "aws-dd-forwarder-${VERSION}" aws-dd-forwarder-${VERSION}
+    hub release create -a $BUNDLE_PATH -m "aws-dd-forwarder-${FORWARDER_VERSION}" aws-dd-forwarder-${FORWARDER_VERSION}
     
-    # Upload the sandbox layers
+    # Upload the prod layers
     echo
     echo "Uploading layers"
-    ./tools/publish_prod.sh $NEXT_LAYER_VERSION $VERSION
+    ./tools/publish_prod.sh $LAYER_VERSION $FORWARDER_VERSION
 
     # Set vars for use in the installation test
     TEMPLATE_URL="https://${BUCKET}.s3.amazonaws.com/aws/forwarder/latest.yaml"
-    FORWARDER_SOURCE_URL="https://github.com/DataDog/datadog-serverless-functions/releases/download/aws-dd-forwarder-${VERSION}/aws-dd-forwarder-${VERSION}.zip'"
+    FORWARDER_SOURCE_URL="https://github.com/DataDog/datadog-serverless-functions/releases/download/aws-dd-forwarder-${FORWARDER_VERSION}/aws-dd-forwarder-${FORWARDER_VERSION}.zip'"
 else
     # Build the bundle
     echo
     echo "Building the Forwarder bundle..."
-    ./tools/build_bundle.sh $VERSION
+    ./tools/build_bundle.sh $FORWARDER_VERSION
 
     # Sign the bundle
     echo
@@ -140,29 +140,29 @@ else
     # Upload the bundle to S3 instead of GitHub for a sandbox release
     echo
     echo "Uploading non-public sandbox version of Forwarder to S3..."
-    aws s3 cp $BUNDLE_PATH s3://${BUCKET}/aws/forwarder-staging-zip/aws-dd-forwarder-${VERSION}.zip
+    aws s3 cp $BUNDLE_PATH s3://${BUCKET}/aws/forwarder-staging-zip/aws-dd-forwarder-${FORWARDER_VERSION}.zip
     
     # Upload the sandbox layers
     echo
     echo "Uploading layers"
-    ./tools/publish_sandbox.sh $NEXT_LAYER_VERSION $VERSION
+    ./tools/publish_sandbox.sh $LAYER_VERSION $FORWARDER_VERSION
 
     # Set vars for use in the installation test
     TEMPLATE_URL="https://${BUCKET}.s3.amazonaws.com/aws/forwarder-staging/latest.yaml"
-    FORWARDER_SOURCE_URL="s3://${BUCKET}/aws/forwarder-staging-zip/aws-dd-forwarder-${VERSION}.zip"
+    FORWARDER_SOURCE_URL="s3://${BUCKET}/aws/forwarder-staging-zip/aws-dd-forwarder-${FORWARDER_VERSION}.zip"
 fi
 
 # Upload the CloudFormation template to the S3 bucket
 echo
-echo "Uploading template.yaml to s3://${BUCKET}/aws/forwarder/${VERSION}.yaml"
+echo "Uploading template.yaml to s3://${BUCKET}/aws/forwarder/${FORWARDER_VERSION}.yaml"
 
 if [ "$ACCOUNT" = "prod" ] ; then
-    aws s3 cp template.yaml s3://${BUCKET}/aws/forwarder/${VERSION}.yaml \
+    aws s3 cp template.yaml s3://${BUCKET}/aws/forwarder/${FORWARDER_VERSION}.yaml \
         --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
     aws s3 cp template.yaml s3://${BUCKET}/aws/forwarder/latest.yaml \
         --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
 else
-    aws s3 cp template.yaml s3://${BUCKET}/aws/forwarder-staging/${VERSION}.yaml
+    aws s3 cp template.yaml s3://${BUCKET}/aws/forwarder-staging/${FORWARDER_VERSION}.yaml
     aws s3 cp template.yaml s3://${BUCKET}/aws/forwarder-staging/latest.yaml
 fi
 

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -63,7 +63,7 @@ Parameters:
   LayerARN:
     Type: String
     Default: ""
-    Description: DO NOT CHANGE unless you know what you are doing. ARN for the layer containing the forwarder code.
+    Description: ARN for the layer containing the forwarder code. If empty, the script will use the version of the layer the forwarder was published with.
   DdTags:
     Type: String
     Default: ""

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -53,10 +53,10 @@ Parameters:
     Type: String
     Default: ""
     Description: DO NOT CHANGE unless you know what you are doing. Override the default location of the function source code.
-  InstallFromLayer:
+  InstallAsLayer:
     Type: String
     Default: true
-    Description: Disable to use legacy installation flow, (via Github), for regions where Lambda layers aren't supported, such as regions in China.
+    Description: hether to use the layer based installation flow. Set to false to use our legacy installation flow, which installs a second function that copies the forwarder code from Github to an S3 bucket. Disable this option if installing into AWS China regions, where we don't publish layers. Defaults to true.
     AllowedValues:
       - true
       - false
@@ -215,10 +215,10 @@ Conditions:
   UseZipCopier:
     Fn::Or:
       - Condition: IsAWSChina
-      - Condition: SetSourceZipUrl
-      - Fn::Equals:
-          - Ref: InstallFromLayer
-          - "false"
+      - Fn::And:
+          - Fn::Equals: [!Ref InstallAsLayer, "false"]
+          - Fn::Not:
+              - Condition: SetLayerARN
   CreateDdApiKeySecret:
     Fn::Equals:
       - Ref: DdApiKeySecretArn
@@ -937,7 +937,7 @@ Metadata:
           - DdFetchLambdaTags
           - TagsCacheTTLSeconds
           - SourceZipUrl
-          - InstallFromLayer
+          - InstallAsLayer
           - LayerARN
           - PermissionsBoundaryArn
           - DdUsePrivateLink

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -5,6 +5,7 @@ Mappings:
   Constants:
     DdForwarder:
       Version: 3.32.0
+      LayerVersion: 1
 Parameters:
   DdApiKey:
     Type: String
@@ -59,6 +60,10 @@ Parameters:
     AllowedValues:
       - true
       - false
+  LayerARN:
+    Type: String
+    Default: ""
+    Description: DO NOT CHANGE unless you know what you are doing. Version of the layer ARN containing the forwarder code.
   DdTags:
     Type: String
     Default: ""
@@ -203,6 +208,10 @@ Conditions:
     Fn::Equals:
       - Ref: AWS::Partition
       - "aws-cn"
+  IsGovCloud:
+    Fn::Equals:
+      - Ref: AWS::Partition
+      - "aws-us-gov"
   UseZipCopier:
     Fn::Or:
       - Condition: IsAWSChina
@@ -305,6 +314,11 @@ Conditions:
       - Fn::Equals:
           - Ref: DdHttpProxyURL
           - ""
+  SetLayerARN:
+    Fn::Not:
+      - Fn::Equals:
+          - Ref: LayerARN
+          - ""
   UseVPC:
     Fn::Or:
       - Condition: SetDdUsePrivateLink
@@ -374,6 +388,24 @@ Resources:
       Description: Pushes logs, metrics and traces from AWS to Datadog.
       Role: !GetAtt "ForwarderRole.Arn"
       Handler: lambda_function.lambda_handler
+      Layers:
+        Fn::If:
+          - UseZipCopier
+          - []
+          - - Fn::If:
+                - SetLayerARN
+                - !Ref LayerARN
+                - Fn::Join:
+                    - ":"
+                    - - arn
+                      - !Ref AWS::Partition
+                      - lambda
+                      - !Ref AWS::Region
+                      - Fn::If: [IsGovCloud, "002406178527", "464622532012"]
+                      - layer
+                      - Datadog-Forwarder
+                      - Fn::FindInMap: [Constants, DdForwarder, LayerVersion]
+
       Code:
         Fn::If:
           - UseZipCopier

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -56,7 +56,7 @@ Parameters:
   InstallAsLayer:
     Type: String
     Default: true
-    Description: hether to use the layer based installation flow. Set to false to use our legacy installation flow, which installs a second function that copies the forwarder code from Github to an S3 bucket. Disable this option if installing into AWS China regions, where we don't publish layers. Defaults to true.
+    Description: Whether to use the layer-based installation flow. Set to false to use our legacy installation flow, which installs a second function that copies the forwarder code from Github to an S3 bucket. Defaults to true.
     AllowedValues:
       - true
       - false

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -217,7 +217,7 @@ Conditions:
       - Condition: IsAWSChina
       - Condition: SetSourceZipUrl
       - Fn::Equals:
-          - InstallFromLayer
+          - Ref: InstallFromLayer
           - "false"
   CreateDdApiKeySecret:
     Fn::Equals:

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -417,7 +417,7 @@ Resources:
                     DdForwarderVersion:
                       !FindInMap [Constants, DdForwarder, Version],
                   }
-          - ZipFile: println("Hello")
+          - ZipFile: " "
 
       MemorySize:
         Ref: MemorySize
@@ -938,6 +938,7 @@ Metadata:
           - TagsCacheTTLSeconds
           - SourceZipUrl
           - InstallFromLayer
+          - LayerARN
           - PermissionsBoundaryArn
           - DdUsePrivateLink
           - DdUseVPC

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -56,14 +56,14 @@ Parameters:
   InstallFromLayer:
     Type: String
     Default: true
-    Description: DO NOT CHANGE unless you know what you are doing. Disable to use legacy installation flow, (via Github), for regions where Lambda layers aren't supported.
+    Description: Disable to use legacy installation flow, (via Github), for regions where Lambda layers aren't supported, such as regions in China.
     AllowedValues:
       - true
       - false
   LayerARN:
     Type: String
     Default: ""
-    Description: DO NOT CHANGE unless you know what you are doing. Version of the layer ARN containing the forwarder code.
+    Description: DO NOT CHANGE unless you know what you are doing. ARN for the layer containing the forwarder code.
   DdTags:
     Type: String
     Default: ""

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -52,6 +52,13 @@ Parameters:
     Type: String
     Default: ""
     Description: DO NOT CHANGE unless you know what you are doing. Override the default location of the function source code.
+  InstallFromLayer:
+    Type: String
+    Default: true
+    Description: DO NOT CHANGE unless you know what you are doing. Disable to use legacy installation flow, (via Github), for regions where Lambda layers aren't supported.
+    AllowedValues:
+      - true
+      - false
   DdTags:
     Type: String
     Default: ""
@@ -196,6 +203,13 @@ Conditions:
     Fn::Equals:
       - Ref: AWS::Partition
       - "aws-cn"
+  UseZipCopier:
+    Fn::Or:
+      - Condition: IsAWSChina
+      - Condition: SetSourceZipUrl
+      - Fn::Equals:
+          - InstallFromLayer
+          - "false"
   CreateDdApiKeySecret:
     Fn::Equals:
       - Ref: DdApiKeySecretArn
@@ -349,8 +363,8 @@ Rules:
         AssertDescription: DdApiKey or DdApiKeySecretArn must be set
 Resources:
   Forwarder:
-    Type: AWS::Serverless::Function
-    DependsOn: ForwarderZip
+    Type: AWS::Lambda::Function
+    DependsOn: ForwarderZipReady
     Properties:
       FunctionName:
         Fn::If:
@@ -358,23 +372,29 @@ Resources:
           - Ref: FunctionName
           - Ref: AWS::NoValue
       Description: Pushes logs, metrics and traces from AWS to Datadog.
+      Role: !GetAtt "ForwarderRole.Arn"
       Handler: lambda_function.lambda_handler
+      Code:
+        Fn::If:
+          - UseZipCopier
+          - S3Bucket: !Ref ForwarderBucket
+            S3Key:
+              Fn::Sub:
+                - "aws-dd-forwarder-${DdForwarderVersion}.zip"
+                - {
+                    DdForwarderVersion:
+                      !FindInMap [Constants, DdForwarder, Version],
+                  }
+          - ZipFile: println("Hello")
+
       MemorySize:
         Ref: MemorySize
       Runtime: python3.7
       Timeout:
         Ref: Timeout
-      CodeUri:
-        Bucket: !Ref ForwarderBucket
-        Key:
-          Fn::Sub:
-            - "aws-dd-forwarder-${DdForwarderVersion}.zip"
-            - {
-                DdForwarderVersion:
-                  !FindInMap [Constants, DdForwarder, Version],
-              }
       Tags:
-        dd_forwarder_version: !FindInMap [Constants, DdForwarder, Version]
+        - Key: "dd_forwarder_version"
+          Value: !FindInMap [Constants, DdForwarder, Version]
       Environment:
         Variables:
           DD_ENHANCED_METRICS: "false"
@@ -523,67 +543,94 @@ Resources:
               - Ref: AWS::NoValue
       ReservedConcurrentExecutions:
         Ref: ReservedConcurrency
-      PermissionsBoundary:
-        Fn::If:
-          - SetPermissionsBoundary
-          - Ref: PermissionsBoundaryArn
-          - Ref: AWS::NoValue
       VpcConfig:
         Fn::If:
           - UseVPC
           - SecurityGroupIds: !Ref VPCSecurityGroupIds
             SubnetIds: !Ref VPCSubnetIds
           - Ref: AWS::NoValue
+
+  ForwarderRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+      PermissionsBoundary:
+        Fn::If:
+          - SetPermissionsBoundary
+          - Ref: PermissionsBoundaryArn
+          - Ref: AWS::NoValue
       Policies:
-        - Version: "2012-10-17"
-          Statement:
-            - Effect: Allow
-              Action:
-                - s3:*
-              Resource:
-                - Fn::Join:
-                    - "/"
-                    - - Fn::GetAtt: "ForwarderBucket.Arn"
-                      - "*"
-            - Effect: Allow
-              Action:
-                - s3:GetObject
-              Resource: "*"
-            - Effect: Allow
-              Action:
-                - kms:Decrypt
-              Resource: "*"
-            - Effect: Allow
-              Action:
-                - secretsmanager:GetSecretValue
-              Resource:
-                Fn::If:
-                  - CreateDdApiKeySecret
-                  - Ref: DdApiKeySecret
-                  - !Sub "${DdApiKeySecretArn}*"
-            - !If
-              - SetDdFetchLambdaTags
-              - Effect: Allow
-                Action:
-                  - tag:GetResources
+        - PolicyName: ForwarderRolePolicy0
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Action:
+                  - s3:*
+                Resource:
+                  - Fn::Join:
+                      - "/"
+                      - - Fn::GetAtt: ForwarderBucket.Arn
+                        - "*"
+                Effect: Allow
+              - Action:
+                  - s3:GetObject
                 Resource: "*"
-              - Ref: AWS::NoValue
-            - !If
-              - UseVPC
-              - Effect: Allow
-                Action:
-                  - ec2:CreateNetworkInterface
-                  - ec2:DescribeNetworkInterfaces
-                  - ec2:DeleteNetworkInterface
+                Effect: Allow
+              - Action:
+                  - kms:Decrypt
                 Resource: "*"
-              - Ref: AWS::NoValue
-            - !If
-              - SetAdditionalTargetLambdas
-              - Effect: Allow
-                Action:
-                  - lambda:InvokeFunction
-                Resource: !Ref AdditionalTargetLambdaArns
-              - Ref: AWS::NoValue
+                Effect: Allow
+              - Action:
+                  - secretsmanager:GetSecretValue
+                Resource:
+                  Fn::If:
+                    - CreateDdApiKeySecret
+                    - Ref: DdApiKeySecret
+                    - Fn::Sub: "${DdApiKeySecretArn}*"
+                Effect: Allow
+              - Fn::If:
+                  - SetDdFetchLambdaTags
+                  - Action:
+                      - tag:GetResources
+                    Resource: "*"
+                    Effect: Allow
+                  - Ref: AWS::NoValue
+              - Fn::If:
+                  - UseVPC
+                  - Action:
+                      - ec2:CreateNetworkInterface
+                      - ec2:DescribeNetworkInterfaces
+                      - ec2:DeleteNetworkInterface
+                    Resource: "*"
+                    Effect: Allow
+                  - Ref: AWS::NoValue
+              - Fn::If:
+                  - SetAdditionalTargetLambdas
+                  - Action:
+                      - lambda:InvokeFunction
+                    Resource:
+                      Ref: AdditionalTargetLambdaArns
+                    Effect: Allow
+                  - Ref: AWS::NoValue
+      Tags:
+        - Value:
+            Fn::FindInMap:
+              - Constants
+              - DdForwarder
+              - Version
+          Key: dd_forwarder_version
+
   CloudWatchLogsPermission:
     Type: AWS::Lambda::Permission
     Properties:
@@ -666,6 +713,7 @@ Resources:
             Principal: "*"
   ForwarderZip:
     Type: Custom::ForwarderZip
+    Condition: UseZipCopier
     Properties:
       ServiceToken: !GetAtt "ForwarderZipCopier.Arn"
       DestZipsBucket: !Ref "ForwarderBucket"
@@ -681,6 +729,7 @@ Resources:
                 }
   ForwarderZipCopier:
     Type: AWS::Serverless::Function
+    Condition: UseZipCopier
     Properties:
       Description: Copies Datadog Forwarder zip to the destination S3 bucket
       Handler: index.handler
@@ -785,6 +834,10 @@ Resources:
       Environment:
         Variables:
           DD_FORWARDER_VERSION: !FindInMap [Constants, DdForwarder, Version]
+  ForwarderZipReady:
+    Type: AWS::CloudFormation::WaitConditionHandle
+    Metadata:
+      ForwarderZipCopierReady: !If [UseZipCopier, !Ref ForwarderZip, ""]
 Outputs:
   DatadogForwarderArn:
     Description: Datadog Forwarder Lambda Function ARN
@@ -852,6 +905,7 @@ Metadata:
           - DdFetchLambdaTags
           - TagsCacheTTLSeconds
           - SourceZipUrl
+          - InstallFromLayer
           - PermissionsBoundaryArn
           - DdUsePrivateLink
           - DdUseVPC

--- a/aws/logs_monitoring/tools/add_new_region.sh
+++ b/aws/logs_monitoring/tools/add_new_region.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019 Datadog, Inc.
+
+# Copy layers from us-east-1 to new region
+# args: [new-region]
+
+set -e 
+
+OLD_REGION='us-east-1'
+
+PYTHON_VERSIONS_FOR_AWS_CLI=("python3.7")
+LAYER_NAMES=("Datadog-Forwarder")
+NEW_REGION=$1
+
+publish_layer() {
+    region=$1
+    layer_name=$2
+    aws_version_key=$3
+    layer_path=$4
+
+    version_nbr=$(aws lambda publish-layer-version --layer-name $layer_name \
+        --description "Datadog Lambda Layer for Python" \
+        --zip-file "fileb://$layer_path" \
+        --region $region \
+        --compatible-runtimes $aws_version_key \
+                        | jq -r '.Version')
+
+    aws lambda add-layer-version-permission --layer-name $layer_name \
+        --version-number $version_nbr \
+        --statement-id "release-$version_nbr" \
+        --action lambda:GetLayerVersion --principal "*" \
+        --region $region
+
+    echo "Published layer for region $region, version $aws_version_key, layer_name $layer_name, layer_version $version_nbr"
+}
+
+get_max_version() {
+    layer_name=$1
+    region=$2
+    last_layer_version=$(aws lambda list-layer-versions --layer-name $layer_name --region $region | jq -r ".LayerVersions | .[0] |  .Version")
+    if [ "$last_layer_version" == "null" ]; then
+        echo 0
+    else
+        echo $last_layer_version
+    fi
+}
+
+if [ -z "$1" ]; then
+    echo "Region parameter not specified, exiting"
+    exit 1
+fi
+
+j=0
+for layer_name in "${LAYER_NAMES[@]}"; do
+    # get latest version
+    last_layer_version=$(get_max_version $layer_name $OLD_REGION)
+    starting_version=$(get_max_version $layer_name $NEW_REGION)
+    starting_version=$(expr $starting_version + 1)
+
+    # exit if region is already all caught up
+    if [ $starting_version -gt $last_layer_version ]; then
+        echo "INFO: $NEW_REGION is already up to date for $layer_name"
+        continue
+    fi
+
+    # run for each version of layer
+    for i in $(seq 1 $last_layer_version); do 
+        layer_path=$layer_name"_"$i.zip
+        aws_version_key="${PYTHON_VERSIONS_FOR_AWS_CLI[$j]}"
+
+        # download layer versions 
+        URL=$(AWS_REGION=$OLD_REGION aws lambda get-layer-version --layer-name $layer_name --version-number $i --query Content.Location --output text)
+        curl $URL -o $layer_path
+
+        # publish layer to new region
+        publish_layer $NEW_REGION $layer_name $aws_version_key $layer_path
+        rm $layer_path
+    done
+
+    j=$(expr $j + 1)
+done

--- a/aws/logs_monitoring/tools/build_bundle.sh
+++ b/aws/logs_monitoring/tools/build_bundle.sh
@@ -34,7 +34,7 @@ function make_path_absolute {
 
 function docker_build_zip {
     # Args: [python version] [zip destination]
-    destination=$(make_path_absolute $2)
+    zip_destination=$(make_path_absolute $2)
     layer_destination=$(make_path_absolute $3)
 
     # Install datadogpy in a docker container to avoid the mess from switching
@@ -44,21 +44,21 @@ function docker_build_zip {
     docker build --file "${DIR}/Dockerfile_bundle" -t "datadog-bundle:$1" .. --no-cache \
         --build-arg runtime=$1
 
-    # Run the image by runtime tag, tar its generatd `python` directory to sdout,
+    # Run the image by runtime tag, tar its generated `python` directory to sdout,
     # then extract it to a temp directory.
     docker run datadog-bundle:$1 tar cf - . | tar -xf - -C $temp_dir
 
     # Zip to destination, and keep directory structure as based in $temp_dir
-    (cd $temp_dir && zip -q -r $destination ./)
+    (cd $temp_dir && zip -q -r $zip_destination ./)
 
     rm -rf $temp_dir
-    echo "Done creating forwarder zip archive $destination"
+    echo "Done creating forwarder zip archive $zip_destination"
 
     temp_dir=$(mktemp -d)
     SUB_DIRECTORY=python
     mkdir $temp_dir/$SUB_DIRECTORY
 
-    # Run the image by runtime tag, tar its generatd `python` directory to sdout,
+    # Run the image by runtime tag, tar its generated `python` directory to sdout,
     # then extract it to a temp directory.
     docker run datadog-bundle:$1 tar cf - . | tar -xf - -C $temp_dir/$SUB_DIRECTORY
 

--- a/aws/logs_monitoring/tools/installation_test.sh
+++ b/aws/logs_monitoring/tools/installation_test.sh
@@ -69,11 +69,11 @@ publish_test() {
 
 echo
 echo "Running Publish with Zip Copier test"
-publish_test $(param SourceZipUrl \"${FORWARDER_SOURCE_URL}\")
+publish_test "$(param SourceZipUrl \"${FORWARDER_SOURCE_URL}\"),$(param InstallAsLayer \"false\")"
 
 RUN_ID=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c10)
 
 echo
 echo "Running Publish with Layer test"
-LAYER_ARN="arn:aws:lambda:${AWS_REGION}:${CURRENT_ACCOUNT}:layer:${LAYER_NAME}:${NEXT_LAYER_VERSION}"
+LAYER_ARN="arn:aws:lambda:${AWS_REGION}:${CURRENT_ACCOUNT}:layer:${LAYER_NAME}:${LAYER_VERSION}"
 publish_test $(param LayerARN \"${LAYER_ARN}\")

--- a/aws/logs_monitoring/tools/installation_test.sh
+++ b/aws/logs_monitoring/tools/installation_test.sh
@@ -39,7 +39,7 @@ function param {
     echo "{\"ParameterKey\":\"${KEY}\",\"ParameterValue\":${VALUE}}"
 }
 
-PARAM_LIST=[$(param DdApiKey \"${DD_API_KEY}\"),$(param DdSite \"datadoghq.com\"),$(param SourceZipUrl \"${FORWARDER_SOURCE_URL}\"),$(param ReservedConcurrency \"1\")]
+PARAM_LIST=[$(param DdApiKey \"${DD_API_KEY}\"),$(param DdSite \"datadoghq.com\"),$(param ReservedConcurrency \"1\")]
 echo "Setting params ${PARAM_LIST}"
 
 # Create an instance of the stack
@@ -54,4 +54,4 @@ aws cloudformation wait stack-create-complete --stack-name $STACK_NAME --region 
 echo "Completed stack creation"
 
 echo "Cleaning up stack"
-aws cloudformation delete-stack --stack-name $STACK_NAME  --region $AWS_REGION
+#aws cloudformation delete-stack --stack-name $STACK_NAME  --region $AWS_REGION

--- a/aws/logs_monitoring/tools/installation_test.sh
+++ b/aws/logs_monitoring/tools/installation_test.sh
@@ -64,12 +64,14 @@ publish_test() {
     echo "Completed stack creation"
 
     echo "Cleaning up stack"
-    #aws cloudformation delete-stack --stack-name $STACK_NAME  --region $AWS_REGION
+    aws cloudformation delete-stack --stack-name $STACK_NAME  --region $AWS_REGION
 }
 
-#echo
-#echo "Running Publish with Zip Copier test"
-#publish_test $(param SourceZipUrl \"${FORWARDER_SOURCE_URL}\")
+echo
+echo "Running Publish with Zip Copier test"
+publish_test $(param SourceZipUrl \"${FORWARDER_SOURCE_URL}\")
+
+RUN_ID=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c10)
 
 echo
 echo "Running Publish with Layer test"

--- a/aws/logs_monitoring/tools/installation_test.sh
+++ b/aws/logs_monitoring/tools/installation_test.sh
@@ -77,5 +77,3 @@ echo
 echo "Running Publish with Layer test"
 LAYER_ARN="arn:aws:lambda:${AWS_REGION}:${CURRENT_ACCOUNT}:layer:${LAYER_NAME}:${NEXT_LAYER_VERSION}"
 publish_test $(param LayerARN \"${LAYER_ARN}\")
-
-

--- a/aws/logs_monitoring/tools/installation_test.sh
+++ b/aws/logs_monitoring/tools/installation_test.sh
@@ -11,6 +11,11 @@ set -e
 # Deploy the stack to a less commonly used region to avoid any problems with limits
 AWS_REGION="us-west-2"
 
+# Limits any layer publishing to the test region
+export REGIONS=$AWS_REGION
+# Prevents the scripts from asking permission 
+export NO_INPUT=true
+
 # Move into the root directory, so this script can be called from any directory
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd $DIR/..
@@ -30,7 +35,7 @@ if [ "$AWS_ACCOUNT" = "464622532012" ] ; then
     exit 1
 fi
 
-# Run script in this process. This gives us TEMPLATE_URL and FORWARDER_SOURCE_URL env vars
+# Run script in this process. This gives us TEMPLATE_URL, NEXT_LAYER_VERSION and FORWARDER_SOURCE_URL env vars
 . release.sh $CURRENT_VERSION sandbox
 
 function param {
@@ -38,20 +43,37 @@ function param {
     VALUE=$2
     echo "{\"ParameterKey\":\"${KEY}\",\"ParameterValue\":${VALUE}}"
 }
+echo $FORWARDER_SOURCE_URL
 
-PARAM_LIST=[$(param DdApiKey \"${DD_API_KEY}\"),$(param DdSite \"datadoghq.com\"),$(param ReservedConcurrency \"1\")]
-echo "Setting params ${PARAM_LIST}"
+publish_test() {
+    ADDED_PARAMS=$1
 
-# Create an instance of the stack
-STACK_NAME="datadog-forwarder-integration-stack-${RUN_ID}"
-echo "Creating stack ${STACK_NAME}"
-aws cloudformation create-stack --stack-name $STACK_NAME --template-url $TEMPLATE_URL --capabilities "CAPABILITY_AUTO_EXPAND" "CAPABILITY_IAM" --on-failure "DELETE" \
-    --parameters=$PARAM_LIST --region $AWS_REGION
+    PARAM_LIST=[$(param DdApiKey \"${DD_API_KEY}\"),$(param DdSite \"datadoghq.com\"),$(param ReservedConcurrency \"1\"),$ADDED_PARAMS]
+    echo "Setting params ${PARAM_LIST}"
 
-echo "Waiting for stack to complete creation ${STACK_NAME}"
-aws cloudformation wait stack-create-complete --stack-name $STACK_NAME --region $AWS_REGION
+    # Create an instance of the stack
+    STACK_NAME="datadog-forwarder-integration-stack-${RUN_ID}"
 
-echo "Completed stack creation"
+    echo "Creating stack using Zip Copier Flow ${STACK_NAME}"
+    aws cloudformation create-stack --stack-name $STACK_NAME --template-url $TEMPLATE_URL --capabilities "CAPABILITY_AUTO_EXPAND" "CAPABILITY_IAM" --on-failure "DELETE" \
+        --parameters=$PARAM_LIST --region $AWS_REGION
 
-echo "Cleaning up stack"
-#aws cloudformation delete-stack --stack-name $STACK_NAME  --region $AWS_REGION
+    echo "Waiting for stack to complete creation ${STACK_NAME}"
+    aws cloudformation wait stack-create-complete --stack-name $STACK_NAME --region $AWS_REGION
+
+    echo "Completed stack creation"
+
+    echo "Cleaning up stack"
+    #aws cloudformation delete-stack --stack-name $STACK_NAME  --region $AWS_REGION
+}
+
+#echo
+#echo "Running Publish with Zip Copier test"
+#publish_test $(param SourceZipUrl \"${FORWARDER_SOURCE_URL}\")
+
+echo
+echo "Running Publish with Layer test"
+LAYER_ARN="arn:aws:lambda:${AWS_REGION}:${CURRENT_ACCOUNT}:layer:${LAYER_NAME}:${NEXT_LAYER_VERSION}"
+publish_test $(param LayerARN \"${LAYER_ARN}\")
+
+

--- a/aws/logs_monitoring/tools/list_layers.sh
+++ b/aws/logs_monitoring/tools/list_layers.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2021 Datadog, Inc.
+
+# Lists most recent layers ARNs across regions to STDOUT
+# Optionals args: [layer-name] [region]
+
+set -e
+
+LAYER_NAMES=("Datadog-Forwarder")
+AVAILABLE_REGIONS=$(aws ec2 describe-regions | jq -r '.[] | .[] | .RegionName')
+LAYERS_MISSING_REGIONS=()
+
+# Check region arg
+if [ -z "$2" ]; then
+    >&2 echo "Region parameter not specified, running for all available regions."
+    REGIONS=$AVAILABLE_REGIONS
+else
+
+    >&2 echo "Region parameter specified: $2"
+    if [[ ! "$AVAILABLE_REGIONS" == *"$2"* ]]; then
+        >&2 echo "Could not find $2 in available regions:" $AVAILABLE_REGIONS
+        >&2 echo ""
+        >&2 echo "EXITING SCRIPT."
+        exit 1
+    fi
+    REGIONS=($2)
+fi
+
+# Check region arg
+if [ -z "$1" ]; then
+    >&2 echo "Layer parameter not specified, running for all layers "
+    LAYERS=("${LAYER_NAMES[@]}")
+else
+    >&2 echo "Layer parameter specified: $1"
+    if [[ ! " ${LAYER_NAMES[@]} " =~ " ${1} " ]]; then
+        >&2 echo "Could not find $1 in layers: ${LAYER_NAMES[@]}"
+        >&2 echo ""
+        >&2 echo "EXITING SCRIPT."
+        return 1
+    fi
+    LAYERS=($1)
+fi
+
+for region in $REGIONS
+do
+    for layer_name in "${LAYERS[@]}"
+    do
+        last_layer_arn=$(aws lambda list-layer-versions --layer-name $layer_name --region $region | jq -r ".LayerVersions | .[0] |  .LayerVersionArn")
+        if [ "$last_layer_arn" == "null" ]; then
+            >&2 echo "No layer found for $region, $layer_name"
+            if [[ ! " ${LAYERS_MISSING_REGIONS[@]} " =~ " ${region} " ]]; then
+                LAYERS_MISSING_REGIONS+=( $region )
+            fi
+        else
+            echo $last_layer_arn
+        fi
+    done
+done
+
+if [ ${#LAYERS_MISSING_REGIONS[@]} -gt 0 ]; then
+    echo "WARNING: Following regions missing layers: ${LAYERS_MISSING_REGIONS[@]}"
+    echo "Please run ./add_new_region.sh <new_region> to add layers to the missing regions" 
+    exit 1
+fi

--- a/aws/logs_monitoring/tools/publish_layers.sh
+++ b/aws/logs_monitoring/tools/publish_layers.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019 Datadog, Inc.
+
+# Publish the datadog python lambda layer across regions, using the AWS CLI
+# Usage: VERSION=5 REGIONS=us-east-1 LAYERS=Datadog-Python27 publish_layers.sh
+# VERSION is required.
+set -e
+
+# Makes sure any subprocesses will be terminated with this process
+trap "pkill -P $$; exit 1;" INT
+
+PYTHON_VERSIONS_FOR_AWS_CLI=("python3.7")
+LAYER_PATHS=(".forwarder/aws-dd-forwarder-${FORWARDER_VERSION}.zip")
+AVAILABLE_LAYERS=("Datadog-Forwarder")
+AVAILABLE_REGIONS=$(aws ec2 describe-regions | jq -r '.[] | .[] | .RegionName')
+
+# Check that the layer files exist
+for layer_file in "${LAYER_PATHS[@]}"
+do
+    if [ ! -f $layer_file  ]; then
+        echo "Could not find $layer_file."
+        exit 1
+    fi
+done
+
+# Determine the target regions
+if [ -z "$REGIONS" ]; then
+    echo "Region not specified, running for all available regions."
+    REGIONS=$AVAILABLE_REGIONS
+else
+    echo "Region specified: $REGIONS"
+    if [[ ! "$AVAILABLE_REGIONS" == *"$REGIONS"* ]]; then
+        echo "Could not find $REGIONS in available regions: $AVAILABLE_REGIONS"
+        echo ""
+        echo "EXITING SCRIPT."
+        exit 1
+    fi
+fi
+
+# Determine the target layers
+if [ -z "$LAYERS" ]; then
+    echo "Layer not specified, running for all layers."
+    LAYERS=("${AVAILABLE_LAYERS[@]}")
+else
+    echo "Layer specified: $LAYERS"
+    if [[ ! " ${AVAILABLE_LAYERS[@]} " =~ " ${LAYERS} " ]]; then
+        echo "Could not find $LAYERS in available layers: ${AVAILABLE_LAYERS[@]}"
+        echo ""
+        echo "EXITING SCRIPT."
+        exit 1
+    fi
+fi
+
+# Determine the target layer version
+if [ -z "$VERSION" ]; then
+    echo "Layer version not specified"
+    echo ""
+    echo "EXITING SCRIPT."
+    exit 1
+else
+    echo "Layer version specified: $VERSION"
+fi
+
+if [ "$NO_INPUT" = true ] ; then
+    echo "Publishing version $VERSION of layers ${LAYERS[*]} to regions ${REGIONS[*]}"
+else
+    read -p "Ready to publish version $VERSION of layers ${LAYERS[*]} to regions ${REGIONS[*]} (y/n)?" CONT
+    if [ "$CONT" != "y" ]; then
+        echo "Exiting"
+        exit 1
+    fi
+fi
+
+index_of_layer() {
+    layer_name=$1
+    for i in "${!AVAILABLE_LAYERS[@]}"; do
+        if [[ "${AVAILABLE_LAYERS[$i]}" = "${layer_name}" ]]; then
+            echo "${i}";
+        fi
+    done
+}
+
+publish_layer() {
+    region=$1
+    layer_name=$2
+    aws_version_key=$3
+    layer_path=$4
+    version_nbr=$(aws lambda publish-layer-version --layer-name $layer_name \
+        --description "Datadog Forwarder Layer Package" \
+        --zip-file "fileb://$layer_path" \
+        --region $region \
+        --compatible-runtimes $aws_version_key \
+                        | jq -r '.Version')
+
+    permission=$(aws lambda add-layer-version-permission --layer-name $layer_name \
+        --version-number $version_nbr \
+        --statement-id "release-$version_nbr" \
+        --action lambda:GetLayerVersion --principal "*" \
+        --region $region)
+
+    echo $version_nbr
+}
+
+for region in $REGIONS
+do
+    echo "Starting publishing layer for region $region..."
+    # Publish the layers for each version of python
+    for layer_name in "${LAYERS[@]}"; do
+        latest_version=$(aws lambda list-layer-versions --region $region --layer-name $layer_name --query 'LayerVersions[0].Version || `0`')
+        if [ $latest_version -ge $VERSION ]; then
+            echo "Layer $layer_name version $VERSION already exists in region $region, skipping..."
+            continue
+        elif [ $latest_version -lt $((VERSION-1)) ]; then
+            read -p "WARNING: The latest version of layer $layer_name in region $region is $latest_version, publish all the missing versions including $VERSION or EXIT the script (y/n)?" CONT
+            if [ "$CONT" != "y" ]; then
+                echo "Exiting"
+                exit 1
+            fi
+        fi
+
+        index=$(index_of_layer $layer_name)
+        aws_version_key="${PYTHON_VERSIONS_FOR_AWS_CLI[$index]}"
+        layer_path="${LAYER_PATHS[$index]}"
+
+        while [ $latest_version -lt $VERSION ]; do
+            latest_version=$(publish_layer $region $layer_name $aws_version_key $layer_path)
+            echo "Published version $latest_version for layer $layer_name in region $region"
+
+            # This shouldn't happen unless someone manually deleted the latest version, say 28
+            # and then try to republish it again. The published version is actually be 29, because
+            # Lambda layers are immutable and AWS will skip deleted version and use the next number. 
+            if [ $latest_version -gt $VERSION ]; then
+                echo "ERROR: Published version $latest_version is greater than the desired version $VERSION!"
+                echo "Exiting"
+                exit 1
+            fi
+        done
+    done
+done
+
+echo "Done !"

--- a/aws/logs_monitoring/tools/publish_layers.sh
+++ b/aws/logs_monitoring/tools/publish_layers.sh
@@ -14,7 +14,7 @@ set -e
 trap "pkill -P $$; exit 1;" INT
 
 PYTHON_VERSIONS_FOR_AWS_CLI=("python3.7")
-LAYER_PATHS=(".forwarder/aws-dd-forwarder-${FORWARDER_VERSION}.zip")
+LAYER_PATHS=(".forwarder/aws-dd-forwarder-${FORWARDER_VERSION}-layer.zip")
 AVAILABLE_LAYERS=("Datadog-Forwarder")
 AVAILABLE_REGIONS=$(aws ec2 describe-regions | jq -r '.[] | .[] | .RegionName')
 

--- a/aws/logs_monitoring/tools/publish_prod.sh
+++ b/aws/logs_monitoring/tools/publish_prod.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Use with `./publish_prod.sh <DESIRED_NEW_VERSION>
+
+set -e
+unset $AWS_VAULT
+
+# Ensure on main, and pull the latest
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ $BRANCH != "main" ]; then
+    echo "Not on main, aborting"
+    exit 1
+else
+    echo "Updating main"
+    git pull origin main
+fi
+
+# Ensure no uncommitted changes
+if [ -n "$(git status --porcelain)" ]; then
+    echo "Detected uncommitted changes, aborting"
+    exit 1
+fi
+
+# Read the new version
+if [ -z "$1" ]; then
+    echo "Must specify a layer version"
+    exit 1
+else
+    LAYER_VERSION=$1
+fi
+
+# Read the new version
+if [ -z "$2" ]; then
+    echo "Must specify a forwarder version"
+    exit 1
+else
+    FORWARDER_VERSION=$2
+fi
+
+# Ensure AWS access before proceeding
+saml2aws login -a govcloud-us1-fed-human-engineering
+AWS_PROFILE=govcloud-us1-fed-human-engineering aws sts get-caller-identity
+aws-vault exec prod-engineering -- aws sts get-caller-identity
+
+echo
+echo "Publishing layers to commercial AWS regions"
+VERSION=$LAYER_VERSION FORWARDER_VERSION=$FORWARDER_VERSION aws-vault exec prod-engineering -- ./tools/publish_layers.sh
+
+echo "Publishing layers to GovCloud AWS regions"
+saml2aws login -a govcloud-us1-fed-human-engineering
+VERSION=$LAYER_VERSION FORWARDER_VERSION=$FORWARDER_VERSION AWS_PROFILE=govcloud-us1-fed-human-engineering ./tools/publish_layers.sh

--- a/aws/logs_monitoring/tools/publish_prod.sh
+++ b/aws/logs_monitoring/tools/publish_prod.sh
@@ -44,8 +44,8 @@ aws-vault exec prod-engineering -- aws sts get-caller-identity
 
 echo
 echo "Publishing layers to commercial AWS regions"
-VERSION=$LAYER_VERSION FORWARDER_VERSION=$FORWARDER_VERSION aws-vault exec prod-engineering -- ./tools/publish_layers.sh
+LAYER_VERSION=$LAYER_VERSION FORWARDER_VERSION=$FORWARDER_VERSION aws-vault exec prod-engineering -- ./tools/publish_layers.sh
 
 echo "Publishing layers to GovCloud AWS regions"
 saml2aws login -a govcloud-us1-fed-human-engineering
-VERSION=$LAYER_VERSION FORWARDER_VERSION=$FORWARDER_VERSION AWS_PROFILE=govcloud-us1-fed-human-engineering ./tools/publish_layers.sh
+LAYER_VERSION=$LAYER_VERSION FORWARDER_VERSION=$FORWARDER_VERSION AWS_PROFILE=govcloud-us1-fed-human-engineering ./tools/publish_layers.sh

--- a/aws/logs_monitoring/tools/publish_sandbox.sh
+++ b/aws/logs_monitoring/tools/publish_sandbox.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+unset AWS_VAULT
+# Read the new version
+if [ -z "$1" ]; then
+    echo "Must specify a desired version number"
+    exit 1
+else
+    LAYER_VERSION=$1
+fi
+
+# Read the new version
+if [ -z "$2" ]; then
+    echo "Must specify a forwarder version"
+    exit 1
+else
+    FORWARDER_VERSION=$2
+fi
+
+echo "FORWARDER_VERSION=$FORWARDER_VERSION"
+
+VERSION=$LAYER_VERSION FORWARDER_VERSION=$FORWARDER_VERSION aws-vault exec sandbox-account-admin -- ./tools/publish_layers.sh

--- a/aws/logs_monitoring/tools/publish_sandbox.sh
+++ b/aws/logs_monitoring/tools/publish_sandbox.sh
@@ -19,4 +19,4 @@ fi
 
 echo "FORWARDER_VERSION=$FORWARDER_VERSION"
 
-VERSION=$LAYER_VERSION FORWARDER_VERSION=$FORWARDER_VERSION aws-vault exec sandbox-account-admin -- ./tools/publish_layers.sh
+LAYER_VERSION=$LAYER_VERSION FORWARDER_VERSION=$FORWARDER_VERSION aws-vault exec sandbox-account-admin -- ./tools/publish_layers.sh


### PR DESCRIPTION
### What does this PR do?

Creates a new install flow for the forwarder using lambda layers, instead of relying on a second ZipCopier function. It makes this new install flow the default, but also keeps the ZipCopier flow as an option for regions where we can't publish lambda layers, (such as the regions in China). It also updates the installation_test script to validate both install flows.

### Motivation

The ZipCopier function, which copies an external zip from github into a local s3 bucket was proving difficult for some customers to use in restrictive AWS environments, (such as where VPC usage is mandated for all functions). This alternative flow  reduces the number of resources installed by the template by packaging code into a lambda layer.

### Testing Guidelines
You can run the ./tools/installation_test.sh script.

### Additional Notes



### Types of changes

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [X] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [X] This PR's description is comprehensive
- [X] This PR contains breaking changes that are documented in the description
- [X] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [X] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [X] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
