### PR TITLE
[AZI-529] improve log forwarder retry behavior

### DIFF
--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -5,7 +5,7 @@
 
 var https = require('https');
 
-const VERSION = '0.5.6';
+const VERSION = '0.5.7';
 
 const STRING = 'string'; // example: 'some message'
 const STRING_ARRAY = 'string-array'; // example: ['one message', 'two message', ...]
@@ -28,6 +28,9 @@ const DD_TAGS = process.env.DD_TAGS || ''; // Replace '' by your comma-separated
 const DD_SERVICE = process.env.DD_SERVICE || 'azure';
 const DD_SOURCE = process.env.DD_SOURCE || 'azure';
 const DD_SOURCE_CATEGORY = process.env.DD_SOURCE_CATEGORY || 'azure';
+
+const MAX_RETRIES = 4; // max number of times to retry a single http request
+const RETRY_INTERVAL = 1000; // amount of time (milliseconds) to wait before retrying request, doubles after every retry
 
 /*
 To scrub PII from your logs, uncomment the applicable configs below. If you'd like to scrub more than just
@@ -155,52 +158,59 @@ class HTTPClient {
         var batches = this.batcher.batch(records);
         var promises = [];
         for (var i = 0; i < batches.length; i++) {
-            promises.push(this.sendWithRetry(batches[i]));
+            promises.push(this.send(batches[i]));
         }
         return await Promise.all(
             promises.map(p => p.catch(e => this.context.log.error(e)))
         );
     }
 
-    sendWithRetry(record) {
-        return new Promise((resolve, reject) => {
-            return this.send(record)
-                .then(res => {
-                    resolve(true);
-                })
-                .catch(err => {
-                    this.send(record)
-                        .then(res => {
-                            resolve(true);
-                        })
-                        .catch(err => {
-                            reject(
-                                `unable to send request after 2 tries, err: ${err}`
-                            );
-                        });
-                });
-        });
-    }
-
     send(record) {
         return new Promise((resolve, reject) => {
-            const req = https
-                .request(this.httpOptions, resp => {
-                    if (resp.statusCode < 200 || resp.statusCode > 299) {
-                        reject(`invalid status code ${resp.statusCode}`);
-                    } else {
-                        resolve(true);
+            var numRetries = MAX_RETRIES;
+            var retryInterval = RETRY_INTERVAL;
+            const httpRequest = (options, record) => {
+                const retryRequest = error => {
+                    if (numRetries === 0) {
+                        reject(error);
+                        return;
                     }
-                })
-                .on('error', error => {
-                    reject(error);
-                });
-            req.on('timeout', () => {
-                req.destroy();
-                reject(`request timed out after ${DD_REQUEST_TIMEOUT_MS}ms`);
-            })
-            req.write(this.scrubber.scrub(JSON.stringify(record)));
-            req.end();
+                    this.context.log.warn(
+                        `Unable to send request, with error ${error}. Retrying after ${retryInterval}ms with ${numRetries} retries remaining`
+                    );
+                    numRetries--;
+                    retryInterval *= 2;
+                    setTimeout(() => {
+                        httpRequest(options, record);
+                    }, retryInterval);
+                };
+                const req = https
+                    .request(options, resp => {
+                        if (resp.statusCode < 200 || resp.statusCode > 299) {
+                            retryRequest(
+                                new Error(
+                                    `invalid status code ${resp.statusCode}`
+                                )
+                            );
+                        } else {
+                            resolve(true);
+                        }
+                    })
+                    .on('error', error => {
+                        retryRequest(error);
+                    })
+                    .on('timeout', () => {
+                        req.destroy();
+                        retryRequest(
+                            new Error(
+                                `request timed out after ${DD_REQUEST_TIMEOUT_MS}ms`
+                            )
+                        );
+                    });
+                req.write(this.scrubber.scrub(JSON.stringify(record)));
+                req.end();
+            };
+            httpRequest(this.httpOptions, record);
         });
     }
 }
@@ -219,9 +229,7 @@ class Scrubber {
                 );
             } catch {
                 context.log.error(
-                    `Regexp for rule ${name} pattern ${
-                        settings['pattern']
-                    } is malformed, skipping. Please update the pattern for this rule to be applied.`
+                    `Regexp for rule ${name} pattern ${settings['pattern']} is malformed, skipping. Please update the pattern for this rule to be applied.`
                 );
             }
         }

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -30,7 +30,7 @@ const DD_SOURCE = process.env.DD_SOURCE || 'azure';
 const DD_SOURCE_CATEGORY = process.env.DD_SOURCE_CATEGORY || 'azure';
 
 const MAX_RETRIES = 4; // max number of times to retry a single http request
-const RETRY_INTERVAL = 1000; // amount of time (milliseconds) to wait before retrying request, doubles after every retry
+const RETRY_INTERVAL = 250; // amount of time (milliseconds) to wait before retrying request, doubles after every retry
 
 /*
 To scrub PII from your logs, uncomment the applicable configs below. If you'd like to scrub more than just

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -173,8 +173,7 @@ class HTTPClient {
         // don't retry 4xx responses
         return (
             !this.isStatusCodeValid(statusCode) &&
-            statusCode < 400 &&
-            statusCode > 499
+            (statusCode < 400 || statusCode > 499)
         );
     }
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Retries sending logs if the HTTP request failed. It will retry up to 4 times, with a 1 second timeout between retries, doubling each time. It will not retry http 4xx responses.

### Motivation

The network connection can be flaky and it is worth retrying a failed request.

### Testing Guidelines

Ran unit tests and tested in the Azure portal.

To test request errors, I constructed a bad http request with invalid options, and saw it attempt to retry the request. You can see the retry backoff in the timestamps.
<img width="1072" alt="Screen Shot 2022-07-28 at 9 13 46 AM" src="https://user-images.githubusercontent.com/43612608/181520519-fabaa7d4-261f-4d40-adda-7ac8fbf87b79.png">

Retrying based on status code. It doesn't retry on a 404, but does retry with a 500.
<img width="1152" alt="Screen Shot 2022-07-28 at 9 51 33 AM" src="https://user-images.githubusercontent.com/43612608/181522753-f165a919-0cfb-4a5e-acc9-ffb1475050b8.png">

There was also a random timeout that got retried:
<img width="1113" alt="Screen Shot 2022-07-28 at 9 09 09 AM" src="https://user-images.githubusercontent.com/43612608/181522911-7b0dcb87-dfc5-46cd-9181-112a9def1f70.png">

### Additional Notes

Is 4 retries too much/not enough? How is a 1 sec timeout interval? Will doubling the timeout cause it to wait too long?

Without using external libraries, the only way to add a delay is with `setTimeout`, which requires a callback to be provided.

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
