### PR TITLE
CLOUDS-2607:Properly parse partitions for gov and china service arns

### DIFF
--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -378,7 +378,7 @@ def get_partition_from_region(region):
     partition = "aws"
     if region:
         if GOV in region:
-            partition = "aws-gov"
+            partition = "aws-us-gov"
         elif CN in region:
             partition = "aws-cn"
     return partition

--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -374,6 +374,7 @@ def find_s3_source(key):
 
     return "s3"
 
+
 def get_partition_from_region(region):
     partition = "aws"
     if region:
@@ -382,6 +383,7 @@ def get_partition_from_region(region):
         elif CN in region:
             partition = "aws-cn"
     return partition
+
 
 def parse_service_arn(source, key, bucket, context):
     if source == "elb":

--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -36,6 +36,8 @@ from settings import (
     DD_USE_VPC,
 )
 
+GOV, CN = "gov", "cn"
+
 
 logger = logging.getLogger()
 
@@ -401,8 +403,13 @@ def parse_service_arn(source, key, bucket, context):
             elbname = name.replace(".", "/")
             if len(idsplit) > 1:
                 idvalue = idsplit[1]
-                return "arn:aws:elasticloadbalancing:{}:{}:loadbalancer/{}".format(
-                    region, idvalue, elbname
+                partition = "aws"
+                if GOV in region:
+                    partition = "aws-gov"
+                elif CN in region:
+                    partition = "aws-cn"
+                return "arn:{}:elasticloadbalancing:{}:{}:loadbalancer/{}".format(
+                    partition, region, idvalue, elbname
                 )
     if source == "s3":
         # For S3 access logs we use the bucket name to rebuild the arn

--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -374,6 +374,14 @@ def find_s3_source(key):
 
     return "s3"
 
+def get_partition_from_region(region):
+    partition = "aws"
+    if region:
+        if GOV in region:
+            partition = "aws-gov"
+        elif CN in region:
+            partition = "aws-cn"
+    return partition
 
 def parse_service_arn(source, key, bucket, context):
     if source == "elb":
@@ -403,11 +411,7 @@ def parse_service_arn(source, key, bucket, context):
             elbname = name.replace(".", "/")
             if len(idsplit) > 1:
                 idvalue = idsplit[1]
-                partition = "aws"
-                if GOV in region:
-                    partition = "aws-gov"
-                elif CN in region:
-                    partition = "aws-cn"
+                partition = get_partition_from_region(region)
                 return "arn:{}:elasticloadbalancing:{}:{}:loadbalancer/{}".format(
                     partition, region, idvalue, elbname
                 )
@@ -448,8 +452,8 @@ def parse_service_arn(source, key, bucket, context):
             filesplit = filename.split("_")
             if len(filesplit) == 6:
                 clustername = filesplit[3]
-                return "arn:aws:redshift:{}:{}:cluster:{}:".format(
-                    region, accountID, clustername
+                return "arn:{}:redshift:{}:{}:cluster:{}:".format(
+                    get_partition_from_region(region), region, accountID, clustername
                 )
     return
 

--- a/aws/logs_monitoring/tests/test_parsing.py
+++ b/aws/logs_monitoring/tests/test_parsing.py
@@ -378,7 +378,8 @@ class TestParseServiceArn(unittest.TestCase):
                 None,
                 None,
             ),
-            "arn:aws-gov:elasticloadbalancing:us-gov-east-1:123456789123:loadbalancer/app/my-alb-name/123456789aabcdef",
+            "arn:aws-us-gov:elasticloadbalancing:us-gov-east-1:123456789123:loadbalancer/app/my-alb-name"
+            "/123456789aabcdef",
         )
 
 

--- a/aws/logs_monitoring/tests/test_parsing.py
+++ b/aws/logs_monitoring/tests/test_parsing.py
@@ -213,6 +213,16 @@ class TestParseEventSource(unittest.TestCase):
             "redshift",
         )
 
+    def test_redshift_gov_event(self):
+        self.assertEqual(
+            parse_event_source(
+                {"Records": ["logs-from-s3"]},
+                "AWSLogs/123456779121/redshift/us-gov-east-1/2020/10/21/123456779121_redshift_us-gov-east"
+                "-1_mycluster_userlog_2020-10-21T18:01.gz",
+            ),
+            "redshift",
+        )
+
     def test_route53_event(self):
         self.assertEqual(
             parse_event_source(

--- a/aws/logs_monitoring/tests/test_parsing.py
+++ b/aws/logs_monitoring/tests/test_parsing.py
@@ -358,6 +358,19 @@ class TestParseServiceArn(unittest.TestCase):
             "arn:aws:elasticloadbalancing:us-east-1:123456789123:loadbalancer/app/my-alb-name/123456789aabcdef",
         )
 
+    def test_elb_s3_key_multi_prefix_gov(self):
+        self.assertEqual(
+            parse_service_arn(
+                "elb",
+                "elasticloadbalancing/my-alb-name/AWSLogs/123456789123/elasticloadbalancing/us-gov-east-1/2022/02/08"
+                "/123456789123_elasticloadbalancing_us-gov-east-1_app.my-alb-name.123456789aabcdef_20220208T1127Z_10"
+                ".0.0.2_1abcdef2.log.gz",
+                None,
+                None,
+            ),
+            "arn:aws-gov:elasticloadbalancing:us-gov-east-1:123456789123:loadbalancer/app/my-alb-name/123456789aabcdef",
+        )
+
 
 class TestParseAwsWafLogs(unittest.TestCase):
     def test_waf_string_invalid_json(self):


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Properly creates the partition section of arns parsed from services running in gov and cn regions.
<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
