### PR TITLE
feat(cloudformation-template): allow to set a static prefix to stack exports

### DIFF
--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -210,6 +210,10 @@ Parameters:
     Type: String
     Default: ""
     Description: The name of the forwarder bucket to create. If not provided, AWS will generate a unique name.
+  StaticExportsPrefix:
+    Type: String
+    Default: ""
+    Description: "Sets a static prefix the stack exports rather than prefixing with the stack name (useful when deploying via StackSets)"
 Conditions:
   IsAWSChina:
     Fn::Equals:
@@ -377,6 +381,11 @@ Conditions:
     Fn::Not:
       - Fn::Equals:
           - Ref: DdForwarderBucketName
+          - ""
+  SetStaticExportsPrefix:
+    Fn::Not:
+      - Fn::Equals:
+          - Ref: StaticExportsPrefix
           - ""
 Rules:
   MustSetDdApiKey:
@@ -941,14 +950,20 @@ Outputs:
         - Arn
     Export:
       Name:
-        Fn::Sub: ${AWS::StackName}-ForwarderArn
+        Fn::If:
+          - SetStaticExportsPrefix
+          - Fn::Sub: ${StaticExportsPrefix}-ForwarderArn
+          - Fn::Sub: ${AWS::StackName}-ForwarderArn
   DdApiKeySecretArn:
     Description: ARN of SecretsManager Secret with Datadog API Key
     Value:
       Ref: DdApiKeySecret
     Export:
       Name:
-        Fn::Sub: ${AWS::StackName}-ApiKeySecretArn
+        Fn::If:
+          - SetStaticExportsPrefix
+          - Fn::Sub: ${StaticExportsPrefix}-ApiKeySecretArn
+          - Fn::Sub: ${AWS::StackName}-ApiKeySecretArn
     Condition: CreateDdApiKeySecret
   ForwarderBucketName:
     Description: Name of the S3 bucket used by the Forwarder
@@ -956,7 +971,10 @@ Outputs:
       Ref: ForwarderBucket
     Export:
       Name:
-        Fn::Sub: ${AWS::StackName}-ForwarderBucketName
+        Fn::If:
+          - SetStaticExportsPrefix
+          - Fn::Sub: ${StaticExportsPrefix}-ForwarderBucketName
+          - Fn::Sub: ${AWS::StackName}-ForwarderBucketName
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -1019,6 +1037,7 @@ Metadata:
           - DdTraceIntakeUrl
           - AdditionalTargetLambdaArns
           - DdForwarderBucketName
+          - StaticExportsPrefix
     ParameterLabels:
       DdApiKey:
         default: "DdApiKey *"


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Simple non-breaking change to the CloudFormation template to allow users to set a static prefix that will be used in Stack Exports rather than interpolating the stack name.

### Motivation

When deploying the template using StackSets, the resulting stacks have random-ish unpredictable names.
This prevents users from relying on predictable Stack Exports to discover the Forwarder Function ARN or the Datadog API Key Secret.

### Testing Guidelines

Tested the template with no parameters to ensure no changes.
Tested the template by deploying via StackSet with prefix setting.

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [x] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
