### PR TITLE
Increase max_item_size_bytes

### DIFF
--- a/aws/logs_monitoring/logs.py
+++ b/aws/logs_monitoring/logs.py
@@ -60,7 +60,7 @@ def forward_logs(logs):
         batcher = DatadogBatcher(256 * 1000, 256 * 1000, 1)
         cli = DatadogTCPClient(DD_URL, DD_PORT, DD_NO_SSL, DD_API_KEY, scrubber)
     else:
-        batcher = DatadogBatcher(256 * 1000, 4 * 1000 * 1000, 400)
+        batcher = DatadogBatcher(512 * 1000, 4 * 1000 * 1000, 400)
         cli = DatadogHTTPClient(
             DD_URL, DD_PORT, DD_NO_SSL, DD_SKIP_SSL_VALIDATION, DD_API_KEY, scrubber
         )


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Increase `max_item_size_bytes` from 256KB to 512KB, so the longest log entry from CW logs can still fit and not get discarded.
The documented size limit for CW logs entry is also 256KB, but the actual limit seems to be around 262KB.

### Motivation

https://github.com/DataDog/datadog-serverless-functions/issues/462

### Testing Guidelines

Tested a log entry with 263KB, which did not appear in Datadog before the change but appear after the change.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [x] This PR passes the installation tests (ask a Datadog member to run the tests)
