### PR TITLE
[SLES-918] Add client side APM stats computation

### DIFF
--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_lambda_invocation.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_lambda_invocation.json~snapshot
@@ -740,6 +740,20 @@
       "verb": "POST"
     },
     {
+      "data": null,
+      "headers": {
+        "Accept-Encoding": "gzip",
+        "Content-Encoding": "gzip",
+        "Content-Length": "<redacted from snapshot>",
+        "Content-Type": "application/json",
+        "Dd-Api-Key": "abcdefghijklmnopqrstuvwxyz012345",
+        "Host": "recorder:8080",
+        "User-Agent": "<redacted from snapshot>"
+      },
+      "path": "/api/v0.2/stats",
+      "verb": "POST"
+    },
+    {
       "data": {
         "series": [
           {

--- a/aws/logs_monitoring/trace_forwarder/cmd/trace/main.go
+++ b/aws/logs_monitoring/trace_forwarder/cmd/trace/main.go
@@ -145,9 +145,16 @@ func sendTracesToIntake(tracePayloads []*pb.TracePayload) error {
 			fmt.Printf("Failed to send traces with error %v\n", err)
 			hadErr = true
 		}
+		stats := apm.ComputeAPMStats(tracePayload)
+		err = edgeConnection.SendStats(context.Background(), stats, 3)
+		if err != nil {
+			fmt.Printf("Failed to send trace stats with error %v\n", err)
+			hadErr = true
+		}
 	}
+
 	if hadErr {
-		return errors.New("Failed to send traces to intake")
+		return errors.New("Failed to send traces or stats to intake")
 	}
 	return nil
 }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
Add client side stats computation. Server side stats computations were removed previously without adding the client side computations back causing stats to stop working. 

### Motivation

<!--- What inspired you to submit this pull request? --->
https://datadoghq.atlassian.net/browse/SLES-918
https://datadoghq.atlassian.net/browse/SLES-919

### Testing Guidelines

<!--- How did you test this pull request? --->
- Integration Tests
- Unit Tests

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
