### PR TITLE
Ignore non-utf8 characters

### DIFF
--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -200,7 +200,7 @@ def s3_handler(event, context, metadata):
     else:
         # Check if using multiline log regex pattern
         # and determine whether line or pattern separated logs
-        data = data.decode("utf-8", errors='ignore')
+        data = data.decode("utf-8", errors="ignore")
         if DD_MULTILINE_LOG_REGEX_PATTERN and multiline_regex_start_pattern.match(data):
             split_data = multiline_regex.split(data)
         else:

--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -200,7 +200,7 @@ def s3_handler(event, context, metadata):
     else:
         # Check if using multiline log regex pattern
         # and determine whether line or pattern separated logs
-        data = data.decode("utf-8")
+        data = data.decode("utf-8", errors='ignore')
         if DD_MULTILINE_LOG_REGEX_PATTERN and multiline_regex_start_pattern.match(data):
             split_data = multiline_regex.split(data)
         else:


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Sometimes the log content from s3 object may contain characters that are not encoded in utf-8, and it would cause the Forwarder to error like `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xfd in position 115924522: invalid start byte`. This PR makes the Forwarder to **ignore** the invalid or non-decodable characters, and therefore it doesn't error and still forward the rest of the logs that are valid.

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [x] This PR passes the installation tests (ask a Datadog member to run the tests)
