### PR TITLE
[aws-ints] fixing cloudtrail records parsing

### DIFF
--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -198,15 +198,20 @@ def s3_handler(event, context, metadata):
             # file around 60MB gzipped
             data = b"".join(BufferedReader(decompress_stream))
 
+    is_cloudtrail_bucket = False
     if is_cloudtrail(str(key)):
         cloud_trail = json.loads(data)
-        for event in cloud_trail["Records"]:
-            # Create structured object and send it
-            structured_line = merge_dicts(
-                event, {"aws": {"s3": {"bucket": bucket, "key": key}}}
-            )
-            yield structured_line
-    else:
+        if cloud_trail.get("Records") is not None:
+            # only parse as a cloudtrail bucket if we have a Records field to parse
+            is_cloudtrail_bucket = True
+            for event in cloud_trail["Records"]:
+                # Create structured object and send it
+                structured_line = merge_dicts(
+                    event, {"aws": {"s3": {"bucket": bucket, "key": key}}}
+                )
+                yield structured_line
+
+    if not is_cloudtrail_bucket:
         # Check if using multiline log regex pattern
         # and determine whether line or pattern separated logs
         data = data.decode("utf-8", errors="ignore")


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
There are some cloudtrail logs that don't come with the s3 "Records" field. This pr accounts for that by not assuming the field exists.

### Motivation
Issues with this parsing found here: https://github.com/DataDog/datadog-serverless-functions/issues/593

### Testing Guidelines
Generated a lambda layer off of this change and it's running fine.

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
