### PR TITLE
Add handling for transit-gateway flow logs from cloudwatch + s3 logs

### DIFF
--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -313,6 +313,7 @@ def find_cloudwatch_source(log_group):
         "cloudtrail",
         "msk",
         "elasticsearch",
+        "transitgateway",
     ]:
         if source in log_group:
             return source
@@ -461,6 +462,8 @@ def awslogs_handler(event, context, metadata):
     # i.e. 123456779121_CloudTrail_us-east-1
     if "_CloudTrail_" in logs["logStream"]:
         source = "cloudtrail"
+    if "tgw-attach" in logs["logStream"]:
+        source = "transitgateway"
     metadata[DD_SOURCE] = parse_event_source(event, source)
 
     metadata[DD_SERVICE] = get_service_from_tags(metadata)

--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -171,7 +171,6 @@ def s3_handler(event, context, metadata):
 
     # Get the object from the event and show its content type
     bucket = event["Records"][0]["s3"]["bucket"]["name"]
-    logger.debug(f"Bucket: {bucket}")
     key = urllib.parse.unquote_plus(event["Records"][0]["s3"]["object"]["key"])
 
     source = parse_event_source(event, key)

--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -174,7 +174,7 @@ def s3_handler(event, context, metadata):
     key = urllib.parse.unquote_plus(event["Records"][0]["s3"]["object"]["key"])
 
     source = parse_event_source(event, key)
-    if bucket.startswith("tg-s3"):
+    if "transit-gateway" in bucket:
         source = "transitgateway"
     metadata[DD_SOURCE] = source
 

--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -171,9 +171,12 @@ def s3_handler(event, context, metadata):
 
     # Get the object from the event and show its content type
     bucket = event["Records"][0]["s3"]["bucket"]["name"]
+    logger.debug(f"Bucket: {bucket}")
     key = urllib.parse.unquote_plus(event["Records"][0]["s3"]["object"]["key"])
 
     source = parse_event_source(event, key)
+    if bucket.startswith("tg-s3"):
+        source = "transitgateway"
     metadata[DD_SOURCE] = source
 
     metadata[DD_SERVICE] = get_service_from_tags(metadata)


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Add handling for transit-gateway flow logs from cloudwatch + s3 logs

Cloudwatch logs are prefixed with `tgw-attach` by default but s3 buckets need to be named with `transit-gateway` for the source to be set correctly

Sample log stream : `tgw-attach-*`

### Testing Guidelines

Tested with sample logs

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
