### PR TITLE
[SLS-2196] Undo server-side stats computation (remove computeStatsKey)

### DIFF
--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_lambda_invocation.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_lambda_invocation.json~snapshot
@@ -382,7 +382,6 @@
               {
                 "duration": "458278320",
                 "meta": {
-                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -408,7 +407,6 @@
               {
                 "duration": "13428",
                 "meta": {
-                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -434,7 +432,6 @@
               {
                 "duration": "35645",
                 "meta": {
-                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -460,7 +457,6 @@
               {
                 "duration": "9277",
                 "meta": {
-                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -486,7 +482,6 @@
               {
                 "duration": "26367",
                 "meta": {
-                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -512,7 +507,6 @@
               {
                 "duration": "127197",
                 "meta": {
-                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -538,7 +532,6 @@
               {
                 "duration": "499751709",
                 "meta": {
-                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -567,7 +560,6 @@
               {
                 "duration": "218750",
                 "meta": {
-                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -596,7 +588,6 @@
               {
                 "duration": "460493896",
                 "meta": {
-                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -626,7 +617,6 @@
               {
                 "duration": "479066650",
                 "meta": {
-                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -663,7 +653,6 @@
               {
                 "duration": "577401367",
                 "meta": {
-                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -699,7 +688,6 @@
               {
                 "duration": "578297119",
                 "meta": {
-                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -742,7 +730,6 @@
           {
             "duration": "499751709",
             "meta": {
-              "_dd.compute_stats": "1",
               "_dd.origin": "lambda",
               "account_id": "0000000000",
               "aws_account": "0000000000",
@@ -771,7 +758,6 @@
           {
             "duration": "218750",
             "meta": {
-              "_dd.compute_stats": "1",
               "_dd.origin": "lambda",
               "account_id": "0000000000",
               "aws_account": "0000000000",
@@ -800,7 +786,6 @@
           {
             "duration": "460493896",
             "meta": {
-              "_dd.compute_stats": "1",
               "_dd.origin": "lambda",
               "account_id": "0000000000",
               "aws_account": "0000000000",
@@ -830,7 +815,6 @@
           {
             "duration": "479066650",
             "meta": {
-              "_dd.compute_stats": "1",
               "_dd.origin": "lambda",
               "account_id": "0000000000",
               "aws_account": "0000000000",
@@ -867,7 +851,6 @@
           {
             "duration": "577401367",
             "meta": {
-              "_dd.compute_stats": "1",
               "_dd.origin": "lambda",
               "account_id": "0000000000",
               "aws_account": "0000000000",
@@ -903,7 +886,6 @@
           {
             "duration": "578297119",
             "meta": {
-              "_dd.compute_stats": "1",
               "_dd.origin": "lambda",
               "account_id": "0000000000",
               "aws_account": "0000000000",

--- a/aws/logs_monitoring/trace_forwarder/internal/apm/model.go
+++ b/aws/logs_monitoring/trace_forwarder/internal/apm/model.go
@@ -45,7 +45,6 @@ type (
 
 const (
 	originMetadataKey       = "_dd.origin"
-	computeStatsKey         = "_dd.compute_stats"
 	parentSourceMetadataKey = "_dd.parent_source"
 	sourceXray              = "xray"
 )
@@ -84,10 +83,6 @@ func ParseTrace(content string) ([]*pb.TracePayload, error) {
 				sp.Meta = map[string]string{}
 			}
 			sp.Meta[originMetadataKey] = "lambda"
-
-			// Instruct the span intake pipeline to compute stats
-			// in the APM backend.
-			sp.Meta[computeStatsKey] = "1"
 
 			pbSpan := convertSpanToPB(sp)
 			// We skip root dd-trace spans that are parented to X-Ray,

--- a/aws/logs_monitoring/trace_forwarder/internal/apm/testdata/basic.json~snapshot
+++ b/aws/logs_monitoring/trace_forwarder/internal/apm/testdata/basic.json~snapshot
@@ -16,8 +16,7 @@
       Start: (int64) 1586269922931758000,
       Duration: (int64) 254812000,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=7) {
-       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+      Meta: (map[string]string) (len=6) {
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=10) "cold_start": (string) (len=5) "false",
        (string) (len=12) "function_arn": (string) (len=68) "arn:aws:lambda:us-east-1:172597598159:function:hello-dog-dev-hello36",
@@ -46,8 +45,7 @@
       Start: (int64) 1586269922945357000,
       Duration: (int64) 138997000,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=6) {
-       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+      Meta: (map[string]string) (len=5) {
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=11) "http.method": (string) (len=3) "GET",
        (string) (len=16) "http.status_code": (string) (len=3) "200",
@@ -70,8 +68,7 @@
       Start: (int64) 1586269923086220000,
       Duration: (int64) 100232000,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=2) {
-       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+      Meta: (map[string]string) (len=1) {
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda"
       },
       Metrics: (map[string]float64) <nil>,
@@ -93,8 +90,7 @@
     Start: (int64) 1586269922931758000,
     Duration: (int64) 254812000,
     Error: (int32) 0,
-    Meta: (map[string]string) (len=7) {
-     (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+    Meta: (map[string]string) (len=6) {
      (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
      (string) (len=10) "cold_start": (string) (len=5) "false",
      (string) (len=12) "function_arn": (string) (len=68) "arn:aws:lambda:us-east-1:172597598159:function:hello-dog-dev-hello36",
@@ -123,8 +119,7 @@
     Start: (int64) 1586269922945357000,
     Duration: (int64) 138997000,
     Error: (int32) 0,
-    Meta: (map[string]string) (len=6) {
-     (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+    Meta: (map[string]string) (len=5) {
      (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
      (string) (len=11) "http.method": (string) (len=3) "GET",
      (string) (len=16) "http.status_code": (string) (len=3) "200",

--- a/aws/logs_monitoring/trace_forwarder/internal/apm/testdata/inferred_span.json~snapshot
+++ b/aws/logs_monitoring/trace_forwarder/internal/apm/testdata/inferred_span.json~snapshot
@@ -16,8 +16,7 @@
       Start: (int64) 1636820292450000100,
       Duration: (int64) 149992638,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=12) {
-       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+      Meta: (map[string]string) (len=11) {
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=28) "_inferred_span.synchronisity": (string) (len=4) "sync",
        (string) (len=25) "_inferred_span.tag_source": (string) (len=4) "self",
@@ -59,8 +58,7 @@
       Start: (int64) 1636820292466458000,
       Duration: (int64) 133507715,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=17) {
-       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+      Meta: (map[string]string) (len=16) {
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=10) "cold_start": (string) (len=5) "false",
        (string) (len=14) "datadog_lambda": (string) (len=6) "3.49.0",
@@ -103,8 +101,7 @@
       Start: (int64) 1636820292466887200,
       Duration: (int64) 19825652,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=10) {
-       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+      Meta: (map[string]string) (len=9) {
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=9) "aws.agent": (string) (len=8) "botocore",
        (string) (len=13) "aws.operation": (string) (len=11) "SendMessage",
@@ -132,8 +129,7 @@
       Start: (int64) 1636820292487212000,
       Duration: (int64) 21565856,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=11) {
-       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+      Meta: (map[string]string) (len=10) {
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=9) "aws.agent": (string) (len=8) "botocore",
        (string) (len=13) "aws.operation": (string) (len=7) "Publish",
@@ -162,8 +158,7 @@
       Start: (int64) 1636820292508904400,
       Duration: (int64) 6481144,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=9) {
-       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+      Meta: (map[string]string) (len=8) {
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=9) "aws.agent": (string) (len=8) "botocore",
        (string) (len=13) "aws.operation": (string) (len=7) "PutItem",
@@ -190,8 +185,7 @@
       Start: (int64) 1636820292515487000,
       Duration: (int64) 7799031,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=10) {
-       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+      Meta: (map[string]string) (len=9) {
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=9) "aws.agent": (string) (len=8) "botocore",
        (string) (len=13) "aws.operation": (string) (len=9) "PutRecord",
@@ -219,8 +213,7 @@
       Start: (int64) 1636820292523388000,
       Duration: (int64) 13733007,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=8) {
-       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+      Meta: (map[string]string) (len=7) {
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=9) "aws.agent": (string) (len=8) "botocore",
        (string) (len=13) "aws.operation": (string) (len=9) "PutEvents",
@@ -246,8 +239,7 @@
       Start: (int64) 1636820292538263000,
       Duration: (int64) 38689743,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=9) {
-       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+      Meta: (map[string]string) (len=8) {
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=9) "aws.agent": (string) (len=8) "botocore",
        (string) (len=13) "aws.operation": (string) (len=9) "PutObject",
@@ -274,8 +266,7 @@
       Start: (int64) 1636820292579315000,
       Duration: (int64) 20111883,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=9) {
-       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+      Meta: (map[string]string) (len=8) {
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=9) "aws.agent": (string) (len=8) "botocore",
        (string) (len=13) "aws.operation": (string) (len=6) "Invoke",
@@ -307,8 +298,7 @@
     Start: (int64) 1636820292450000100,
     Duration: (int64) 149992638,
     Error: (int32) 0,
-    Meta: (map[string]string) (len=12) {
-     (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+    Meta: (map[string]string) (len=11) {
      (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
      (string) (len=28) "_inferred_span.synchronisity": (string) (len=4) "sync",
      (string) (len=25) "_inferred_span.tag_source": (string) (len=4) "self",
@@ -350,8 +340,7 @@
     Start: (int64) 1636820292466458000,
     Duration: (int64) 133507715,
     Error: (int32) 0,
-    Meta: (map[string]string) (len=17) {
-     (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+    Meta: (map[string]string) (len=16) {
      (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
      (string) (len=10) "cold_start": (string) (len=5) "false",
      (string) (len=14) "datadog_lambda": (string) (len=6) "3.49.0",
@@ -394,8 +383,7 @@
     Start: (int64) 1636820292466887200,
     Duration: (int64) 19825652,
     Error: (int32) 0,
-    Meta: (map[string]string) (len=10) {
-     (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+    Meta: (map[string]string) (len=9) {
      (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
      (string) (len=9) "aws.agent": (string) (len=8) "botocore",
      (string) (len=13) "aws.operation": (string) (len=11) "SendMessage",
@@ -423,8 +411,7 @@
     Start: (int64) 1636820292487212000,
     Duration: (int64) 21565856,
     Error: (int32) 0,
-    Meta: (map[string]string) (len=11) {
-     (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+    Meta: (map[string]string) (len=10) {
      (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
      (string) (len=9) "aws.agent": (string) (len=8) "botocore",
      (string) (len=13) "aws.operation": (string) (len=7) "Publish",
@@ -453,8 +440,7 @@
     Start: (int64) 1636820292508904400,
     Duration: (int64) 6481144,
     Error: (int32) 0,
-    Meta: (map[string]string) (len=9) {
-     (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+    Meta: (map[string]string) (len=8) {
      (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
      (string) (len=9) "aws.agent": (string) (len=8) "botocore",
      (string) (len=13) "aws.operation": (string) (len=7) "PutItem",
@@ -481,8 +467,7 @@
     Start: (int64) 1636820292515487000,
     Duration: (int64) 7799031,
     Error: (int32) 0,
-    Meta: (map[string]string) (len=10) {
-     (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+    Meta: (map[string]string) (len=9) {
      (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
      (string) (len=9) "aws.agent": (string) (len=8) "botocore",
      (string) (len=13) "aws.operation": (string) (len=9) "PutRecord",
@@ -510,8 +495,7 @@
     Start: (int64) 1636820292523388000,
     Duration: (int64) 13733007,
     Error: (int32) 0,
-    Meta: (map[string]string) (len=8) {
-     (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+    Meta: (map[string]string) (len=7) {
      (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
      (string) (len=9) "aws.agent": (string) (len=8) "botocore",
      (string) (len=13) "aws.operation": (string) (len=9) "PutEvents",
@@ -537,8 +521,7 @@
     Start: (int64) 1636820292538263000,
     Duration: (int64) 38689743,
     Error: (int32) 0,
-    Meta: (map[string]string) (len=9) {
-     (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+    Meta: (map[string]string) (len=8) {
      (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
      (string) (len=9) "aws.agent": (string) (len=8) "botocore",
      (string) (len=13) "aws.operation": (string) (len=9) "PutObject",

--- a/aws/logs_monitoring/trace_forwarder/internal/apm/testdata/inferred_span_service_tag.json~snapshot
+++ b/aws/logs_monitoring/trace_forwarder/internal/apm/testdata/inferred_span_service_tag.json~snapshot
@@ -16,8 +16,7 @@
       Start: (int64) 1636820292450000100,
       Duration: (int64) 149992638,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=12) {
-       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+      Meta: (map[string]string) (len=11) {
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=27) "_inferred_span.syncronicity": (string) (len=4) "sync",
        (string) (len=25) "_inferred_span.tag_source": (string) (len=4) "self",
@@ -59,8 +58,7 @@
       Start: (int64) 1636820292466458000,
       Duration: (int64) 133507715,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=18) {
-       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+      Meta: (map[string]string) (len=17) {
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=10) "cold_start": (string) (len=5) "false",
        (string) (len=14) "datadog_lambda": (string) (len=6) "3.49.0",
@@ -104,8 +102,7 @@
       Start: (int64) 1636820292466887200,
       Duration: (int64) 19825652,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=11) {
-       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+      Meta: (map[string]string) (len=10) {
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=9) "aws.agent": (string) (len=8) "botocore",
        (string) (len=13) "aws.operation": (string) (len=11) "SendMessage",
@@ -134,8 +131,7 @@
       Start: (int64) 1636820292487212000,
       Duration: (int64) 21565856,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=12) {
-       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+      Meta: (map[string]string) (len=11) {
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=9) "aws.agent": (string) (len=8) "botocore",
        (string) (len=13) "aws.operation": (string) (len=7) "Publish",
@@ -165,8 +161,7 @@
       Start: (int64) 1636820292508904400,
       Duration: (int64) 6481144,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=10) {
-       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+      Meta: (map[string]string) (len=9) {
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=9) "aws.agent": (string) (len=8) "botocore",
        (string) (len=13) "aws.operation": (string) (len=7) "PutItem",
@@ -194,8 +189,7 @@
       Start: (int64) 1636820292515487000,
       Duration: (int64) 7799031,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=11) {
-       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+      Meta: (map[string]string) (len=10) {
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=9) "aws.agent": (string) (len=8) "botocore",
        (string) (len=13) "aws.operation": (string) (len=9) "PutRecord",
@@ -224,8 +218,7 @@
       Start: (int64) 1636820292523388000,
       Duration: (int64) 13733007,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=9) {
-       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+      Meta: (map[string]string) (len=8) {
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=9) "aws.agent": (string) (len=8) "botocore",
        (string) (len=13) "aws.operation": (string) (len=9) "PutEvents",
@@ -252,8 +245,7 @@
       Start: (int64) 1636820292538263000,
       Duration: (int64) 38689743,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=10) {
-       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+      Meta: (map[string]string) (len=9) {
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=9) "aws.agent": (string) (len=8) "botocore",
        (string) (len=13) "aws.operation": (string) (len=9) "PutObject",
@@ -281,8 +273,7 @@
       Start: (int64) 1636820292579315000,
       Duration: (int64) 20111883,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=10) {
-       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+      Meta: (map[string]string) (len=9) {
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=9) "aws.agent": (string) (len=8) "botocore",
        (string) (len=13) "aws.operation": (string) (len=6) "Invoke",
@@ -315,8 +306,7 @@
     Start: (int64) 1636820292450000100,
     Duration: (int64) 149992638,
     Error: (int32) 0,
-    Meta: (map[string]string) (len=12) {
-     (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+    Meta: (map[string]string) (len=11) {
      (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
      (string) (len=27) "_inferred_span.syncronicity": (string) (len=4) "sync",
      (string) (len=25) "_inferred_span.tag_source": (string) (len=4) "self",
@@ -358,8 +348,7 @@
     Start: (int64) 1636820292466458000,
     Duration: (int64) 133507715,
     Error: (int32) 0,
-    Meta: (map[string]string) (len=18) {
-     (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+    Meta: (map[string]string) (len=17) {
      (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
      (string) (len=10) "cold_start": (string) (len=5) "false",
      (string) (len=14) "datadog_lambda": (string) (len=6) "3.49.0",
@@ -403,8 +392,7 @@
     Start: (int64) 1636820292466887200,
     Duration: (int64) 19825652,
     Error: (int32) 0,
-    Meta: (map[string]string) (len=11) {
-     (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+    Meta: (map[string]string) (len=10) {
      (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
      (string) (len=9) "aws.agent": (string) (len=8) "botocore",
      (string) (len=13) "aws.operation": (string) (len=11) "SendMessage",
@@ -433,8 +421,7 @@
     Start: (int64) 1636820292487212000,
     Duration: (int64) 21565856,
     Error: (int32) 0,
-    Meta: (map[string]string) (len=12) {
-     (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+    Meta: (map[string]string) (len=11) {
      (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
      (string) (len=9) "aws.agent": (string) (len=8) "botocore",
      (string) (len=13) "aws.operation": (string) (len=7) "Publish",
@@ -464,8 +451,7 @@
     Start: (int64) 1636820292508904400,
     Duration: (int64) 6481144,
     Error: (int32) 0,
-    Meta: (map[string]string) (len=10) {
-     (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+    Meta: (map[string]string) (len=9) {
      (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
      (string) (len=9) "aws.agent": (string) (len=8) "botocore",
      (string) (len=13) "aws.operation": (string) (len=7) "PutItem",
@@ -493,8 +479,7 @@
     Start: (int64) 1636820292515487000,
     Duration: (int64) 7799031,
     Error: (int32) 0,
-    Meta: (map[string]string) (len=11) {
-     (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+    Meta: (map[string]string) (len=10) {
      (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
      (string) (len=9) "aws.agent": (string) (len=8) "botocore",
      (string) (len=13) "aws.operation": (string) (len=9) "PutRecord",
@@ -523,8 +508,7 @@
     Start: (int64) 1636820292523388000,
     Duration: (int64) 13733007,
     Error: (int32) 0,
-    Meta: (map[string]string) (len=9) {
-     (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+    Meta: (map[string]string) (len=8) {
      (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
      (string) (len=9) "aws.agent": (string) (len=8) "botocore",
      (string) (len=13) "aws.operation": (string) (len=9) "PutEvents",
@@ -551,8 +535,7 @@
     Start: (int64) 1636820292538263000,
     Duration: (int64) 38689743,
     Error: (int32) 0,
-    Meta: (map[string]string) (len=10) {
-     (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+    Meta: (map[string]string) (len=9) {
      (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
      (string) (len=9) "aws.agent": (string) (len=8) "botocore",
      (string) (len=13) "aws.operation": (string) (len=9) "PutObject",

--- a/aws/logs_monitoring/trace_forwarder/internal/apm/testdata/service_rename.json~snapshot
+++ b/aws/logs_monitoring/trace_forwarder/internal/apm/testdata/service_rename.json~snapshot
@@ -16,8 +16,7 @@
       Start: (int64) 1586269721581541000,
       Duration: (int64) 555729248,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=5) {
-       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+      Meta: (map[string]string) (len=4) {
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=8) "language": (string) (len=10) "javascript",
        (string) (len=2) "my": (string) (len=5) "value",
@@ -39,8 +38,7 @@
       Start: (int64) 1586269722137387000,
       Duration: (int64) 11963,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=5) {
-       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+      Meta: (map[string]string) (len=4) {
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=8) "language": (string) (len=10) "javascript",
        (string) (len=2) "my": (string) (len=5) "value",
@@ -62,8 +60,7 @@
       Start: (int64) 1586269722137368600,
       Duration: (int64) 32959,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=5) {
-       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+      Meta: (map[string]string) (len=4) {
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=8) "language": (string) (len=10) "javascript",
        (string) (len=2) "my": (string) (len=5) "value",
@@ -85,8 +82,7 @@
       Start: (int64) 1586269722137421600,
       Duration: (int64) 9033,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=5) {
-       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+      Meta: (map[string]string) (len=4) {
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=8) "language": (string) (len=10) "javascript",
        (string) (len=2) "my": (string) (len=5) "value",
@@ -108,8 +104,7 @@
       Start: (int64) 1586269722137407200,
       Duration: (int64) 25391,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=5) {
-       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+      Meta: (map[string]string) (len=4) {
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=8) "language": (string) (len=10) "javascript",
        (string) (len=2) "my": (string) (len=5) "value",
@@ -131,8 +126,7 @@
       Start: (int64) 1586269722137314000,
       Duration: (int64) 120117,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=4) {
-       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+      Meta: (map[string]string) (len=3) {
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=8) "language": (string) (len=10) "javascript",
        (string) (len=2) "my": (string) (len=5) "value"
@@ -153,8 +147,7 @@
       Start: (int64) 1586269721581080000,
       Duration: (int64) 556922119,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=6) {
-       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+      Meta: (map[string]string) (len=5) {
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=11) "dns.address": (string) (len=13) "172.217.9.196",
        (string) (len=12) "dns.hostname": (string) (len=14) "www.google.com",
@@ -178,8 +171,7 @@
       Start: (int64) 1586269721580981500,
       Duration: (int64) 613575195,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=8) {
-       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+      Meta: (map[string]string) (len=7) {
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=2) "my": (string) (len=5) "value",
        (string) (len=8) "out.host": (string) (len=14) "www.google.com",
@@ -211,8 +203,7 @@
       Start: (int64) 1586269721580333800,
       Duration: (int64) 654928711,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=7) {
-       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+      Meta: (map[string]string) (len=6) {
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=11) "http.method": (string) (len=3) "GET",
        (string) (len=16) "http.status_code": (string) (len=3) "200",
@@ -242,8 +233,7 @@
       Start: (int64) 1586269721580143000,
       Duration: (int64) 674647949,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=8) {
-       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+      Meta: (map[string]string) (len=7) {
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=10) "cold_start": (string) (len=5) "false",
        (string) (len=12) "function_arn": (string) (len=74) "arn:aws:lambda:us-east-1:172597598159:function:hello-dog-node-dev-hello10x",
@@ -281,8 +271,7 @@
     Start: (int64) 1586269721581080000,
     Duration: (int64) 556922119,
     Error: (int32) 0,
-    Meta: (map[string]string) (len=6) {
-     (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+    Meta: (map[string]string) (len=5) {
      (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
      (string) (len=11) "dns.address": (string) (len=13) "172.217.9.196",
      (string) (len=12) "dns.hostname": (string) (len=14) "www.google.com",
@@ -306,8 +295,7 @@
     Start: (int64) 1586269721580981500,
     Duration: (int64) 613575195,
     Error: (int32) 0,
-    Meta: (map[string]string) (len=8) {
-     (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+    Meta: (map[string]string) (len=7) {
      (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
      (string) (len=2) "my": (string) (len=5) "value",
      (string) (len=8) "out.host": (string) (len=14) "www.google.com",
@@ -339,8 +327,7 @@
     Start: (int64) 1586269721580333800,
     Duration: (int64) 654928711,
     Error: (int32) 0,
-    Meta: (map[string]string) (len=7) {
-     (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+    Meta: (map[string]string) (len=6) {
      (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
      (string) (len=11) "http.method": (string) (len=3) "GET",
      (string) (len=16) "http.status_code": (string) (len=3) "200",
@@ -370,8 +357,7 @@
     Start: (int64) 1586269721580143000,
     Duration: (int64) 674647949,
     Error: (int32) 0,
-    Meta: (map[string]string) (len=8) {
-     (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+    Meta: (map[string]string) (len=7) {
      (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
      (string) (len=10) "cold_start": (string) (len=5) "false",
      (string) (len=12) "function_arn": (string) (len=74) "arn:aws:lambda:us-east-1:172597598159:function:hello-dog-node-dev-hello10x",

--- a/aws/logs_monitoring/trace_forwarder/internal/apm/testdata/xray_reparent.json~snapshot
+++ b/aws/logs_monitoring/trace_forwarder/internal/apm/testdata/xray_reparent.json~snapshot
@@ -16,8 +16,7 @@
       Start: (int64) 1586269922945357000,
       Duration: (int64) 138997000,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=5) {
-       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+      Meta: (map[string]string) (len=4) {
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=11) "http.method": (string) (len=3) "GET",
        (string) (len=16) "http.status_code": (string) (len=3) "200",
@@ -39,8 +38,7 @@
       Start: (int64) 1586269923086220000,
       Duration: (int64) 100232000,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=2) {
-       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+      Meta: (map[string]string) (len=1) {
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda"
       },
       Metrics: (map[string]float64) (len=1) {
@@ -64,8 +62,7 @@
     Start: (int64) 1586269922945357000,
     Duration: (int64) 138997000,
     Error: (int32) 0,
-    Meta: (map[string]string) (len=5) {
-     (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+    Meta: (map[string]string) (len=4) {
      (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
      (string) (len=11) "http.method": (string) (len=3) "GET",
      (string) (len=16) "http.status_code": (string) (len=3) "200",
@@ -87,8 +84,7 @@
     Start: (int64) 1586269923086220000,
     Duration: (int64) 100232000,
     Error: (int32) 0,
-    Meta: (map[string]string) (len=2) {
-     (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
+    Meta: (map[string]string) (len=1) {
      (string) (len=10) "_dd.origin": (string) (len=6) "lambda"
     },
     Metrics: (map[string]float64) (len=1) {


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
Due to issues with client side stats computations, we switched to server-side stats computations was made historically. Since those issues are resolved, we can switch back to client-side stats computations.

### Motivation

<!--- What inspired you to submit this pull request? --->
https://datadoghq.atlassian.net/browse/SLS-2196

### Testing Guidelines

<!--- How did you test this pull request? --->
- Unit tests
- Integration tests

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [x] This PR passes the installation tests (ask a Datadog member to run the tests)
