### PR TITLE
[Azure Blob Storage] Gunzip data that has magic header

### DIFF
--- a/azure/blobs_logs_monitoring/index.js
+++ b/azure/blobs_logs_monitoring/index.js
@@ -4,6 +4,7 @@
 // Copyright 2021 Datadog, Inc.
 
 var tls = require('tls');
+var zlib = require('zlib');
 
 const VERSION = '0.2.0';
 
@@ -45,6 +46,10 @@ module.exports = function(context, blobContent) {
     if (typeof blobContent === 'string') {
         logs = blobContent.trim().split('\n');
     } else if (Buffer.isBuffer(blobContent)) {
+        // Gunzip data that has magic header https://en.wikipedia.org/wiki/Gzip
+        if(blobContent[0]==0x1f && blobContent[1]==0x8b){
+            blobContent = zlib.gunzipSync(blobContent);
+        }
         logs = blobContent
             .toString('utf8')
             .trim()


### PR DESCRIPTION
### What does this PR do?

Gunzip data of `blobContent` from Azure Blob storage when it has magic header `0x1f 0x8b`.

### Motivation

Currently gzip files in Blob storage are transferred to Datadog as they are and result in garbled logs.
This PR gunzip those files before sending.

### Testing Guidelines

Upload the gzipped files to the blob storage and confirm in Datadog Logs whether they are gunzipped.

### Additional Notes

Magic header idea is taken from the following
https://github.com/DataDog/datadog-serverless-functions/blob/327bfa6c66fa68ea6bf9be7c6419f2faa9f0320d/aws/logs_monitoring/parsing.py#L185-L190

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
