### PR TITLE
[azure] Add 10 second timeout to Azure log submission requests

### DIFF
--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -197,7 +197,7 @@ class HTTPClient {
                 });
             req.on('timeout', () => {
                 req.destroy();
-                reject(`request timed out after ${DD_REQUEST_TIMEOUT_MS}ms`)
+                reject(`request timed out after ${DD_REQUEST_TIMEOUT_MS}ms`);
             })
             req.write(this.scrubber.scrub(JSON.stringify(record)));
             req.end();


### PR DESCRIPTION
## Ticket
* https://datadoghq.atlassian.net/browse/AZI-449

## Changes
* Adds 10 second timeout to Azure log submission requests

## Impact
* Azure log submission requests lasting longer than 10 seconds will no longer block submission

## Motivation
* We don't want the function to run forever

## Testing
* Tested code as seen in this PR to verify submission still works when there's no timeout
* Tested code with timeout set to 1ms to cause requests to always time out. Verified that the expected timeout log message is displayed in the console, the request is destroyed, the function terminates cleanly, and no logs are submitted to datadog.

## Deployment
<!--
How is this going to be deployed?

RISKS AND MITIGATION: What are the potential risks and pitfalls? How can potential risks be prevented, mitigated, or otherwise addressed? How will the deploy be monitored such that any issues are caught?

DOWNSTREAM EFFECTS: Are there potential downstream effects? e.g. host tag churn, increased job execution time, increased traffic to dogpound/crawl state/postgres, increased traffic to third-party APIs
-->
* No deployment process for log forwarder

## Owner Checklist
- [ ] code is running on staging
- [ ] code is merged and released on prod
- [ ] dashboards and logs are on screen for monitoring during rollout
- [ ] dogweb has been deployed to a canary
- [ ] changes have been manually verified on canary
- [ ] dogweb is deployed to us3.prod.dog
- [ ] dogweb is deployed to eu1.prod.dog
- [ ] dogweb is deployed to us1.prod.dog
- [ ] dogweb is deployed to us1.fed.dog (GovCloud)
- [ ] [Crawler dashboard has been updated with new metrics / Monitors have been created or updated](#Monitoring)

## Reviewer Checklist
- [ ] Go through mental exercise: What could go wrong? Discuss if needed.
- [ ] Approved [Testing](#Testing)
- [ ] Approved [Deployment plan](#Deployment)