### PR TITLE
(DOCS-3837) Remove CloudFormation for US1-FED region

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -96,6 +96,12 @@ resource "aws_cloudformation_stack" "datadog_forwarder" {
 
 {{< /site-region >}}
 
+{{< site-region region="gov" >}}
+
+If you are using the `US1-FED` site, follow the manual setup instructions below.
+
+{{< /site-region >}}
+
 ### Manual
 
 If you can't install the Forwarder using the provided CloudFormation template, you can install the Forwarder manually following the steps below. Feel free to open an issue or pull request to let us know if there is anything we can improve to make the template work for you.

--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -26,8 +26,7 @@ Datadog recommends using [CloudFormation](#cloudformation) to automatically inst
 
 Once installed, you can subscribe the Forwarder to log sources, such as S3 buckets or CloudWatch log groups following the [instructions](https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/?tab=awsconsole#set-up-triggers).
 
-<!-- xxx tabs xxx -->
-<!-- xxx tab "CloudFormation" xxx -->
+{{< site-region region="us,us3,eu" >}}
 
 ### CloudFormation
 
@@ -42,9 +41,6 @@ Once installed, you can subscribe the Forwarder to log sources, such as S3 bucke
 
 **Note:** If you had previously enabled your AWS Integration using the following [CloudFormation template](https://github.com/DataDog/cloudformation-template/tree/master/aws) from your AWS integration tile in Datadog, your account should already be provisioned with a Datadog Lambda Forwarder function.  
 **Note:** The code block of the Datadog Lambda Forwarder function is empty, as the logic is implemented through a Lambda layer.
-
-<!-- xxz tab xxx -->
-<!-- xxx tab "Terraform" xxx -->
 
 ### Terraform
 
@@ -98,8 +94,7 @@ resource "aws_cloudformation_stack" "datadog_forwarder" {
 }
 ```
 
-<!-- xxz tab xxx -->
-<!-- xxx tab "Manual" xxx -->
+{{< /site-region >}}
 
 ### Manual
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Remove the CloudFormation instructions for customers who have selected the `US1-FED` region in the documentation site.

### Motivation
DOCS-3837

### Testing Guidelines

Preview link:
https://docs-staging.datadoghq.com/bryce/DOCS-3837-update-pull-config-preview/logs/guide/forwarder/#installation

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
