### PR TITLE
DOCS-3282 Add note about Lambda layer

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -39,7 +39,8 @@ Once installed, you can subscribe the Forwarder to log sources, such as S3 bucke
 5. [Set up triggers to the installed Forwarder](https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#set-up-triggers).
 6. Repeat the above steps in another region if you operate in multiple AWS regions.
 
-**Note:** If you had previously enabled your AWS Integration using the following [CloudFormation template](https://github.com/DataDog/cloudformation-template/tree/master/aws) from your AWS integration tile in Datadog, your account should already be provisioned with a Datadog Lambda Forwarder function.
+**Note:** If you had previously enabled your AWS Integration using the following [CloudFormation template](https://github.com/DataDog/cloudformation-template/tree/master/aws) from your AWS integration tile in Datadog, your account should already be provisioned with a Datadog Lambda Forwarder function.  
+**Note:** The code block of the Datadog Lambda Forwarder function is empty, as the logic is implemented through a Lambda layer.
 
 <!-- xxz tab xxx -->
 <!-- xxx tab "Terraform" xxx -->


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adds a note about the forwarder's code block being empty due to the logic being implemented through a Lambda layer.

### Motivation

DOCS-3282

### Testing Guidelines

Created the following preview link:
https://docs-staging.datadoghq.com/bryce/update-pull-config-preview/serverless/libraries_integrations/forwarder/ 

### Additional Notes

Customer was initially confused by the absence of code in the forwarder when set up via CloudFormation. They realized it was being implemented through a Lambda layer when they found this note in the stack's YAML file:

> The Forwarder's source code is too big to fit the inline code size limit for CloudFormation. In most of AWS
>    partitions and regions, the Forwarder is able to load its source code from a Lambda layer attached to it.
>    In places where Datadog can't/doesn't yet publish Lambda layers, use another Lambda to copy the source code
>    from github to a s3 bucket in the partition & region where the forwarder is deployed to.

However, I noticed that this is mentioned within the main docs under the `InstallAsLayer` parameter:
https://docs.datadoghq.com/serverless/libraries_integrations/forwarder/#advanced-optional 

As such, I've created this PR with an initial attempt at clarifying this. Let me know if there may be better ways to clarify or otherwise bring attention to this, or if you have any other feedback or suggestions in this regard.

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
