### PR TITLE
Fix deploy prod deploy script for GovCloud

### DIFF
--- a/aws/logs_monitoring/release.sh
+++ b/aws/logs_monitoring/release.sh
@@ -41,18 +41,18 @@ if [ "$ACCOUNT" = "prod" ]; then
     BUCKET="datadog-cloudformation-template"
 fi
 
-function awe-login() {
-    cfg=$@
+function aws-login() {
+    cfg=( "$@" )
     shift
     if [ "$ACCOUNT" = "prod" ] ; then
-        aws-vault exec prod-engineering --  $cfg
+        aws-vault exec prod-engineering --  ${cfg[@]}
     else
-        aws-vault exec sandbox-account-admin --  $cfg
+        aws-vault exec sandbox-account-admin --  ${cfg[@]}
     fi
 }
 
 get_max_layer_version() {
-    last_layer_version=$(awe-login aws lambda list-layer-versions --layer-name $LAYER_NAME --region us-west-2 | jq -r ".LayerVersions | .[0] |  .Version")
+    last_layer_version=$(aws-login aws lambda list-layer-versions --layer-name $LAYER_NAME --region us-west-2 | jq -r ".LayerVersions | .[0] |  .Version")
     if [ "$last_layer_version" == "null" ]; then
         echo 0
     else
@@ -61,9 +61,9 @@ get_max_layer_version() {
 }
 
 # Validate identity
-awe-login aws sts get-caller-identity
+aws-login aws sts get-caller-identity
 
-CURRENT_ACCOUNT="$(awe-login aws sts get-caller-identity --query Account --output text)"
+CURRENT_ACCOUNT="$(aws-login aws sts get-caller-identity --query Account --output text)"
 CURRENT_LAYER_VERSION=$(get_max_layer_version)
 LAYER_VERSION=$(($CURRENT_LAYER_VERSION +1))
 
@@ -73,7 +73,7 @@ echo "Current layer version is $CURRENT_LAYER_VERSION, next layer version is $LA
 # Validate the template
 echo
 echo "Validating template.yaml..."
-awe-login aws cloudformation validate-template --template-body file://template.yaml
+aws-login aws cloudformation validate-template --template-body file://template.yaml
 
 
 if [ "$ACCOUNT" = "prod" ] ; then
@@ -121,7 +121,7 @@ if [ "$ACCOUNT" = "prod" ] ; then
     # Sign the bundle
     echo
     echo "Signing the Forwarder bundle..."
-    awe-login ./tools/sign_bundle.sh $BUNDLE_PATH $ACCOUNT
+    aws-login ./tools/sign_bundle.sh $BUNDLE_PATH $ACCOUNT
 
     # Create a GitHub release
     echo
@@ -146,12 +146,12 @@ else
     # Sign the bundle
     echo
     echo "Signing the Forwarder bundle..."
-    awe-login ./tools/sign_bundle.sh $BUNDLE_PATH $ACCOUNT
+    aws-login ./tools/sign_bundle.sh $BUNDLE_PATH $ACCOUNT
 
     # Upload the bundle to S3 instead of GitHub for a sandbox release
     echo
     echo "Uploading non-public sandbox version of Forwarder to S3..."
-    awe-login aws s3 cp $BUNDLE_PATH s3://${BUCKET}/aws/forwarder-staging-zip/aws-dd-forwarder-${FORWARDER_VERSION}.zip
+    aws-login aws s3 cp $BUNDLE_PATH s3://${BUCKET}/aws/forwarder-staging-zip/aws-dd-forwarder-${FORWARDER_VERSION}.zip
     
     # Upload the sandbox layers
     echo
@@ -168,13 +168,13 @@ echo
 echo "Uploading template.yaml to s3://${BUCKET}/aws/forwarder/${FORWARDER_VERSION}.yaml"
 
 if [ "$ACCOUNT" = "prod" ] ; then
-    awe-login aws s3 cp template.yaml s3://${BUCKET}/aws/forwarder/${FORWARDER_VERSION}.yaml \
+    aws-login aws s3 cp template.yaml s3://${BUCKET}/aws/forwarder/${FORWARDER_VERSION}.yaml \
         --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
-    awe-login aws s3 cp template.yaml s3://${BUCKET}/aws/forwarder/latest.yaml \
+    aws-login aws s3 cp template.yaml s3://${BUCKET}/aws/forwarder/latest.yaml \
         --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
 else
-    awe-login aws s3 cp template.yaml s3://${BUCKET}/aws/forwarder-staging/${FORWARDER_VERSION}.yaml
-    awe-login aws s3 cp template.yaml s3://${BUCKET}/aws/forwarder-staging/latest.yaml
+    aws-login aws s3 cp template.yaml s3://${BUCKET}/aws/forwarder-staging/${FORWARDER_VERSION}.yaml
+    aws-login aws s3 cp template.yaml s3://${BUCKET}/aws/forwarder-staging/latest.yaml
 fi
 
 echo "Done uploading the CloudFormation template!"

--- a/aws/logs_monitoring/tools/installation_test.sh
+++ b/aws/logs_monitoring/tools/installation_test.sh
@@ -27,13 +27,13 @@ DD_API_KEY=RUN_ID
 
 CURRENT_VERSION="$(grep -o 'Version: \d\+\.\d\+\.\d\+' template.yaml | cut -d' ' -f2)"
 
-function awe-login() {
-    cfg=$@
+function aws-login() {
+    cfg=( "$@" )
     shift
     if [ "$ACCOUNT" = "prod" ] ; then
-        aws-vault exec prod-engineering --  $cfg
+        aws-vault exec prod-engineering --  ${cfg[@]}
     else
-        aws-vault exec sandbox-account-admin --  $cfg
+        aws-vault exec sandbox-account-admin --  ${cfg[@]}
     fi
 }
 
@@ -57,16 +57,16 @@ publish_test() {
     STACK_NAME="datadog-forwarder-integration-stack-${RUN_ID}"
 
     echo "Creating stack using Zip Copier Flow ${STACK_NAME}"
-    awe-login aws cloudformation create-stack --stack-name $STACK_NAME --template-url $TEMPLATE_URL --capabilities "CAPABILITY_AUTO_EXPAND" "CAPABILITY_IAM" --on-failure "DELETE" \
+    aws-login aws cloudformation create-stack --stack-name $STACK_NAME --template-url $TEMPLATE_URL --capabilities "CAPABILITY_AUTO_EXPAND" "CAPABILITY_IAM" --on-failure "DELETE" \
         --parameters=$PARAM_LIST --region $AWS_REGION
 
     echo "Waiting for stack to complete creation ${STACK_NAME}"
-    awe-login aws cloudformation wait stack-create-complete --stack-name $STACK_NAME --region $AWS_REGION
+    aws-login aws cloudformation wait stack-create-complete --stack-name $STACK_NAME --region $AWS_REGION
 
     echo "Completed stack creation"
 
     echo "Cleaning up stack"
-    awe-login aws cloudformation delete-stack --stack-name $STACK_NAME  --region $AWS_REGION
+    aws-login aws cloudformation delete-stack --stack-name $STACK_NAME  --region $AWS_REGION
 }
 
 echo

--- a/aws/logs_monitoring/tools/publish_prod.sh
+++ b/aws/logs_monitoring/tools/publish_prod.sh
@@ -3,7 +3,6 @@
 # Use with `./publish_prod.sh <DESIRED_NEW_VERSION>
 
 set -e
-unset AWS_VAULT
 
 # Ensure on main, and pull the latest
 BRANCH=$(git rev-parse --abbrev-ref HEAD)

--- a/aws/logs_monitoring/tools/publish_sandbox.sh
+++ b/aws/logs_monitoring/tools/publish_sandbox.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -e
-unset AWS_VAULT
 # Read the new version
 if [ -z "$1" ]; then
     echo "Must specify a desired version number"


### PR DESCRIPTION
### What does this PR do?

Currently the forwarder deploy script breaks when submitting to gov-cloud. This is because the script is run in a nested aws-vault session. To fix, I changed the release script so no nesting is used, and aws-vault sessions are more tightly scoped within the script.

### Testing Guidelines

I've run the installation tests to verify nothing has broken.

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
