### PR TITLE
Safely extractt service tag

### DIFF
--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -220,9 +220,8 @@ def get_service_from_tags(metadata):
     # Get service from dd_custom_tags if it exists
     tagsplit = metadata[DD_CUSTOM_TAGS].split(",")
     for tag in tagsplit:
-        tag_name, tag_value = tag.split(":")
-        if tag_name == "service":
-            return tag_value
+        if tag.startswith("service:"):
+            return tag[8:]
 
     # Default service to source value
     return metadata[DD_SOURCE]

--- a/aws/logs_monitoring/tests/test_parsing.py
+++ b/aws/logs_monitoring/tests/test_parsing.py
@@ -20,6 +20,11 @@ from parsing import (
     parse_event_source,
     separate_security_hub_findings,
     parse_aws_waf_logs,
+    get_service_from_tags,
+)
+from settings import (
+    DD_CUSTOM_TAGS,
+    DD_SOURCE,
 )
 
 env_patch.stop()
@@ -716,6 +721,22 @@ class TestAWSLogsHandler(unittest.TestCase):
             },
             metadata,
         )
+
+
+class TestGetServiceFromTags(unittest.TestCase):
+    def test_get_service_from_tags(self):
+        metadata = {
+            DD_SOURCE: "ecs",
+            DD_CUSTOM_TAGS: "env:dev,tag,stack:aws:ecs,service:web,version:v1",
+        }
+        self.assertEqual(get_service_from_tags(metadata), "web")
+
+    def test_get_service_from_tags_default_to_source(self):
+        metadata = {
+            DD_SOURCE: "ecs",
+            DD_CUSTOM_TAGS: "env:dev,tag,stack:aws:ecs,version:v1",
+        }
+        self.assertEqual(get_service_from_tags(metadata), "ecs")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Fixing an issue introduced in https://github.com/DataDog/datadog-serverless-functions/pull/472. `tag_name, tag_value = tag.split(":")` may break on tags without any `:` or with more than one `:` (both valid). 

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
