### PR TITLE
[AZI-62] Make partition count configurable in log forwarder automation

### DIFF
--- a/azure/deploy-to-azure/event_hub.json
+++ b/azure/deploy-to-azure/event_hub.json
@@ -15,6 +15,13 @@
         "description": "Name of Event Hub"
       }
     },
+    "partitionCount": {
+      "type": "int",
+      "defaultValue": 32,
+      "metadata": {
+        "description": "The number of event hub partitions"
+      }
+    },
     "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
@@ -44,7 +51,9 @@
           "dependsOn": [
             "[resourceId('Microsoft.EventHub/namespaces/', parameters('eventHubNamespace'))]"
           ],
-          "properties": {}
+          "properties": {
+            "partitionCount": "[parameters('partitionCount')]"
+          }
         }
       ]
     }

--- a/azure/deploy-to-azure/parent_template.json
+++ b/azure/deploy-to-azure/parent_template.json
@@ -36,6 +36,13 @@
         "description": "Name of Event Hub"
       }
     },
+    "partitionCount": {
+      "type": "int",
+      "defaultValue": 32,
+      "metadata": {
+        "description": "The number of event hub partitions"
+      }
+    },
     "functionAppName": {
       "type": "string",
       "defaultValue": "[concat('datadog-functionapp-', newGuid())]",
@@ -94,6 +101,9 @@
           },
           "eventHubName": {
             "value": "[parameters('eventHubName')]"
+          },
+          "partitionCount": {
+            "value": "[parameters('partitionCount')]"
           },
           "location": {
             "value": "[parameters('resourcesLocation')]"


### PR DESCRIPTION
### What does this PR do?
Make partition count configurable in log forwarder automation. 
Useful for adding more control to scaling the event hub as needed.

### Motivation
AZI-62

### Testing Guidelines

I deployed the parent template, with Event Hub partitionCount set to 28, and I could see it deployed correctly:
![image](https://user-images.githubusercontent.com/1248411/179836943-9c6777e3-f0c1-4a16-bf63-12d40a317862.png)
![image](https://user-images.githubusercontent.com/1248411/179836953-02451c1d-7535-46d2-9a5b-bdf6b2b77123.png)

### Additional Notes
Docs:
https://docs.microsoft.com/en-us/azure/templates/microsoft.eventhub/namespaces/eventhubs?tabs=json

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
