### PR TITLE
Fix link to aws_cloudformation_stack Terraform resource

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -48,7 +48,7 @@ Once installed, you can subscribe the Forwarder to log sources, such as S3 bucke
 
 ### Terraform
 
-Install the Forwarder using the Terraform resource [aws_cloudformation_stack](https://www.terraform.io/docs/providers/aws/r/cloudformation_stack.html) as a wrapper on top of the provided CloudFormation template.
+Install the Forwarder using the Terraform resource [aws_cloudformation_stack](https://www.terraform.io/docs/providers/aws/r/cloudformation_stack) as a wrapper on top of the provided CloudFormation template.
 
 Datadog recommends creating two separate Terraform configurations:
 


### PR DESCRIPTION
### What does this PR do?
Fixes the link to the `aws_cloudformation_stack` Terraform resource

### Motivation
[This link](https://www.terraform.io/docs/providers/aws/r/cloudformation_stack.html) leads the reader to a dead-end. Instead, [this link](https://www.terraform.io/docs/providers/aws/r/cloudformation_stack) should be used.