### PR TITLE
customize role name in log forwarder CFN template

### DIFF
--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -197,6 +197,10 @@ Parameters:
     Type: Number
     Default: 20
     Description: Set the max number of workers sending logs concurrently.
+  ForwarderRoleNamePrefix:
+    Type: String
+    Default: ""
+    Description: Set the name of the execution role to be created for the lambda. Region will be added for global uniqueness.
   PermissionsBoundaryArn:
     Type: String
     Default: ""
@@ -376,6 +380,11 @@ Conditions:
     Fn::Not:
       - Fn::Equals:
           - Ref: PermissionsBoundaryArn
+          - ""
+  SetForwarderRoleName:
+    Fn::Not:
+      - Fn::Equals:
+          - Ref: ForwarderRoleNamePrefix
           - ""
   SetAdditionalTargetLambdas:
     Fn::Not:
@@ -629,6 +638,11 @@ Resources:
   ForwarderRole:
     Type: AWS::IAM::Role
     Properties:
+      RoleName:
+        Fn::If:
+          - SetForwarderRoleName
+          - !Sub "${ForwarderRoleNamePrefix}-${AWS::Region}"
+          - Ref: AWS::NoValue
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Allow users to specify the prefix for the AWS/IAM role the Cloudformation stack creates

### Motivation

In some regulated AWS environments, there are constraints on how resources can be named. That means the stack as it currently exists will fail because the auto-generated role name does not comply with these constraints. This change allows me to use the stack and comply with those constraints.

### Testing Guidelines

Ran it in my organization's environment and observed that the role could be created.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [x] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
