### PR TITLE
[aws-log-forwarder] update python version

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -105,7 +105,7 @@ resource "aws_cloudformation_stack" "datadog_forwarder" {
 
 If you can't install the Forwarder using the provided CloudFormation template, you can install the Forwarder manually following the steps below. Feel free to open an issue or pull request to let us know if there is anything we can improve to make the template work for you.
 
-1. Create a Python 3.7 Lambda function using `aws-dd-forwarder-<VERSION>.zip` from the latest [releases](https://github.com/DataDog/datadog-serverless-functions/releases).
+1. Create a Python 3.8 Lambda function using `aws-dd-forwarder-<VERSION>.zip` from the latest [releases](https://github.com/DataDog/datadog-serverless-functions/releases).
 2. Save your [Datadog API key](https://app.datadoghq.com/organization-settings/api-keys) in AWS Secrets Manager, set environment variable `DD_API_KEY_SECRET_ARN` with the secret ARN on the Lambda function, and add the `secretsmanager:GetSecretValue` permission to the Lambda execution role.
 3. If you need to forward logs from S3 buckets, add the `s3:GetObject` permission to the Lambda execution role.
 4. Set the environment variable `DD_ENHANCED_METRICS` to `false` on the Forwarder. This stops the Forwarder from generating enhanced metrics itself, but it will still forward custom metrics from other lambdas.

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -457,7 +457,7 @@ Resources:
 
       MemorySize:
         Ref: MemorySize
-      Runtime: python3.7
+      Runtime: python3.8
       Timeout:
         Ref: Timeout
       Tags:
@@ -839,7 +839,7 @@ Resources:
     Properties:
       Description: Copies Datadog Forwarder zip to the destination S3 bucket
       Handler: index.handler
-      Runtime: python3.7
+      Runtime: python3.8
       Timeout: 300
       Code:
         ZipFile: |

--- a/aws/logs_monitoring/tools/add_new_region.sh
+++ b/aws/logs_monitoring/tools/add_new_region.sh
@@ -12,7 +12,7 @@ set -e
 
 OLD_REGION='us-east-1'
 
-PYTHON_VERSIONS_FOR_AWS_CLI=("python3.7")
+PYTHON_VERSIONS_FOR_AWS_CLI=("python3.8")
 LAYER_NAMES=("Datadog-Forwarder")
 NEW_REGION=$1
 

--- a/aws/logs_monitoring/tools/build_bundle.sh
+++ b/aws/logs_monitoring/tools/build_bundle.sh
@@ -22,7 +22,7 @@ else
     VERSION=$1
 fi
 
-PYTHON_VERSION="${PYTHON_VERSION:-3.7}"
+PYTHON_VERSION="${PYTHON_VERSION:-3.8}"
 FORWARDER_PREFIX="aws-dd-forwarder"
 FORWARDER_DIR="../.forwarder"
 

--- a/aws/logs_monitoring/tools/integration_tests/cache_test_lambda/serverless.yml
+++ b/aws/logs_monitoring/tools/integration_tests/cache_test_lambda/serverless.yml
@@ -1,7 +1,7 @@
 service: integration-tests
 provider:
   name: aws
-  runtime: python3.7
+  runtime: python3.8
 
 functions:
   cache_test_lambda:

--- a/aws/logs_monitoring/tools/integration_tests/docker-compose.yml
+++ b/aws/logs_monitoring/tools/integration_tests/docker-compose.yml
@@ -1,8 +1,8 @@
-version: "3.7"
+version: "3.8"
 
 services:
   forwarder:
-    image: datadog-log-forwarder:${PYTHON_RUNTIME:-python3.7}
+    image: datadog-log-forwarder:${PYTHON_RUNTIME:-python3.8}
     command: lambda_function.lambda_handler
     environment:
       AWS_ACCOUNT_ID: ${AWS_ACCOUNT_ID:-0000000000}

--- a/aws/logs_monitoring/tools/integration_tests/integration_tests.sh
+++ b/aws/logs_monitoring/tools/integration_tests/integration_tests.sh
@@ -7,7 +7,7 @@
 
 set -e
 
-PYTHON_VERSION="python3.7"
+PYTHON_VERSION="python3.8"
 SKIP_FORWARDER_BUILD=false
 UPDATE_SNAPSHOTS=false
 LOG_LEVEL=info

--- a/aws/logs_monitoring/tools/publish_layers.sh
+++ b/aws/logs_monitoring/tools/publish_layers.sh
@@ -13,7 +13,7 @@ set -e
 # Makes sure any subprocesses will be terminated with this process
 trap "pkill -P $$; exit 1;" INT
 
-PYTHON_VERSIONS_FOR_AWS_CLI=("python3.7")
+PYTHON_VERSIONS_FOR_AWS_CLI=("python3.8")
 LAYER_PATHS=(".forwarder/aws-dd-forwarder-${FORWARDER_VERSION}-layer.zip")
 AVAILABLE_LAYERS=("Datadog-Forwarder")
 AVAILABLE_REGIONS=$(aws ec2 describe-regions | jq -r '.[] | .[] | .RegionName')


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Updates the datadog forwarder lambda layer to python version 3.8, and updates the datadog forwarder lambda to use 3.8 as well.

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
Updates via the cloudformation template will succeed as the new layer version will only work with 3.8 and the cf template will update the function to version 3.8. Tested by bundling up the new lambda layer and using it with a lambda using python 3.8. Worked as expected.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
