### PR TITLE
Restrict the logic for trace detection in logs

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -175,10 +175,16 @@ def extract_trace_payload(event):
     try:
         message = event["message"]
         obj = json.loads(event["message"])
-        if not "traces" in obj or not isinstance(obj["traces"], list):
-            return None
-        return {"message": message, "tags": event[DD_CUSTOM_TAGS]}
-    except Exception:
+
+        obj_has_traces = "traces" in obj
+        traces_is_a_list = isinstance(obj["traces"], list)
+        # check that the log is not containing a traces array unrelated to Datadog
+        trace_id_found = len(obj["traces"][0]) > 0 and obj["traces"][0][0]["trace_id"] is not None
+    
+        if obj_has_traces and traces_is_a_list and trace_id_found:
+            return {"message": message, "tags": event[DD_CUSTOM_TAGS]}
+        return None
+    except Exception as e:
         return None
 
 

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -179,8 +179,12 @@ def extract_trace_payload(event):
         obj_has_traces = "traces" in obj
         traces_is_a_list = isinstance(obj["traces"], list)
         # check that the log is not containing a traces array unrelated to Datadog
-        trace_id_found = len(obj["traces"][0]) > 0 and obj["traces"][0][0]["trace_id"] is not None
-    
+        trace_id_found = (
+            len(obj["traces"]) > 0
+            and len(obj["traces"][0]) > 0
+            and obj["traces"][0][0]["trace_id"] is not None
+        )
+
         if obj_has_traces and traces_is_a_list and trace_id_found:
             return {"message": message, "tags": event[DD_CUSTOM_TAGS]}
         return None

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -188,7 +188,7 @@ def extract_trace_payload(event):
         if obj_has_traces and traces_is_a_list and trace_id_found:
             return {"message": message, "tags": event[DD_CUSTOM_TAGS]}
         return None
-    except Exception as e:
+    except Exception:
         return None
 
 

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -178,7 +178,7 @@ def extract_trace_payload(event):
 
         obj_has_traces = "traces" in obj
         traces_is_a_list = isinstance(obj["traces"], list)
-        # check that the log is not containing a traces array unrelated to Datadog
+        # check that the log is not containing a trace array unrelated to Datadog
         trace_id_found = (
             len(obj["traces"]) > 0
             and len(obj["traces"][0]) > 0

--- a/aws/logs_monitoring/tests/test_lambda_function.py
+++ b/aws/logs_monitoring/tests/test_lambda_function.py
@@ -198,34 +198,35 @@ class TestLambdaFunctionEndToEnd(unittest.TestCase):
 
         del os.environ["DD_FETCH_LAMBDA_TAGS"]
 
-class TestLambdaFunctionExtractTracePayload(unittest.TestCase):
 
+class TestLambdaFunctionExtractTracePayload(unittest.TestCase):
     def test_extract_trace_payload_none_no_trace(self):
         message_json = """{
             "key": "value"
         }"""
-        self.assertEqual(extract_trace_payload({"message":message_json}), None)
+        self.assertEqual(extract_trace_payload({"message": message_json}), None)
 
     def test_extract_trace_payload_none_exception(self):
         message_json = """{
             "invalid_json"
         }"""
-        self.assertEqual(extract_trace_payload({"message":message_json}), None)
+        self.assertEqual(extract_trace_payload({"message": message_json}), None)
 
     def test_extract_trace_payload_unrelated_datadog_trace(self):
         message_json = """{"traces":["I am a trace"]}"""
-        self.assertEqual(extract_trace_payload({"message":message_json}), None)
+        self.assertEqual(extract_trace_payload({"message": message_json}), None)
 
     def test_extract_trace_payload_valid_trace(self):
         message_json = """{"traces":[[{"trace_id":1234}]]}"""
         tags_json = """["key0:value", "key1:value1"]"""
         item = {
-            "message":'{"traces":[[{"trace_id":1234}]]}',
-            "tags": '["key0:value", "key1:value1"]'
+            "message": '{"traces":[[{"trace_id":1234}]]}',
+            "tags": '["key0:value", "key1:value1"]',
         }
-        self.assertEqual(extract_trace_payload({"message":message_json, "ddtags": tags_json}), item)
+        self.assertEqual(
+            extract_trace_payload({"message": message_json, "ddtags": tags_json}), item
+        )
 
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/aws/logs_monitoring/tests/test_lambda_function.py
+++ b/aws/logs_monitoring/tests/test_lambda_function.py
@@ -29,6 +29,7 @@ from lambda_function import (
     extract_host_from_cloudtrails,
     extract_host_from_guardduty,
     extract_host_from_route53,
+    extract_trace_payload,
     enrich,
     transform,
     split,
@@ -197,6 +198,34 @@ class TestLambdaFunctionEndToEnd(unittest.TestCase):
 
         del os.environ["DD_FETCH_LAMBDA_TAGS"]
 
+class TestLambdaFunctionExtractTracePayload(unittest.TestCase):
+
+    def test_extract_trace_payload_none_no_trace(self):
+        message_json = """{
+            "key": "value"
+        }"""
+        self.assertEqual(extract_trace_payload({"message":message_json}), None)
+
+    def test_extract_trace_payload_none_exception(self):
+        message_json = """{
+            "invalid_json"
+        }"""
+        self.assertEqual(extract_trace_payload({"message":message_json}), None)
+
+    def test_extract_trace_payload_unrelated_datadog_trace(self):
+        message_json = """{"traces":["I am a trace"]}"""
+        self.assertEqual(extract_trace_payload({"message":message_json}), None)
+
+    def test_extract_trace_payload_valid_trace(self):
+        message_json = """{"traces":[[{"trace_id":1234}]]}"""
+        tags_json = """["key0:value", "key1:value1"]"""
+        item = {
+            "message":'{"traces":[[{"trace_id":1234}]]}',
+            "tags": '["key0:value", "key1:value1"]'
+        }
+        self.assertEqual(extract_trace_payload({"message":message_json, "ddtags": tags_json}), item)
+
 
 if __name__ == "__main__":
     unittest.main()
+


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

- Modify the logic to better discriminate a Datadog trace in logs
- Add units tests around the modified function

Before : traces array was enough
After : traces array + first item of the array containing a 'trace_id' field

Now logs containing the trace keyword, which are NOT Datadog traces, are correctly logged.

Before:
<img width="564" alt="Screen Shot 2021-12-15 at 12 52 32 PM" src="https://user-images.githubusercontent.com/864493/146239559-735e479a-f3ec-4bb8-8edb-d8151fa1b17e.png">
After:
<img width="794" alt="Screen Shot 2021-12-15 at 12 53 47 PM" src="https://user-images.githubusercontent.com/864493/146239543-dbd1e8b6-5dbb-4271-9aee-df8171ff191b.png">



### Motivation

Support ticket

### Testing Guidelines

- [x] Unit testing
- [x] redeploy a forwarder in sandbox

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
