### PR TITLE
[AZI-868] Conditionally deploy Activity Logs template with diagnostic settings

### DIFF
--- a/azure/deploy-to-azure/parent_template.json
+++ b/azure/deploy-to-azure/parent_template.json
@@ -9,18 +9,18 @@
         "description": "Datadog site to send logs"
       }
     },
+    "sendActivityLogs": {
+      "type": "bool",
+      "metadata": {
+        "description": "Enable Activity Logs forwarding and create subscription diagnostic settings"
+      },
+      "defaultValue": false
+    },
     "apiKey": {
       "type": "securestring",
       "metadata": {
         "description": "Datadog API key"
       }
-    },
-    "sendActivityLogs": {
-      "type": "bool",
-      "metadata": {
-        "description": "Enable Activity Logs forwarding"
-      },
-      "defaultValue": false
     },
     "eventHubNamespace": {
       "type": "string",

--- a/azure/deploy-to-azure/parent_template.json
+++ b/azure/deploy-to-azure/parent_template.json
@@ -2,6 +2,26 @@
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "datadogSite": {
+      "type": "string",
+      "defaultValue": "datadoghq.com",
+      "metadata": {
+        "description": "Datadog site to send logs"
+      }
+    },
+    "apiKey": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Datadog API key"
+      }
+    },
+    "sendActivityLogs": {
+      "type": "bool",
+      "metadata": {
+        "description": "Enable Activity Logs forwarding"
+      },
+      "defaultValue": false
+    },
     "eventHubNamespace": {
       "type": "string",
       "defaultValue": "[concat('datadog-ns-', newGuid())]",
@@ -30,37 +50,32 @@
         "description": "The name of the function."
       }
     },
-    "apiKey": {
-      "type": "securestring",
-      "metadata": {
-        "description": "Datadog API key"
-      }
-    },
-    "location": {
+    "resourcesLocation": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
-        "description": "Specify a location for the resources."
+        "description": "Specify a location for the Azure resources."
       }
     },
-    "datadogSite": {
+    "storageEndpointSuffix": {
       "type": "string",
-      "defaultValue": "datadoghq.com",
-      "metadata": {
-        "description": "Datadog site to send logs"
-      }
-    },
-    "endpointSuffix": {
-      "type": "string",
-      "defaultValue": "core.windows.net",
+      "defaultValue": "[environment().suffixes.storage]",
       "metadata": {
         "description": "Endpoint suffix for storage account"
       }
+    },
+    "diagnosticSettingName": {
+        "type": "string",
+        "defaultValue": "datadog-activity-logs-diagnostic-setting",
+        "metadata": {
+            "description": "The name of the diagnostic setting if sending Activity Logs"
+        }
     }
   },
   "variables": {
     "eventHubTemplateLink": "https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/master/azure/deploy-to-azure/event_hub.json",
-    "functionAppTemplateLink": "https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/master/azure/deploy-to-azure/function_template.json"
+    "functionAppTemplateLink": "https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/master/azure/deploy-to-azure/function_template.json",
+    "activityLogDiagnosticSettingsTemplateLink": "https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/master/azure/deploy-to-azure/activity_log_diagnostic_settings.json"
   },
   "resources": [
     {
@@ -81,7 +96,7 @@
             "value": "[parameters('eventHubName')]"
           },
           "location": {
-            "value": "[parameters('location')]"
+            "value": "[parameters('resourcesLocation')]"
           }
         }
       }
@@ -113,19 +128,51 @@
             "value": "[parameters('apiKey')]"
           },
           "location": {
-            "value": "[parameters('location')]"
+            "value": "[parameters('resourcesLocation')]"
           },
           "datadogSite": {
             "value": "[parameters('datadogSite')]"
           },
           "endpointSuffix": {
-            "value": "[parameters('endpointSuffix')]"
+            "value": "[parameters('storageEndpointSuffix')]"
           }
         }
       },
       "dependsOn": [
         "[resourceId('Microsoft.Resources/deployments','eventHubTemplate')]"
       ]
+    },
+    {
+      "condition": "[parameters('sendActivityLogs')]",
+      "type": "Microsoft.Resources/deployments",
+      "name": "activityLogDiagnosticSettingsTemplate",
+      "apiVersion": "2018-05-01",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('activityLogDiagnosticSettingsTemplateLink')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "settingName": {
+            "value": "[parameters('diagnosticSettingName')]"
+          },
+          "resourceGroup": {
+            "value": "[resourceGroup().name]"
+          },
+          "eventHubNamespace": {
+            "value": "[parameters('eventHubNamespace')]"
+          },
+          "eventHubName": {
+            "value": "[parameters('eventHubName')]"
+          }
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Resources/deployments','functionAppTemplate')]"
+      ],
+      "subscriptionId": "[subscription().subscriptionId]",
+      "location": "[parameters('resourcesLocation')]"
     }
   ],
     "outputs": {


### PR DESCRIPTION
### What does this PR do?

Renamed some existing parameters for clarity.
Deploy diagnostic settings template if the user selects it from drop-down (or sends true via command-line).

<img width="856" alt="image" src="https://user-images.githubusercontent.com/1248411/177073814-cd409266-677e-4bfd-9381-c06c6d07ee56.png">


### Motivation

AZI-868

### Testing Guidelines

Deployed the full template and watched logs flow in ([in ricky-test org](https://ricky-test.datadoghq.com/logs?from_ts=1656811347221&index=&live=false&query=service%3Aazure&to_ts=1656825001680)).

<img width="1121" alt="image" src="https://user-images.githubusercontent.com/1248411/177025886-c82250e6-0f98-427a-8c4f-16ce4bf53087.png">



Diagnostic settings were successfully created on Azure:
```
islam@Azure:~$ az monitor diagnostic-settings subscription show --name datadog-activity-logs-diagnostic-setting
{
  "eventHubAuthorizationRuleId": "/subscriptions/[my-subscription-id]/resourceGroups/io-deleteme-no-diag-location/providers/Microsoft.EventHub/namespaces/datadog-ns-[id]/authorizationRules/RootManageSharedAccessKey",
  "eventHubName": "datadog-eventhub",
  "id": "subscriptions/[my-subscription-id]/providers/microsoft.insights/diagnosticSettings/datadog-activity-logs-diagnostic-setting",
  "location": "global",
  "logs": [
    {
      "category": "Administrative",
      "categoryGroup": null,
      "enabled": true
    },
    {
      "category": "Security",
      "categoryGroup": null,
      "enabled": true
    },
    {
      "category": "ServiceHealth",
      "categoryGroup": null,
      "enabled": true
    },
    {
      "category": "Alert",
      "categoryGroup": null,
      "enabled": true
    },
    {
      "category": "Recommendation",
      "categoryGroup": null,
      "enabled": true
    },
    {
      "category": "Policy",
      "categoryGroup": null,
      "enabled": true
    },
    {
      "category": "Autoscale",
      "categoryGroup": null,
      "enabled": true
    },
    {
      "category": "ResourceHealth",
      "categoryGroup": null,
      "enabled": true
    }
  ],
  "name": "datadog-activity-logs-diagnostic-setting",
  "serviceBusRuleId": null,
  "storageAccountId": null,
  "type": "Microsoft.Insights/diagnosticSettings",
  "workspaceId": null
}
```

Also tested deactivating my eventhub and re-activating it to make sure the logs are flowing only through it.

### Additional Notes

Resource group and the test diagnostic setting have been cleaned-up.

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
