### PR TITLE
Changed type to secureString for apiKey parameter

### DIFF
--- a/azure/eventhub_log_forwarder/activity_logs_deploy.ps1
+++ b/azure/eventhub_log_forwarder/activity_logs_deploy.ps1
@@ -22,12 +22,13 @@ New-AzResourceGroup -Name $ResourceGroupName -Location $ResourceGroupLocation
 
 $environment = Get-AzEnvironment -Name $Environment
 $endpointSuffix = $environment.StorageEndpointSuffix
+$secureApiKey = ConvertTo-SecureString $ApiKey -AsPlainText -Force
 
 $deploymentArgs = @{
     TemplateUri = "https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/master/azure/eventhub_log_forwarder/parent_template.json"
     ResourceGroupName = $ResourceGroupName
     functionCode = $code
-    apiKey = $ApiKey
+    apiKey = $secureApiKey
     location = $ResourceGroupLocation
     eventHubName = $EventhubName
     functionName = $FunctionName

--- a/azure/eventhub_log_forwarder/function_template.json
+++ b/azure/eventhub_log_forwarder/function_template.json
@@ -36,7 +36,7 @@
       }
     },
     "apiKey": {
-      "type": "string",
+      "type": "secureString",
       "metadata": {
         "description": "Datadog API key"
       }

--- a/azure/eventhub_log_forwarder/parent_template.json
+++ b/azure/eventhub_log_forwarder/parent_template.json
@@ -37,7 +37,7 @@
       }
     },
     "apiKey": {
-      "type": "string",
+      "type": "secureString",
       "metadata": {
         "description": "Datadog API key"
       }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Change type for `apiKey` parameter from `string` to `secureString`.

### Motivation

Avoid exposure of Api Key.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/parameters#secure-parameters

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)

![image](https://user-images.githubusercontent.com/5943484/177827347-1d6d1b70-c000-4faf-8972-575c9f107128.png)

![image](https://user-images.githubusercontent.com/5943484/177827225-e93b0b67-9e31-4a31-ba15-4f7b70544662.png)
