### PR TITLE
[AZI-866] Make Parent template and all its linked templates independent of powershell script

### DIFF
--- a/azure/deploy-to-azure/activity_log_diagnostic_settings.json
+++ b/azure/deploy-to-azure/activity_log_diagnostic_settings.json
@@ -1,0 +1,81 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "settingName": {
+            "type": "string",
+            "defaultValue": "datadog-activity-logs-diagnostic-setting",
+            "metadata": {
+                "description": "The name of the diagnostic setting"
+            }
+        },
+        "resourceGroup": {
+            "type": "string",
+            "metadata": {
+                "description": "Name of the Resource Group of the EventHub"
+            }
+        },
+        "eventHubNamespace": {
+            "type": "string",
+            "metadata": {
+                "description": "Name of EventHub namespace, which must be globally unique."
+            }
+        },
+        "eventHubName": {
+            "type": "string",
+            "defaultValue": "datadog-eventhub",
+            "metadata": {
+                "description": "Name of the EventHub to which the Activity logs will be sent."
+            }
+        }
+    },
+    "variables": {
+        "subscriptionId": "[subscription().subscriptionId]",
+        "eventHubAuthorizationRuleId": "[concat('/subscriptions/', variables('subscriptionId'), '/resourceGroups/', parameters('resourceGroup'), '/providers/Microsoft.EventHub/namespaces/', parameters('eventHubNamespace'), '/authorizationRules/RootManageSharedAccessKey')]"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Insights/diagnosticSettings",
+            "apiVersion": "2017-05-01-preview",
+            "name": "[parameters('settingName')]",
+            "properties": {
+                "eventHubAuthorizationRuleId": "[variables('eventHubAuthorizationRuleId')]",
+                "eventHubName": "[parameters('eventHubName')]",
+                "logs": [
+                    {
+                        "category": "Administrative",
+                        "enabled": true
+                    },
+                    {
+                        "category": "Security",
+                        "enabled": true
+                    },
+                    {
+                        "category": "ServiceHealth",
+                        "enabled": true
+                    },
+                    {
+                        "category": "Alert",
+                        "enabled": true
+                    },
+                    {
+                        "category": "Recommendation",
+                        "enabled": true
+                    },
+                    {
+                        "category": "Policy",
+                        "enabled": true
+                    },
+                    {
+                        "category": "Autoscale",
+                        "enabled": true
+                    },
+                    {
+                        "category": "ResourceHealth",
+                        "enabled": true
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/azure/deploy-to-azure/event_hub.json
+++ b/azure/deploy-to-azure/event_hub.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "eventHubNamespace": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of EventHub namespace"
+      }
+    },
+    "eventHubName": {
+      "type": "string",
+      "defaultValue": "datadog-eventhub",
+      "metadata": {
+        "description": "Name of Event Hub"
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location for all resources."
+      }
+    }
+  },
+  "resources": [
+    {
+      "apiVersion": "2018-01-01-preview",
+      "name": "[parameters('eventHubNamespace')]",
+      "type": "Microsoft.EventHub/namespaces",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard",
+        "tier": "Standard",
+        "capacity": 1
+      },
+      "tags": {},
+      "properties": {},
+      "resources": [
+        {
+          "apiVersion": "2017-04-01",
+          "name": "[parameters('eventHubName')]",
+          "type": "eventhubs",
+          "dependsOn": [
+            "[resourceId('Microsoft.EventHub/namespaces/', parameters('eventHubNamespace'))]"
+          ],
+          "properties": {}
+        }
+      ]
+    }
+  ]
+}

--- a/azure/deploy-to-azure/parent_template.json
+++ b/azure/deploy-to-azure/parent_template.json
@@ -30,12 +30,6 @@
         "description": "The name of the function."
       }
     },
