### PR TITLE
Fix line breaks in README.md for `Advanced (optional)` log forwarder CloudFormation parameters

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -1,7 +1,7 @@
 # Overview
-Repository of lambda functions that process AWS log streams and send data to Datadog as logs or metrics.
 
-* [Instructions to collect and forward any AWS service logs](https://github.com/DataDog/datadog-serverless-functions/tree/master/aws/logs_monitoring)
-* [Instructions to collect and send VPC metrics from flow logs](https://github.com/DataDog/datadog-serverless-functions/tree/master/aws/vpc_flow_log_monitoring)
-* [Instructions to collect and send RDS metrics](https://github.com/DataDog/datadog-serverless-functions/tree/master/aws/rds_enhanced_monitoring)
+Repository of Lambda functions that process AWS log streams and send data to Datadog as logs or metrics.
 
+* [Instructions to collect and forward any AWS service logs](logs_monitoring)
+* [Instructions to collect and send VPC metrics from flow logs](vpc_flow_log_monitoring)
+* [Instructions to collect and send RDS metrics](rds_enhanced_monitoring)

--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -365,8 +365,10 @@ To test different patterns against your logs, turn on [debug logs](#troubleshoot
 
 `AdditionalTargetLambdaARNs`
 : Comma separated list of Lambda ARNs that will get called asynchronously with the same `event` the Datadog Forwarder receives.
+
 `InstallAsLayer`
-: Whether to use the layer-based installation flow. Set to false to use our legacy installation flow, which installs a second function that copies the forwarder code from Github to an S3 bucket. Defaults to true.
+: Whether to use the layer-based installation flow. Set to false to use our legacy installation flow, which installs a second function that copies the forwarder code from GitHub to an S3 bucket. Defaults to true.
+
 `LayerARN`
 : ARN for the layer containing the forwarder code. If empty, the script will use the version of the layer the forwarder was published with. Defaults to empty.
 

--- a/azure/README.md
+++ b/azure/README.md
@@ -1,4 +1,4 @@
 # Azure functions
 
-* [EventHub triggered function](./activity_logs_monitoring/)
-* [Blob triggered function](./blobs_logs_monitoring/)
+* [EventHub triggered function](activity_logs_monitoring)
+* [Blob triggered function](blobs_logs_monitoring)


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

- Fixes to `README.md` where advanced parameters are missing required line breaks - new options related to Lambda Layer bleed into each other.
- Opening aws/azure `README.md` pages - drop absolute URLs/cleanup.

<!--- A brief description of the change being made with this pull request. --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [x] This PR passes the installation tests (ask a Datadog member to run the tests)
