### PR TITLE
Output Forwarder S3 bucket name

### DIFF
--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -902,6 +902,13 @@ Outputs:
       Name:
         Fn::Sub: ${AWS::StackName}-ApiKeySecretArn
     Condition: CreateDdApiKeySecret
+  ForwarderBucketName:
+    Description: Name of the S3 bucket used by the Forwarder
+    Value:
+      Ref: ForwarderBucket
+    Export:
+      Name:
+        Fn::Sub: ${AWS::StackName}-ForwarderBucketName
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Because CloudFormation does not have an option to force deleting a s3 bucket with objects in it, we need to output the bucket name, so customers can force delete the bucket outside the CloudFormation stack.

### Motivation

https://github.com/DataDog/datadog-serverless-functions/issues/469

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [x] This PR passes the installation tests (ask a Datadog member to run the tests)
