### PR TITLE
Document step function support

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -11,7 +11,7 @@ aliases:
 
 The Datadog Forwarder is an AWS Lambda function that ships logs, custom metrics, and traces from your environment to Datadog. The Forwarder can:
 
-- Forward CloudWatch, ELB, S3, CloudTrail, VPC, SNS, and CloudFront logs to Datadog
+- Forward CloudWatch, ELB, S3, CloudTrail, VPC, SNS, Step Functions (since version 3.46.0), and CloudFront logs to Datadog
 - Forward S3 events to Datadog
 - Forward Kinesis data stream events to Datadog (only CloudWatch logs are supported)
 - Forward custom metrics from AWS Lambda functions using CloudWatch logs


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Add to the documentation that Step Functions forwarding to Datadog is supported since version 3.46.0 by https://github.com/DataDog/datadog-serverless-functions/pull/546

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

Recently tried to subscribe my Step Function's Cloudwatch log group to the Datadog Forwarder lambda.
Logs looked great but the logs weren't received by the DataDog server.
Eventually, I figured my DataDog Forwarder version was old (3.44.0).

In general, it wasn't mentioned that a step function is supported though I was able to saw it can be used on some articles on the web.
It would have been really helpful to know from the official docs that:
1. Step Functions are supported by the DataDog Forwarder
2. A minimum version is required. 

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
