### PR TITLE
Use securestring in resource_deploy script also

### DIFF
--- a/azure/deploy-to-azure/function_template.json
+++ b/azure/deploy-to-azure/function_template.json
@@ -30,7 +30,7 @@
       }
     },
     "apiKey": {
-      "type": "string",
+      "type": "securestring",
       "metadata": {
         "description": "Datadog API key"
       }

--- a/azure/eventhub_log_forwarder/function_template.json
+++ b/azure/eventhub_log_forwarder/function_template.json
@@ -36,7 +36,7 @@
       }
     },
     "apiKey": {
-      "type": "secureString",
+      "type": "securestring",
       "metadata": {
         "description": "Datadog API key"
       }

--- a/azure/eventhub_log_forwarder/parent_template.json
+++ b/azure/eventhub_log_forwarder/parent_template.json
@@ -37,7 +37,7 @@
       }
     },
     "apiKey": {
-      "type": "secureString",
+      "type": "securestring",
       "metadata": {
         "description": "Datadog API key"
       }

--- a/azure/eventhub_log_forwarder/resource_deploy.ps1
+++ b/azure/eventhub_log_forwarder/resource_deploy.ps1
@@ -21,12 +21,13 @@ New-AzResourceGroup -Name $ResourceGroupName -Location $ResourceGroupLocation
 
 $environment = Get-AzEnvironment -Name $Environment
 $endpointSuffix = $environment.StorageEndpointSuffix
+$secureApiKey = ConvertTo-SecureString $ApiKey -AsPlainText -Force
 
 $deploymentArgs = @{
     TemplateUri = "https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/master/azure/eventhub_log_forwarder/parent_template.json"
     ResourceGroupName = $ResourceGroupName
     functionCode = $code
-    apiKey = $ApiKey
+    apiKey = $secureApiKey
     location = $ResourceGroupLocation
     eventHubName = $EventhubName
     functionName = $FunctionName


### PR DESCRIPTION
### What does this PR do?
Change type for `apiKey` parameter from `string` to `securestring` for resoure_deploy too.
Official docs use all lowercase securestring for the type, so I changed them to match.

Ref https://github.com/DataDog/datadog-serverless-functions/pull/581



### Motivation

Avoid exposure of Api Key.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/data-types#secure-strings-and-objects

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
