### PR TITLE
Allow the Forwarder to be deployed via StackSets

### DIFF
--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -1,5 +1,4 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Transform: AWS::Serverless-2016-10-31
 Description: Pushes logs, metrics and traces from AWS to Datadog.
 Mappings:
   Constants:
@@ -791,116 +790,136 @@ Resources:
   # In places where Datadog can't/doesn't yet publish Lambda layers, use another Lambda to copy the source code
   # from github to a s3 bucket in the partition & region where the forwarder is deployed to.
   ForwarderZipCopier:
-    Type: AWS::Serverless::Function
+    Type: AWS::Lambda::Function
     Condition: UseZipCopier
     Properties:
       Description: Copies Datadog Forwarder zip to the destination S3 bucket
       Handler: index.handler
       Runtime: python3.7
       Timeout: 300
-      InlineCode: |
-        import json
-        import logging
-        import threading
-        import boto3
-        import urllib.request
-        import os
+      Code:
+        ZipFile: |
+          import json
+          import logging
+          import threading
+          import boto3
+          import urllib.request
+          import os
 
-        def send_cfn_resp(event, context, response_status):
-            resp_body = json.dumps({
-                'Status': response_status,
-                'Reason': f'See reasons in CloudWatch Logs - group: {context.log_group_name}, stream:{context.log_stream_name}',
-                'PhysicalResourceId': context.log_stream_name,
-                'StackId': event['StackId'],
-                'RequestId': event['RequestId'],
-                'LogicalResourceId': event['LogicalResourceId'],
-                'Data': {}
-            }).encode('utf-8')
-            req = urllib.request.Request(url=event['ResponseURL'], data=resp_body, method='PUT')
-            with urllib.request.urlopen(req) as f:
-                logging.info(f'Sent response to CloudFormation: {f.status}, {f.reason}')
-        def delete_zips(bucket):
-            s3 = boto3.resource('s3')
-            bucket = s3.Bucket(bucket)
-            bucket.objects.all().delete()
-        def copy_zip(source_zip_url, dest_zips_bucket):
-            s3 = boto3.client('s3')
-            s3_prelude = "s3://"
-            filename = "aws-dd-forwarder-{}.zip".format(os.environ.get("DD_FORWARDER_VERSION"))
-            if source_zip_url.startswith(s3_prelude):
-                parts = source_zip_url[len(s3_prelude):].split('/')
-                bucket = parts[0]
-                key = '/'.join(parts[1:])
-                response = s3.get_object(Bucket=bucket, Key=key)
-                data = response["Body"]
-                s3.upload_fileobj(data, dest_zips_bucket, filename)
-            else:
-                with urllib.request.urlopen(source_zip_url) as data:
-                    s3.upload_fileobj(data, dest_zips_bucket, filename)
-        def timeout(event, context):
-            logging.error('Execution is about to time out, sending failure response to CloudFormation')
-            send_cfn_resp(event, context, 'FAILED')
-        def handler(event, context):
-            # make sure we send a failure to CloudFormation if the function
-            # is going to timeout
-            timer = threading.Timer((context.get_remaining_time_in_millis()
-                      / 1000.00) - 0.5, timeout, args=[event, context])
-            timer.start()
-            logging.info(f'Received event: {json.dumps(event)}')
-            try:
-                source_zip_url = event['ResourceProperties']['SourceZipUrl']
-                dest_zips_bucket = event['ResourceProperties']['DestZipsBucket']
-                if event['RequestType'] == 'Delete':
-                    delete_zips(dest_zips_bucket)
-                else:
-                    copy_zip(source_zip_url, dest_zips_bucket)
-            except Exception as e:
-                logging.exception(f'Exception when copying zip from {source_zip_url} to {dest_zips_bucket}')
-                send_cfn_resp(event, context, 'FAILED')
-            else:
-                send_cfn_resp(event, context, 'SUCCESS')
-            finally:
-                timer.cancel()
+          def send_cfn_resp(event, context, response_status):
+              resp_body = json.dumps({
+                  'Status': response_status,
+                  'Reason': f'See reasons in CloudWatch Logs - group: {context.log_group_name}, stream:{context.log_stream_name}',
+                  'PhysicalResourceId': context.log_stream_name,
+                  'StackId': event['StackId'],
+                  'RequestId': event['RequestId'],
+                  'LogicalResourceId': event['LogicalResourceId'],
+                  'Data': {}
+              }).encode('utf-8')
+              req = urllib.request.Request(url=event['ResponseURL'], data=resp_body, method='PUT')
+              with urllib.request.urlopen(req) as f:
+                  logging.info(f'Sent response to CloudFormation: {f.status}, {f.reason}')
+          def delete_zips(bucket):
+              s3 = boto3.resource('s3')
+              bucket = s3.Bucket(bucket)
+              bucket.objects.all().delete()
+          def copy_zip(source_zip_url, dest_zips_bucket):
+              s3 = boto3.client('s3')
+              s3_prelude = "s3://"
+              filename = "aws-dd-forwarder-{}.zip".format(os.environ.get("DD_FORWARDER_VERSION"))
+              if source_zip_url.startswith(s3_prelude):
+                  parts = source_zip_url[len(s3_prelude):].split('/')
+                  bucket = parts[0]
+                  key = '/'.join(parts[1:])
+                  response = s3.get_object(Bucket=bucket, Key=key)
+                  data = response["Body"]
+                  s3.upload_fileobj(data, dest_zips_bucket, filename)
+              else:
+                  with urllib.request.urlopen(source_zip_url) as data:
+                      s3.upload_fileobj(data, dest_zips_bucket, filename)
+          def timeout(event, context):
+              logging.error('Execution is about to time out, sending failure response to CloudFormation')
+              send_cfn_resp(event, context, 'FAILED')
+          def handler(event, context):
+              # make sure we send a failure to CloudFormation if the function
+              # is going to timeout
+              timer = threading.Timer((context.get_remaining_time_in_millis()
+                        / 1000.00) - 0.5, timeout, args=[event, context])
+              timer.start()
+              logging.info(f'Received event: {json.dumps(event)}')
+              try:
+                  source_zip_url = event['ResourceProperties']['SourceZipUrl']
+                  dest_zips_bucket = event['ResourceProperties']['DestZipsBucket']
+                  if event['RequestType'] == 'Delete':
+                      delete_zips(dest_zips_bucket)
+                  else:
+                      copy_zip(source_zip_url, dest_zips_bucket)
+              except Exception as e:
+                  logging.exception(f'Exception when copying zip from {source_zip_url} to {dest_zips_bucket}')
+                  send_cfn_resp(event, context, 'FAILED')
+              else:
+                  send_cfn_resp(event, context, 'SUCCESS')
+              finally:
+                  timer.cancel()
+      Environment:
+        Variables:
+          DD_FORWARDER_VERSION: !FindInMap [Constants, DdForwarder, Version]
+      Role: !GetAtt "ForwarderZipCopierRole.Arn"
+  ForwarderZipReady:
+    Type: AWS::CloudFormation::WaitConditionHandle
+    Metadata:
+      ForwarderZipCopierReady: !If [UseZipCopier, !Ref ForwarderZip, ""]
+  ForwarderZipCopierRole:
+    Type: AWS::IAM::Role
+    Condition: UseZipCopier
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
       PermissionsBoundary:
         Fn::If:
           - SetPermissionsBoundary
           - Ref: PermissionsBoundaryArn
           - Ref: AWS::NoValue
       Policies:
