### PR TITLE
adding log group tags

### DIFF
--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -453,7 +453,7 @@ def awslogs_handler(event, context, metadata):
 
     metadata[DD_SERVICE] = get_service_from_tags(metadata)
 
-    cloudwatch_logs_client = boto3.client('logs')
+    cloudwatch_logs_client = boto3.client("logs")
     response = None
     try:
         response = cloudwatch_logs_client.list_tags_log_group(
@@ -463,10 +463,15 @@ def awslogs_handler(event, context, metadata):
         logger.exception(f"Failed to get log group tags due to {e}")
     if response is not None:
         formatted_tags = [
-            "{key}:{value}".format(key=k, value=v) if v else k for k,v in response["tags"].items()
+            "{key}:{value}".format(key=k, value=v) if v else k
+            for k, v in response["tags"].items()
         ]
         if len(formatted_tags) > 0:
-            metadata[DD_CUSTOM_TAGS] = ",".join(formatted_tags) if not metadata[DD_CUSTOM_TAGS] else metadata[DD_CUSTOM_TAGS] + "," + ",".join(formatted_tags)
+            metadata[DD_CUSTOM_TAGS] = (
+                ",".join(formatted_tags)
+                if not metadata[DD_CUSTOM_TAGS]
+                else metadata[DD_CUSTOM_TAGS] + "," + ",".join(formatted_tags)
+            )
 
     # Build aws attributes
     aws_attributes = {

--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -453,6 +453,21 @@ def awslogs_handler(event, context, metadata):
 
     metadata[DD_SERVICE] = get_service_from_tags(metadata)
 
+    cloudwatch_logs_client = boto3.client('logs')
+    response = None
+    try:
+        response = cloudwatch_logs_client.list_tags_log_group(
+            logGroupName=logs["logGroup"]
+        )
+    except Exception as e:
+        logger.exception(f"Failed to get log group tags due to {e}")
+    if response is not None:
+        formatted_tags = [
+            "{key}:{value}".format(key=k, value=v) if v else k for k,v in response["tags"].items()
+        ]
+        if len(formatted_tags) > 0:
+            metadata[DD_CUSTOM_TAGS] = ",".join(formatted_tags) if not metadata[DD_CUSTOM_TAGS] else metadata[DD_CUSTOM_TAGS] + "," + ",".join(formatted_tags)
+
     # Build aws attributes
     aws_attributes = {
         "aws": {

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -651,6 +651,11 @@ Resources:
                   - kms:Decrypt
                 Resource: "*"
                 Effect: Allow
+              # Get tags for log groups and attach them to the logs sent to Datadog
+              - Action:
+                  - logs:ListTagsLogGroup
+                Resource: "*"
+                Effect: Allow
               # Access the Datadog API key from Secrets Manager
               - Action:
                   - secretsmanager:GetSecretValue


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
This pr adds support for cloudwatch log group tags. These tags will now get attached to the logs sent to datadog. 

### Motivation
Customer requests

### Testing Guidelines
Created new lambda function with this code, created some custom tags on a few log groups, and confirmed those tags get attached to the logs that make their way to Datadog. Unit and integration tests pass as well.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
