### PR TITLE
[azure] Update Azure log forwarder to use v2 events platform API

### DIFF
--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -5,7 +5,7 @@
 
 var https = require('https');
 
-const VERSION = '0.5.3';
+const VERSION = '0.5.4';
 
 const STRING = 'string'; // example: 'some message'
 const STRING_ARRAY = 'string-array'; // example: ['one message', 'two message', ...]
@@ -132,11 +132,12 @@ class HTTPClient {
         this.httpOptions = {
             hostname: DD_HTTP_URL,
             port: DD_HTTP_PORT,
-            path: '/v1/input',
+            path: '/api/v2/logs',
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
-                'DD-API-KEY': DD_API_KEY
+                'DD-API-KEY': DD_API_KEY,
+                'DD-SOURCE': DD_SOURCE
             }
         };
         this.scrubber = new Scrubber(this.context, SCRUBBER_RULE_CONFIGS);

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -137,7 +137,7 @@ class HTTPClient {
             headers: {
                 'Content-Type': 'application/json',
                 'DD-API-KEY': DD_API_KEY,
-                'DD-SOURCE': 'azure'
+                'DD-EVP-ORIGIN': 'azure'
             }
         };
         this.scrubber = new Scrubber(this.context, SCRUBBER_RULE_CONFIGS);

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -137,7 +137,7 @@ class HTTPClient {
             headers: {
                 'Content-Type': 'application/json',
                 'DD-API-KEY': DD_API_KEY,
-                'DD-SOURCE': DD_SOURCE
+                'DD-SOURCE': 'azure'
             }
         };
         this.scrubber = new Scrubber(this.context, SCRUBBER_RULE_CONFIGS);


### PR DESCRIPTION
### Ticket
* https://datadoghq.atlassian.net/browse/AZI-187

### What does this PR do?
* Updates the Azure log forwarder to use the v2 events platform API
* Increases Azure log forwarder version number

### Motivation
* See ticket

### Testing Guidelines
* Ran unit tests
* Sent test logs via Azure portal using [this resource](https://portal.azure.com/#blade/WebsitesExtension/FunctionMenuBlade/functionOverview/resourceId/%2Fsubscriptions%2F8c56d827-5f07-45ce-8f2b-6c5001db5c6f%2FresourceGroups%2FeclairStandardLBGroup%2Fproviders%2FMicrosoft.Web%2Fsites%2Fricky-test-function-app%2Ffunctions%2FEventHubTrigger1); test logs showed up as expected in the Datadog logs UI

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