-        - Version: "2012-10-17"
-          Statement:
-            - Effect: Allow
-              Action:
-                - s3:PutObject
-                - s3:DeleteObject
-              Resource:
-                - Fn::Join:
-                    - "/"
-                    - - Fn::GetAtt: "ForwarderBucket.Arn"
-                      - "*"
-            - Effect: Allow
-              Action:
-                - s3:ListBucket
-              Resource:
-                - Fn::GetAtt: "ForwarderBucket.Arn"
-            - !If
-              - SetS3SourceZip
+        - PolicyName: ForwarderZipCopierRolePolicy0
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
               - Effect: Allow
                 Action:
-                  - s3:GetObject
+                  - s3:PutObject
+                  - s3:DeleteObject
                 Resource:
                   - Fn::Join:
-                      - ""
-                      - - "arn:*:s3:::"
-                        - !Select [1, !Split ["s3://", !Ref SourceZipUrl]]
-              - Ref: AWS::NoValue
-      Environment:
-        Variables:
-          DD_FORWARDER_VERSION: !FindInMap [Constants, DdForwarder, Version]
-  ForwarderZipReady:
-    Type: AWS::CloudFormation::WaitConditionHandle
-    Metadata:
-      ForwarderZipCopierReady: !If [UseZipCopier, !Ref ForwarderZip, ""]
+                      - "/"
+                      - - Fn::GetAtt: "ForwarderBucket.Arn"
+                        - "*"
+              - Effect: Allow
+                Action:
+                  - s3:ListBucket
+                Resource:
+                  - Fn::GetAtt: "ForwarderBucket.Arn"
+              - !If
+                - SetS3SourceZip
+                - Effect: Allow
+                  Action:
+                    - s3:GetObject
+                  Resource:
+                    - Fn::Join:
+                        - ""
+                        - - "arn:*:s3:::"
+                          - !Select [1, !Split ["s3://", !Ref SourceZipUrl]]
+                - Ref: AWS::NoValue
 Outputs:
   DatadogForwarderArn:
     Description: Datadog Forwarder Lambda Function ARN


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Allow the Forwarder to be deployed via StackSets. The change is simple -- replace `Type: AWS::Serverless::Function` with `Type: AWS::Lambda::Function`, so it doesn't require the transform (not allowed by StackSets).

### Motivation

https://github.com/DataDog/datadog-serverless-functions/issues/423

### Testing Guidelines

Testing StackSets created successfully and the Forwarder deployed to multiple regions.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [x] This PR passes the installation tests (ask a Datadog member to run the tests)
