### PR TITLE
Increase timeout for layer uploading

### DIFF
--- a/aws/logs_monitoring/tools/publish_layers.sh
+++ b/aws/logs_monitoring/tools/publish_layers.sh
@@ -94,6 +94,7 @@ publish_layer() {
         --zip-file "fileb://$layer_path" \
         --region $region \
         --compatible-runtimes $aws_version_key \
+        --cli-read-timeout 300 \
                         | jq -r '.Version')
 
     permission=$(aws lambda add-layer-version-permission --layer-name $layer_name \

--- a/aws/logs_monitoring/tools/publish_prod.sh
+++ b/aws/logs_monitoring/tools/publish_prod.sh
@@ -41,10 +41,10 @@ saml2aws login -a govcloud-us1-fed-human-engineering
 AWS_PROFILE=govcloud-us1-fed-human-engineering aws sts get-caller-identity
 aws-vault exec prod-engineering -- aws sts get-caller-identity
 
-echo
-echo "Publishing layers to commercial AWS regions"
-LAYER_VERSION=$LAYER_VERSION FORWARDER_VERSION=$FORWARDER_VERSION aws-vault exec prod-engineering -- ./tools/publish_layers.sh
-
 echo "Publishing layers to GovCloud AWS regions"
 saml2aws login -a govcloud-us1-fed-human-engineering
 LAYER_VERSION=$LAYER_VERSION FORWARDER_VERSION=$FORWARDER_VERSION AWS_PROFILE=govcloud-us1-fed-human-engineering ./tools/publish_layers.sh
+
+echo
+echo "Publishing layers to commercial AWS regions"
+LAYER_VERSION=$LAYER_VERSION FORWARDER_VERSION=$FORWARDER_VERSION aws-vault exec prod-engineering -- ./tools/publish_layers.sh


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

- Publish layer to GovCloud first, since it takes less time.
- Increase the timeout setting from the default 60s to 300s for uploading layer to a remote region.

### Motivation

https://github.com/DataDog/datadog-serverless-functions/issues/493

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [x] This PR passes the installation tests (ask a Datadog member to run the tests)
