### PR TITLE
[aws] allow overriding service with DD_SERVICE_NAME

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -290,6 +290,9 @@ SSL encrypted TCP connection, set this parameter to true.
 `DdPort`
 : The endpoint port to forward the logs to, useful for forwarding logs through a proxy.
 
+`DdServiceName`
+: Allow to override the service name of the forwarded logs.
+
 `DdSkipSslValidation`
 : Send logs over HTTPS, while NOT validating the certificate provided by the endpoint. This will still encrypt the traffic between the forwarder and the log intake endpoint, but will not verify if the destination SSL certificate is valid.
 

--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -29,6 +29,7 @@ from settings import (
     DD_SOURCE,
     DD_CUSTOM_TAGS,
     DD_SERVICE,
+    DD_SERVICE_NAME,
     DD_HOST,
     DD_FORWARDER_VERSION,
     DD_USE_VPC,
@@ -171,6 +172,10 @@ def s3_handler(event, context, metadata):
     metadata[DD_SOURCE] = source
     ##default service to source value
     metadata[DD_SERVICE] = source
+
+    if DD_SERVICE_NAME:
+        metadata[DD_SERVICE] = DD_SERVICE_NAME
+
     ##Get the ARN of the service and set it as the hostname
     hostname = parse_service_arn(source, key, bucket, context)
     if hostname:
@@ -424,6 +429,9 @@ def awslogs_handler(event, context, metadata):
     # Default service to source value
     metadata[DD_SERVICE] = metadata[DD_SOURCE]
 
+    if DD_SERVICE_NAME:
+        metadata[DD_SERVICE] = DD_SERVICE_NAME
+
     # Build aws attributes
     aws_attributes = {
         "aws": {
@@ -521,6 +529,9 @@ def cwevent_handler(event, metadata):
         metadata[DD_SOURCE] = "cloudwatch"
     ##default service to source value
     metadata[DD_SERVICE] = metadata[DD_SOURCE]
+
+    if DD_SERVICE_NAME:
+        metadata[DD_SERVICE] = DD_SERVICE_NAME
 
     yield data
 

--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -217,6 +217,8 @@ DD_MULTILINE_LOG_REGEX_PATTERN = get_env_var(
     "DD_MULTILINE_LOG_REGEX_PATTERN", default=None
 )
 
+DD_SERVICE_NAME = get_env_var("DD_SERVICE_NAME", default=None)
+
 DD_SOURCE = "ddsource"
 DD_CUSTOM_TAGS = "ddtags"
 DD_SERVICE = "service"

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -64,6 +64,10 @@ Parameters:
     Type: String
     Default: ""
     Description: ARN for the layer containing the forwarder code. If empty, the script will use the version of the layer the forwarder was published with.
+  DdServiceName:
+    Type: String
+    Default: ""
+    Description: Allow to override the service name of the forwarded logs
   DdTags:
     Type: String
     Default: ""
@@ -241,6 +245,11 @@ Conditions:
     Fn::Equals:
       - !Select [0, !Split ["/", !Ref SourceZipUrl]]
       - "s3:"
+  SetDdServiceName:
+    Fn::Not:
+      - Fn::Equals:
+          - Ref: DdServiceName
+          - ""
   SetDdTags:
     Fn::Not:
       - Fn::Equals:
@@ -448,6 +457,11 @@ Resources:
             Fn::If:
               - SetDdFetchLambdaTags
               - Ref: ForwarderBucket
+              - Ref: AWS::NoValue
+          DD_SERVICE_NAME:
+            Fn::If:
+              - SetDdServiceName
+              - Ref: DdServiceName
               - Ref: AWS::NoValue
           DD_SITE:
             Ref: DdSite
@@ -922,6 +936,7 @@ Metadata:
       - Label:
           default: Log Forwarding (Optional)
         Parameters:
+          - DdServiceName
           - DdTags
           - DdMultilineLogRegexPattern
           - DdUseTcp

--- a/aws/logs_monitoring/tests/test_cloudtrail_s3.py
+++ b/aws/logs_monitoring/tests/test_cloudtrail_s3.py
@@ -19,6 +19,7 @@ env_patch = patch.dict(
     {
         "DD_API_KEY": "11111111111111111111111111111111",
         "DD_ADDITIONAL_TARGET_LAMBDAS": "ironmaiden,megadeth",
+        "DD_SERVICE_NAME": "overridden-service-name",
     },
 )
 env_patch.start()
@@ -124,7 +125,7 @@ class TestS3CloudwatchParsing(unittest.TestCase):
             {
                 "ddsource": "cloudtrail",
                 "ddsourcecategory": "aws",
-                "service": "cloudtrail",
+                "service": "overridden-service-name",
                 "aws": {
                     "s3": {
                         "bucket": payload["s3"]["bucket"]["name"],

--- a/aws/logs_monitoring/tests/test_parsing.py
+++ b/aws/logs_monitoring/tests/test_parsing.py
@@ -442,7 +442,7 @@ class TestAWSLogsHandler(unittest.TestCase):
                 "ddsource": "postgresql",
                 "ddtags": "env:dev,logname:postgresql",
                 "host": "datadog",
-                "service": "postgresql",
+                "service": "overridden-service-name",
             },
             metadata,
         )


### PR DESCRIPTION
### What does this PR do?

This PR allows to override the service name by setting DD_SERVICE_NAME environment variable.

### Motivation

When we send ELB logs to Datadog, we end up having `source: elb` and `service: elb`, hence we cannot differentiate the logs from service X from those from service Y.

This PR allows us to filter the logs by service.

### Testing Guidelines

Tested by manually uploading the new code to our log forwarding AWS Lambda

### Types of changes

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
