### PR TITLE
[aws] Allow to override the service name of the logs coming from S3 b…

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -290,6 +290,9 @@ SSL encrypted TCP connection, set this parameter to true.
 `DdPort`
 : The endpoint port to forward the logs to, useful for forwarding logs through a proxy.
 
+`DdUseServiceNameFromS3BucketTags`
+: Allow to override the service name of the logs coming from S3 by a `ddservice` tag on the bucket.
+
 `DdSkipSslValidation`
 : Send logs over HTTPS, while NOT validating the certificate provided by the endpoint. This will still encrypt the traffic between the forwarder and the log intake endpoint, but will not verify if the destination SSL certificate is valid.
 

--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -217,6 +217,8 @@ DD_MULTILINE_LOG_REGEX_PATTERN = get_env_var(
     "DD_MULTILINE_LOG_REGEX_PATTERN", default=None
 )
 
+DD_USE_SERVICE_NAME_FROM_S3_BUCKET_TAGS = get_env_var("DD_USE_SERVICE_NAME_FROM_S3_BUCKET_TAGS", "false", boolean=True)
+
 DD_SOURCE = "ddsource"
 DD_CUSTOM_TAGS = "ddtags"
 DD_SERVICE = "service"

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -64,6 +64,13 @@ Parameters:
     Type: String
     Default: ""
     Description: ARN for the layer containing the forwarder code. If empty, the script will use the version of the layer the forwarder was published with.
+  DdUseServiceNameFromS3BucketTags:
+    Type: String
+    Default: false
+    AllowedValues:
+      - true
+      - false
+    Description: Allow to override the service name of the logs coming from S3 by a `ddservice` tag on the bucket
   DdTags:
     Type: String
     Default: ""
@@ -241,6 +248,10 @@ Conditions:
     Fn::Equals:
       - !Select [0, !Split ["/", !Ref SourceZipUrl]]
       - "s3:"
+  SetDdUseServiceNameFromS3BucketTags:
+    Fn::Equals:
+      - Ref: DdUseServiceNameFromS3BucketTags
+      - true
   SetDdTags:
     Fn::Not:
       - Fn::Equals:
@@ -449,6 +460,11 @@ Resources:
               - SetDdFetchLambdaTags
               - Ref: ForwarderBucket
               - Ref: AWS::NoValue
+          DD_USE_SERVICE_NAME_FROM_S3_BUCKET_TAGS:
+            Fn::If:
+              - SetDdUseServiceNameFromS3BucketTags
+              - Ref: DdUseServiceNameFromS3BucketTags
+              - Ref: AWS::NoValue
           DD_SITE:
             Ref: DdSite
           DD_:
@@ -631,6 +647,7 @@ Resources:
                 Effect: Allow
               - Action:
                   - s3:GetObject
+                  - s3:GetBucketTagging
                 Resource: "*"
                 Effect: Allow
               - Action:
@@ -922,6 +939,7 @@ Metadata:
       - Label:
           default: Log Forwarding (Optional)
         Parameters:
+          - DdUseServiceNameFromS3BucketTags
           - DdTags
           - DdMultilineLogRegexPattern
           - DdUseTcp


### PR DESCRIPTION
…y a `ddservice` tag on the bucket

### What does this PR do?

For logs coming from an S3 bucket, this PR allows to override the service name by setting a `ddservice` tag on the bucket.

### Motivation

When we send ELB logs to Datadog, we end up having `source: elb` and `service: elb`, hence we cannot differentiate the logs from service X from those from service Y.

This PR allows us to filter the logs by service.

### Testing Guidelines

Tested by manually uploading the new code to our log forwarding AWS Lambda

### Types of changes

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
