### PR TITLE
AWS-1786 Add ability to not set ReservedConcurrency on log forwarder lambda

### DIFF
--- a/aws/logs_monitoring/release.sh
+++ b/aws/logs_monitoring/release.sh
@@ -7,7 +7,7 @@ set -e
 LAYER_NAME="Datadog-Forwarder"
 
 # Read the current version
-CURRENT_VERSION=$(grep -o 'Version: \d\+\.\d\+\.\d\+' template.yaml | cut -d' ' -f2)
+CURRENT_VERSION=$(grep -E -o 'Version: [0-9]+\.[0-9]+\.[0-9]+' template.yaml | cut -d' ' -f2)
 
 # Read the desired version
 if [ -z "$1" ]; then

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -217,6 +217,13 @@ Parameters:
     Type: String
     Default: ""
     Description: The name of the forwarder bucket to create. If not provided, AWS will generate a unique name.
+  UseReservedConcurrency:
+    Type: String
+    Default: true
+    AllowedValues:
+      - true
+      - false
+    Description: Configure the Datadog Forwarder Lambda to use reserved concurrency. Set to false to use unreserved account concurrency.
 Conditions:
   IsAWSChina:
     Fn::Equals:
@@ -397,6 +404,10 @@ Conditions:
       - Fn::Equals:
           - Ref: DdForwarderBucketName
           - ""
+  SetReservedConcurrentExecutions:
+    Fn::Equals:
+      - Ref: UseReservedConcurrency
+      - true
 Rules:
   MustSetDdApiKey:
     Assertions:
@@ -618,7 +629,10 @@ Resources:
               - Ref: DdTraceIntakeUrl
               - Ref: AWS::NoValue
       ReservedConcurrentExecutions:
-        Ref: ReservedConcurrency
+        Fn::If:
+          - SetReservedConcurrentExecutions
+          - Ref: ReservedConcurrency
+          - Ref: AWS::NoValue
       VpcConfig:
         Fn::If:
           - UseVPC
@@ -1052,6 +1066,7 @@ Metadata:
           - DdTraceIntakeUrl
           - AdditionalTargetLambdaArns
           - DdForwarderBucketName
+          - UseReservedConcurrency
     ParameterLabels:
       DdApiKey:
         default: "DdApiKey *"

--- a/aws/logs_monitoring/tools/installation_test.sh
+++ b/aws/logs_monitoring/tools/installation_test.sh
@@ -25,7 +25,7 @@ RUN_ID=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c10)
 # Since we never run the log forwarder, api key can be anything.
 DD_API_KEY=RUN_ID
 
-CURRENT_VERSION="$(grep -o 'Version: \d\+\.\d\+\.\d\+' template.yaml | cut -d' ' -f2)"
+CURRENT_VERSION="$(grep -E -o 'Version: [0-9]+\.[0-9]+\.[0-9]+' template.yaml | cut -d' ' -f2)"
 
 function aws-login() {
     cfg=( "$@" )


### PR DESCRIPTION
### What does this PR do?

Adds the ability to not set ReservedConcurrency on log forwarder lambda

### Motivation

https://datadoghq.atlassian.net/browse/AWS-1786

### Testing Guidelines

I tested the template using CloudFormation in the AWS console, uploading the file and creating a stack.

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
