### PR TITLE
Add NO_PROXY option to AWS Forwarder

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -358,7 +358,7 @@ To test different patterns against your logs, turn on [debug logs](#troubleshoot
 : Sets the standard web proxy environment variables HTTP_PROXY and HTTPS_PROXY. These are the url endpoints your proxy server exposes. Don't use this in combination with AWS Private Link. Make sure to also set DdSkipSslValidation to true.
 
 `DdNoProxy`
-: Sets the standard web proxy environment variable NO_PROXY. It is a comma separated list of domain names that should be excluded from the web proxy.
+: Sets the standard web proxy environment variable NO_PROXY. It is a comma-separated list of domain names that should be excluded from the web proxy.
 
 `VPCSecurityGroupIds`
 : Comma separated list of VPC Security Group Ids. Used when AWS PrivateLink is enabled.

--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -357,6 +357,9 @@ To test different patterns against your logs, turn on [debug logs](#troubleshoot
 `DdHttpProxyURL`
 : Sets the standard web proxy environment variables HTTP_PROXY and HTTPS_PROXY. These are the url endpoints your proxy server exposes. Don't use this in combination with AWS Private Link. Make sure to also set DdSkipSslValidation to true.
 
+`DdNoProxy`
+: Sets the standard web proxy environment variable NO_PROXY. It is a comma separated list of domain names that should be excluded from the web proxy.
+
 `VPCSecurityGroupIds`
 : Comma separated list of VPC Security Group Ids. Used when AWS PrivateLink is enabled.
 

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -173,7 +173,7 @@ Parameters:
   DdNoProxy:
     Type: String
     Default: ""
-    Description: "Sets the standard web proxy environment variable NO_PROXY. It is a comma separated list of domain names that should be excluded from the web proxy."
+    Description: "Sets the standard web proxy environment variable NO_PROXY. It is a comma-separated list of domain names that should be excluded from the web proxy."
   VPCSecurityGroupIds:
     Type: CommaDelimitedList
     Default: ""

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -170,6 +170,10 @@ Parameters:
     Type: String
     Default: ""
     Description: "Sets the standard web proxy environment variables HTTP_PROXY and HTTPS_PROXY. These are the url endpoints your proxy server exposes. Don't use this in combination with AWS Private Link. Make sure to also set DdSkipSslValidation to true."
+  DdNoProxy:
+    Type: String
+    Default: ""
+    Description: "Sets the standard web proxy environment variable NO_PROXY. It is a comma separated list of domain names that should be excluded from the web proxy."
   VPCSecurityGroupIds:
     Type: CommaDelimitedList
     Default: ""
@@ -313,6 +317,11 @@ Conditions:
     Fn::Not:
       - Fn::Equals:
           - Ref: DdHttpProxyURL
+          - ""
+  SetDdNoProxy:
+    Fn::Not:
+      - Fn::Equals:
+          - Ref: DdNoProxy
           - ""
   SetLayerARN:
     Fn::Not:
@@ -555,6 +564,11 @@ Resources:
             Fn::If:
               - SetDdHttpProxyURL
               - Ref: DdHttpProxyURL
+              - Ref: AWS::NoValue
+          NO_PROXY:
+            Fn::If:
+              - SetDdNoProxy
+              - Ref: DdNoProxy
               - Ref: AWS::NoValue
           DD_ADDITIONAL_TARGET_LAMBDAS:
             Fn::If:
@@ -943,6 +957,7 @@ Metadata:
           - DdUsePrivateLink
           - DdUseVPC
           - DdHttpProxyURL
+          - DdNoProxy
           - VPCSecurityGroupIds
           - VPCSubnetIds
           - DdApiUrl


### PR DESCRIPTION
### What does this PR do?

Adds support for the NO_PROXY environment variable. This pairs with HTTPS_PROXY and HTTP_PROXY environment variables, which set the web proxy url to use for HTTP and HTTPS connections. NO_PROXY is a list of domains that are excluded from the proxy.

### Motivation

Feature  request

### Testing Guidelines

I tested this manually using a forwarder in a VPC with a web proxy.

### Additional Notes


### Types of changes

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [X] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ X This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
