### PR TITLE
Prevent creating ForwarderBucket if it will not be used

### DIFF
--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -327,6 +327,10 @@ Conditions:
       - Fn::Equals:
           - Ref: DdFetchLambdaTags
           - true
+  CreateS3Bucket:
+    Fn::Or:
+      - Condition: CreateS3BucketForTags
+      - Condition: UseZipCopier
   SetDdUsePrivateLink:
     Fn::Equals:
       - Ref: DdUsePrivateLink
@@ -652,17 +656,20 @@ Resources:
             Version: "2012-10-17"
             Statement:
               # Access the s3 bucket that is used by the forwarder as a datastore
-              - Action:
-                  - s3:GetObject
-                  - s3:PutObject
-                  - s3:DeleteObject
-                  - s3:ListBucket
-                Resource:
-                  - Fn::Join:
-                      - "/"
-                      - - Fn::GetAtt: ForwarderBucket.Arn
-                        - "*"
-                Effect: Allow
+              - !If
+                - CreateS3Bucket
+                - Action:
+                    - s3:GetObject
+                    - s3:PutObject
+                    - s3:DeleteObject
+                    - s3:ListBucket
+                  Resource:
+                    - Fn::Join:
+                        - "/"
+                        - - Fn::GetAtt: ForwarderBucket.Arn
+                          - "*"
+                  Effect: Allow
+                - !Ref AWS::NoValue
               # Get the actual log content from the s3 bucket based on the received s3 event.
               # Use PermissionsBoundaryArn to limit (allow/deny) access if needed.
               - Action:
@@ -780,6 +787,7 @@ Resources:
   # A s3 bucket used by the Forwarder as a datastore
   ForwarderBucket:
     Type: AWS::S3::Bucket
+    Condition: CreateS3Bucket
     Properties:
       BucketName:
         Fn::If:
@@ -797,6 +805,7 @@ Resources:
         RestrictPublicBuckets: true
   ForwarderBucketPolicy:
     Type: "AWS::S3::BucketPolicy"
+    Condition: CreateS3Bucket
     Properties:
       Bucket: !Ref ForwarderBucket
       PolicyDocument:
@@ -983,6 +992,7 @@ Outputs:
         Fn::Sub: ${AWS::StackName}-ApiKeySecretArn
     Condition: CreateDdApiKeySecret
   ForwarderBucketName:
+    Condition: CreateS3Bucket
     Description: Name of the S3 bucket used by the Forwarder
     Value:
       Ref: ForwarderBucket


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Teach the Cloudformation template to avoid creating the "ForwarderBucket" resource if it won't be used.

### Motivation

My organization has strict controls on the creation of S3 buckets; I can't use this template unless there is a way to avoid creating one.

### Testing Guidelines

Ran it in my organization's AWS account and observed no errors.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
