### PR TITLE
[CSPINT-28] Extract log source for Carbon Black logs

### DIFF
--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -328,7 +328,7 @@ def find_s3_source(key):
 
     # e.g. carbon-black-cloud-forwarder/alerts/org_key=*****/year=2021/month=7/day=19/hour=18/minute=15/second=41/8436e850-7e78-40e4-b3cd-6ebbc854d0a2.jsonl.gz
     if "carbon-black" in key:
-        return "cbdefence"
+        return "carbonblack"
 
     # the below substrings must be in your target prefix to be detected
     for source in [

--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -326,6 +326,10 @@ def find_s3_source(key):
     if "amazon_documentdb" in key:
         return "docdb"
 
+    # e.g. carbon-black-cloud-forwarder/alerts/org_key=*****/year=2021/month=7/day=19/hour=18/minute=15/second=41/8436e850-7e78-40e4-b3cd-6ebbc854d0a2.jsonl.gz
+    if "carbon-black" in key:
+        return "cbdefence"
+
     # the below substrings must be in your target prefix to be detected
     for source in [
         "amazon_codebuild",

--- a/aws/logs_monitoring/tests/test_parsing.py
+++ b/aws/logs_monitoring/tests/test_parsing.py
@@ -246,6 +246,15 @@ class TestParseEventSource(unittest.TestCase):
             "msk",
         )
 
+    def test_carbon_black_event(self):
+        self.assertEqual(
+            parse_event_source(
+                {"Records": ["logs-from-s3"]},
+                "carbon-black-cloud-forwarder/alerts/8436e850-7e78-40e4-b3cd-6ebbc854d0a2.jsonl.gz",
+            ),
+            "carbonblack",
+        )
+
     def test_cloudwatch_source_if_none_found(self):
         self.assertEqual(parse_event_source({"awslogs": "logs"}, ""), "cloudwatch")
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

#### Update the Datadog Forwarder to extract the source tag for Carbon Black logs. 
Carbon Black logs are located in s3 and (as will be instructed in the integration installation steps) the prefix of s3 objects will contain the string "carbon-black".
The source tag used is `source:carbonblack`.  

<!--- A brief description of the change being made with this pull request. --->

### Motivation

Add a log integration for Carbon Black. 

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
