### PR TITLE
[SMINT-3] Extract source for AWS FSx Windows Cloudwatch Log events

### DIFF
--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -239,6 +239,7 @@ def parse_event_source(event, key):
 
 
 def find_cloudwatch_source(log_group):
+    logger.info("aaaaaaaaaaaaaaaaa log group: {}".format(log_group))
     # e.g. /aws/rds/instance/my-mariadb/error
     if log_group.startswith("/aws/rds"):
         for engine in ["mariadb", "mysql", "postgresql"]:
@@ -265,6 +266,10 @@ def find_cloudwatch_source(log_group):
     # e.g. sns/us-east-1/123456779121/SnsTopicX
     if log_group.startswith("sns/"):
         return "sns"
+
+    # e.g. /aws/fsx/windows/xxx
+    if log_group.startswith("/aws/fsx/windows"):
+        return "aws.fsx"
 
     for source in [
         "/aws/lambda",  # e.g. /aws/lambda/helloDatadog
@@ -411,6 +416,7 @@ def awslogs_handler(event, context, metadata):
         # time (>5min) for file around 60MB gzipped
         data = b"".join(BufferedReader(decompress_stream))
     logs = json.loads(data)
+    logger.debug("decompressed logs: {}".format(logs))
 
     # Set the source on the logs
     source = logs.get("logGroup", "cloudwatch")

--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -239,7 +239,6 @@ def parse_event_source(event, key):
 
 
 def find_cloudwatch_source(log_group):
-    logger.info("aaaaaaaaaaaaaaaaa log group: {}".format(log_group))
     # e.g. /aws/rds/instance/my-mariadb/error
     if log_group.startswith("/aws/rds"):
         for engine in ["mariadb", "mysql", "postgresql"]:
@@ -416,7 +415,6 @@ def awslogs_handler(event, context, metadata):
         # time (>5min) for file around 60MB gzipped
         data = b"".join(BufferedReader(decompress_stream))
     logs = json.loads(data)
-    logger.debug("decompressed logs: {}".format(logs))
 
     # Set the source on the logs
     source = logs.get("logGroup", "cloudwatch")

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_fsx_windows.json
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_fsx_windows.json
@@ -1,0 +1,16 @@
+{
+    "messageType": "DATA_MESSAGE",
+    "owner": "123456789123",
+    "logGroup": "/aws/fsx/windows/12345",
+    "logStream": "123456789123_us-east-1",
+    "subscriptionFilters": [
+        "testFilter"
+    ],
+    "logEvents": [
+        {
+            "id": "35689263648391837472973739781728019701390240798247944192",
+            "timestamp": 1600361930988,
+            "message": "<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='Microsoft-Windows-Security-Auditing' Guid='{54849625-5478-4994-A5BA-3E3B0328C30D}'/><EventID>4663</EventID><Version>1</Version><Level>0</Level><Task>12800</Task><Opcode>0</Opcode><Keywords>0x8020000000000000</Keywords><TimeCreated SystemTime='2021-06-13T21:29:42.250333600Z'/><EventRecordID>294054</EventRecordID><Correlation/><Execution ProcessID='4' ThreadID='6832'/><Channel>Security</Channel><Computer>amznfsxjgnfqf2v.fsx.demo.com</Computer><Security/></System><EventData><Data Name='SubjectUserSid'>S-1-5-21-1387100404-3545110199-3154596375-1113</Data><Data Name='SubjectUserName'>Admin</Data><Data Name='SubjectDomainName'>fsx</Data><Data Name='SubjectLogonId'>0xbc9cfcc</Data><Data Name='ObjectServer'>Security</Data><Data Name='ObjectType'>File</Data><Data Name='ObjectName'>\\Device\\HarddiskVolume13\\share\\My first folder</Data><Data Name='HandleId'>0x1350</Data><Data Name='AccessList'>%%4423</Data><Data Name='AccessMask'>0x80</Data><Data Name='ProcessId'>0x4</Data><Data Name='ProcessName'></Data><Data Name='ResourceAttributes'>S:AI</Data></EventData></Event>"
+        }
+    ]
+}

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_fsx_windows.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_fsx_windows.json~snapshot
@@ -1,0 +1,81 @@
+{
+  "events": [
+    {
+      "content-type": "application/json",
+      "data": [
+        {
+          "aws": {
+            "awslogs": {
+              "logGroup": "/aws/fsx/windows/12345",
+              "logStream": "123456789123_us-east-1",
+              "owner": "123456789123"
+            },
+            "function_version": "$LATEST",
+            "invoked_function_arn": "arn:aws:lambda:us-east-1:0000000000:function:test"
+          },
+          "ddsource": "aws.fsx",
+          "ddsourcecategory": "aws",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>",
+          "host": "/aws/fsx/windows/12345",
+          "id": "35689263648391837472973739781728019701390240798247944192",
+          "message": "<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='Microsoft-Windows-Security-Auditing' Guid='{54849625-5478-4994-A5BA-3E3B0328C30D}'/><EventID>4663</EventID><Version>1</Version><Level>0</Level><Task>12800</Task><Opcode>0</Opcode><Keywords>0x8020000000000000</Keywords><TimeCreated SystemTime='2021-06-13T21:29:42.250333600Z'/><EventRecordID>294054</EventRecordID><Correlation/><Execution ProcessID='4' ThreadID='6832'/><Channel>Security</Channel><Computer>amznfsxjgnfqf2v.fsx.demo.com</Computer><Security/></System><EventData><Data Name='SubjectUserSid'>S-1-5-21-1387100404-3545110199-3154596375-1113</Data><Data Name='SubjectUserName'>Admin</Data><Data Name='SubjectDomainName'>fsx</Data><Data Name='SubjectLogonId'>0xbc9cfcc</Data><Data Name='ObjectServer'>Security</Data><Data Name='ObjectType'>File</Data><Data Name='ObjectName'>\\Device\\HarddiskVolume13\\share\\My first folder</Data><Data Name='HandleId'>0x1350</Data><Data Name='AccessList'>%%4423</Data><Data Name='AccessMask'>0x80</Data><Data Name='ProcessId'>0x4</Data><Data Name='ProcessName'></Data><Data Name='ResourceAttributes'>S:AI</Data></EventData></Event>",
+          "service": "aws.fsx",
+          "timestamp": 1600361930988
+        }
+      ],
+      "path": "/v1/input/abcdefghijklmnopqrstuvwxyz012345",
+      "verb": "POST"
+    },
+    {
+      "content-type": "application/json",
+      "data": {
+        "series": [
+          {
+            "device": null,
+            "host": null,
+            "interval": 10,
+            "metric": "aws.dd_forwarder.incoming_events",
+            "points": "<redacted from snapshot>",
+            "tags": [
+              "forwardername:test",
+              "forwarder_memorysize:1536",
+              "forwarder_version:<redacted from snapshot>",
+              "event_type:awslogs"
+            ],
+            "type": "distribution"
+          },
+          {
+            "device": null,
+            "host": null,
+            "interval": 10,
+            "metric": "aws.dd_forwarder.logs_forwarded",
+            "points": "<redacted from snapshot>",
+            "tags": [
+              "forwardername:test",
+              "forwarder_memorysize:1536",
+              "forwarder_version:<redacted from snapshot>",
+              "event_type:awslogs"
+            ],
+            "type": "distribution"
+          },
+          {
+            "device": null,
+            "host": null,
+            "interval": 10,
+            "metric": "aws.dd_forwarder.metrics_forwarded",
+            "points": "<redacted from snapshot>",
+            "tags": [
+              "forwardername:test",
+              "forwarder_memorysize:1536",
+              "forwarder_version:<redacted from snapshot>",
+              "event_type:awslogs"
+            ],
+            "type": "distribution"
+          }
+        ]
+      },
+      "path": "/api/v1/distribution_points?api_key=abcdefghijklmnopqrstuvwxyz012345",
+      "verb": "POST"
+    }
+  ]
+}

--- a/aws/logs_monitoring/tools/integration_tests/tester/test_snapshots.py
+++ b/aws/logs_monitoring/tools/integration_tests/tester/test_snapshots.py
@@ -132,6 +132,11 @@ class TestForwarderSnapshots(unittest.TestCase):
         snapshot_filename = f"{input_filename}~snapshot"
         self.compare_snapshot(input_filename, snapshot_filename)
 
+    def test_cloudwatch_log_fsx_windows(self):
+        input_filename = f"{snapshot_dir}/cloudwatch_log_fsx_windows.json"
+        snapshot_filename = f"{input_filename}~snapshot"
+        self.compare_snapshot(input_filename, snapshot_filename)
+
     def test_cloudwatch_log_lambda_invocation(self):
         input_filename = f"{snapshot_dir}/cloudwatch_log_lambda_invocation.json"
         snapshot_filename = f"{input_filename}~snapshot"


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Set `source:aws.fsx` for AWS FSx Windows logs. 

<!--- A brief description of the change being made with this pull request. --->

### Motivation

We're adding a new log integration: [AWS FSx Windows file access audit logs](https://aws.amazon.com/blogs/aws/file-access-auditing-is-now-available-for-amazon-fsx-for-windows-file-server/?sc_icampaign=pac_access-auditing-on-fsx&sc_ichannel=ha&sc_icontent=awssm-8577_pac&sc_iplace=ribbon&trk=ha_awssm-8577_pac). This PR updates the Datadog Forwarder to extract the source for these logs. 
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
