### PR TITLE
cloudformation: add parameter for forwarder bucket name

### DIFF
--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -206,6 +206,10 @@ Parameters:
     Type: String
     Default: ""
     Description: The endpoint URL to forward the traces to, useful for forwarding traces through a proxy
+  DdForwarderBucketName:
+    Type: String
+    Default: ""
+    Description: The name of the forwarder bucket to create. If not provided, AWS will generate a unique name.
 Conditions:
   IsAWSChina:
     Fn::Equals:
@@ -368,6 +372,11 @@ Conditions:
     Fn::Not:
       - Fn::Equals:
           - Ref: DdTraceIntakeUrl
+          - ""
+  SetDdForwarderBucketName:
+    Fn::Not:
+      - Fn::Equals:
+          - Ref: DdForwarderBucketName
           - ""
 Rules:
   MustSetDdApiKey:
@@ -653,7 +662,7 @@ Resources:
                     - Ref: DdApiKeySecret
                     - Fn::Sub: "${DdApiKeySecretArn}*"
                 Effect: Allow
-              # Fetch Lambda resource tags for data enrichment 
+              # Fetch Lambda resource tags for data enrichment
               - Fn::If:
                   - SetDdFetchLambdaTags
                   - Action:
@@ -671,7 +680,7 @@ Resources:
                     Resource: "*"
                     Effect: Allow
                   - Ref: AWS::NoValue
-              # To invoke a follower Lambda with the same event received by the forwarder for dual-shipping 
+              # To invoke a follower Lambda with the same event received by the forwarder for dual-shipping
               - Fn::If:
                   - SetAdditionalTargetLambdas
                   - Action:
@@ -742,6 +751,11 @@ Resources:
   ForwarderBucket:
     Type: AWS::S3::Bucket
     Properties:
+      BucketName:
+        Fn::If:
+          - SetDdForwarderBucketName
+          - Ref: DdForwarderBucketName
+          - Ref: AWS::NoValue
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -1020,6 +1020,7 @@ Metadata:
           - DdApiUrl
           - DdTraceIntakeUrl
           - AdditionalTargetLambdaArns
+          - DdForwarderBucketName
     ParameterLabels:
       DdApiKey:
         default: "DdApiKey *"


### PR DESCRIPTION
### What does this PR do?

Allow the user to specify a name for the forwarder bucket. This is necessary to avoid a circular dependency when creating permissions boundaries and passed them in via `PermissionsBoundaryArn`.

From https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html
> If you don't specify a name, AWS CloudFormation generates a unique ID and uses that ID for the bucket name.

### Motivation

Use case: I would like to create a permission boundary that limits datadog S3 privileges, but continue to allow unfettered access to the forwarder bucket (see https://github.com/DataDog/datadog-serverless-functions/blob/master/aws/logs_monitoring/template.yaml#L635-L646).

Before this change, the forwarder bucket's name is always generated, which makes it impossible to create the permission boundary before creating the forwarder bucket/role using cloudformation.

### Testing Guidelines

I am forking it and running this within my own CloudFormation pipeline.

### Types of changes


### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [x] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests (should be covered by installation tests.)
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
