### PR TITLE
Add in the new file pattern for aws waf logs as per https://docs.aws.…

### DIFF
--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -349,8 +349,8 @@ def find_s3_source(key):
     if "vpcdnsquerylogs" in key:
         return "route53"
 
-    # e.g. 2020/10/02/21/aws-waf-logs-testing-1-2020-10-02-21-25-30-x123x-x456x
-    if "aws-waf-logs" in key:
+    # e.g. 2020/10/02/21/aws-waf-logs-testing-1-2020-10-02-21-25-30-x123x-x456x or AWSLogs/123456779121/WAFLogs/us-east-1/xxxxxx-waf/2022/10/11/14/10/123456779121_waflogs_us-east-1_xxxxx-waf_20221011T1410Z_12756524.log.gz
+    if "aws-waf-logs" in key or "waflogs" in key:
         return "waf"
 
     # e.g. AWSLogs/123456779121/redshift/us-east-1/2020/10/21/123456779121_redshift_us-east-1_mycluster_userlog_2020-10-21T18:01.gz

--- a/aws/logs_monitoring/tests/test_parsing.py
+++ b/aws/logs_monitoring/tests/test_parsing.py
@@ -204,6 +204,14 @@ class TestParseEventSource(unittest.TestCase):
             "waf",
         )
 
+        self.assertEqual(
+            parse_event_source(
+                {"Records": ["logs-from-s3"]},
+                "AWSLogs/123456779121/WAFLogs/us-east-1/xxxxxx-waf/2022/10/11/14/10/123456779121_waflogs_us-east-1_xxxxx-waf_20221011T1410Z_12756524.log.gz",
+            ),
+            "waf",
+        )
+
     def test_redshift_event(self):
         self.assertEqual(
             parse_event_source(


### PR DESCRIPTION
### What does this PR do?

Fixes source mapping for S3 based AWS WAF logs

### Motivation

Recently implemented AWS S3 waf logging and discovered datadog log forwarder was marking the logs as source s3 instead of source waf.  Relates to https://github.com/DataDog/datadog-serverless-functions/issues/599

### Testing Guidelines

Ran unit tests

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [X] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [X] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [X] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