-    "functionCode": {
-      "type": "string",
-      "metadata": {
-        "description": "Code for the function to run, saved into index.js"
-      }
-    },
     "apiKey": {
       "type": "string",
       "metadata": {
@@ -66,7 +60,7 @@
   },
   "variables": {
     "eventHubTemplateLink": "https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/master/azure/deploy-to-azure/event_hub.json",
-    "functionAppTemplateLink": "https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/master/azure/deploy-to-azure/function_template.json"
+    "functionAppTemplateLink": "https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/master/azure/function_template.json"
   },
   "resources": [
     {
@@ -114,9 +108,6 @@
           },
           "functionName": {
             "value": "[parameters('functionName')]"
-          },
-          "functionCode": {
-            "value": "[parameters('functionCode')]"
           },
           "apiKey": {
             "value": "[parameters('apiKey')]"

--- a/azure/deploy-to-azure/parent_template.json
+++ b/azure/deploy-to-azure/parent_template.json
@@ -1,0 +1,146 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "eventHubNamespace": {
+      "type": "string",
+      "defaultValue": "[concat('datadog-ns-', newGuid())]",
+      "metadata": {
+        "description": "Name of EventHub namespace, which must be globally unique."
+      }
+    },
+    "eventHubName": {
+      "type": "string",
+      "defaultValue": "datadog-eventhub",
+      "metadata": {
+        "description": "Name of Event Hub"
+      }
+    },
+    "functionAppName": {
+      "type": "string",
+      "defaultValue": "[concat('datadog-functionapp-', newGuid())]",
+      "metadata": {
+        "description": "The name of the function app "
+      }
+    },
+    "functionName": {
+      "type": "string",
+      "defaultValue": "datadog-function",
+      "metadata": {
+        "description": "The name of the function."
+      }
+    },
+    "functionCode": {
+      "type": "string",
+      "metadata": {
+        "description": "Code for the function to run, saved into index.js"
+      }
+    },
+    "apiKey": {
+      "type": "string",
+      "metadata": {
+        "description": "Datadog API key"
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Specify a location for the resources."
+      }
+    },
+    "datadogSite": {
+      "type": "string",
+      "defaultValue": "datadoghq.com",
+      "metadata": {
+        "description": "Datadog site to send logs"
+      }
+    },
+    "endpointSuffix": {
+      "type": "string",
+      "defaultValue": "core.windows.net",
+      "metadata": {
+        "description": "Endpoint suffix for storage account"
+      }
+    }
+  },
+  "variables": {
+    "eventHubTemplateLink": "https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/master/azure/deploy-to-azure/event_hub.json",
+    "functionAppTemplateLink": "https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/master/azure/deploy-to-azure/function_template.json"
+  },
+  "resources": [
+    {
+      "name": "eventHubTemplate",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2018-05-01",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('eventHubTemplateLink')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "eventHubNamespace": {
+            "value": "[parameters('eventHubNamespace')]"
+          },
+          "eventHubName": {
+            "value": "[parameters('eventHubName')]"
+          },
+          "location": {
+            "value": "[parameters('location')]"
+          }
+        }
+      }
+    },
+    {
+      "name": "functionAppTemplate",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2018-05-01",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('functionAppTemplateLink')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "eventHubNamespace": {
+            "value": "[parameters('eventHubNamespace')]"
+          },
+          "eventHubName": {
+            "value": "[parameters('eventHubName')]"
+          },
+          "functionAppName": {
+            "value": "[parameters('functionAppName')]"
+          },
+          "functionName": {
+            "value": "[parameters('functionName')]"
+          },
+          "functionCode": {
+            "value": "[parameters('functionCode')]"
+          },
+          "apiKey": {
+            "value": "[parameters('apiKey')]"
+          },
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "datadogSite": {
+            "value": "[parameters('datadogSite')]"
+          },
+          "endpointSuffix": {
+            "value": "[parameters('endpointSuffix')]"
+          }
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Resources/deployments','eventHubTemplate')]"
+      ]
+    }
+  ],
+    "outputs": {
+      "eventHubNamespace": {
+        "type": "string",
+        "value": "[parameters('eventHubNamespace')]"
+      }
+    }
+}

--- a/azure/deploy-to-azure/parent_template.json
+++ b/azure/deploy-to-azure/parent_template.json
@@ -31,7 +31,7 @@
       }
     },
     "apiKey": {
-      "type": "string",
+      "type": "securestring",
       "metadata": {
         "description": "Datadog API key"
       }
@@ -60,7 +60,7 @@
   },
   "variables": {
     "eventHubTemplateLink": "https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/master/azure/deploy-to-azure/event_hub.json",
-    "functionAppTemplateLink": "https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/master/azure/function_template.json"
+    "functionAppTemplateLink": "https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/master/azure/deploy-to-azure/function_template.json"
   },
   "resources": [
     {


### PR DESCRIPTION
### What does this PR do?

Make Parent template and all its linked templates independent of Powershell script.
Make API a `securestring` so it's not accessible in deployment history, and hidden as a password in the form.

### Motivation

AZI-866, AZI-864

### Testing Guidelines
Deployed the resources correctly, resulting from all linked templates with these parameters.

<img width="1436" alt="Screen Shot 2022-06-23 at 11 26 49 PM" src="https://user-images.githubusercontent.com/1248411/175585896-6760a1f1-fa0b-4717-a44a-268b6fd39ca6.png">


<img width="1440" alt="Screen Shot 2022-06-23 at 11 25 46 PM" src="https://user-images.githubusercontent.com/1248411/175584911-bdbfbb8c-4fd7-4f07-ac7d-6e90531e580f.png">

Edit: 
Added `securestring` API as part of this as it's a small change, the field now looks like this:
<img width="732" alt="image" src="https://user-images.githubusercontent.com/1248411/175755454-b44d40ad-dbe7-4a02-95a2-4574856e00bf.png">


### Additional Notes

N/A.

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [] This PR passes the installation tests (ask a Datadog member to run the tests)
