### PR TITLE
[azure] Fix log splitting when field value is null

### DIFF
--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -5,7 +5,7 @@
 
 var https = require('https');
 
-const VERSION = '0.5.4';
+const VERSION = '0.5.5';
 
 const STRING = 'string'; // example: 'some message'
 const STRING_ARRAY = 'string-array'; // example: ['one message', 'two message', ...]

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -5,7 +5,7 @@
 
 var https = require('https');
 
-const VERSION = '0.5.3';
+const VERSION = '0.5.4';
 
 const STRING = 'string'; // example: 'some message'
 const STRING_ARRAY = 'string-array'; // example: ['one message', 'two message', ...]
@@ -244,10 +244,20 @@ class EventhubLogHandler {
         for (var i = 0; i < fields.length; i++) {
             // loop through the fields to find the one we want to split
             var fieldName = fields[i];
-            if (tempRecord[fieldName] !== undefined) {
-                tempRecord = tempRecord[fieldName];
-            } else {
+            if (
+                tempRecord[fieldName] === undefined ||
+                tempRecord[fieldName] === null
+            ) {
+                // if the field is null or undefined, return
                 return null;
+            } else {
+                // there is some value for the field
+                try {
+                    // if for some reason we can't index into it, return null
+                    tempRecord = tempRecord[fieldName];
+                } catch {
+                    return null;
+                }
             }
         }
         return tempRecord;


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

If a field that we're trying to index into is null, the function will crash - in some cases it seems like some logs may have a field that is null instead of a dictionary, so we should return null if one of the fields is null.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

Better support for log splitting in eventhub log forwarder

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
Tested in test account, confirmed with different field types that it works, that we see the exception `TypeError: Cannot read property 'runOutput' of null` before the change, and after the log is successfully sent and not split.

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
