### PR TITLE
Adding DeletionPolicy to ForwarderBucket

### DIFF
--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -219,6 +219,14 @@ Parameters:
     Type: String
     Default: ""
     Description: The name of the forwarder bucket to create. If not provided, AWS will generate a unique name.
+  FWBucketDeletionPolicy:
+    Description: DeletionPolicy options for the DdForwarderBucketName.
+    Type: String
+    Default: Retain
+    AllowedValues:
+      - Retain
+      - Delete
+      - Snapshot
 Conditions:
   IsAWSChina:
     Fn::Equals:
@@ -790,6 +798,7 @@ Resources:
   # A s3 bucket used by the Forwarder as a datastore
   ForwarderBucket:
     Type: AWS::S3::Bucket
+    DeletionPolicy: Ref: FWBucketDeletionPolicy
     Properties:
       BucketName:
         Fn::If:


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
DD-Support-ticket 969071: adding configureable DeletionPolicy but keeping default for ForwarderBucket since stack deprovisioning fails when ForwarderBucket is not empty (s3 default on aws)  
here are the aws docs that describe how to use deletion policies on s3: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html

### Motivation
we use 'latest.yaml' to provision log forwarders via terraform or cdk.
In both cases (i.e. 'terraform destroy' or 'cdk destroy' the destruction is being reported in the state 'failed' because the Cloudformation stack is not destroyable which is caused by the non-empty s3 bucket. 


This is how it is integrated in cdk:
```
    new CfnStack(this, 'DataDog Forwarder', {
      templateUrl: 'https://datadog-cloudformation-template.s3.amazonaws.com/aws/forwarder/latest.yaml',
```
This is a message by cdk from a ci/cd pipeline:

`The stack named STACKNAME is in a failed state. You may need to delete it from the AWS console : DELETE_FAILED (The following resource(s) failed to delete: [DataDogForwarder]. ): Embedded stack arn:aws:cloudformation:eu-middleeast-1:123456789:stack/stackname-dd-forwarder-DataDogForwarder-C4R4CT3R5/s0m3-uu1d was not successfully deleted: The following resource(s) failed to delete: [ForwarderBucket].`

### Testing Guidelines
# create a stack with default values on the aws console
# delete the stack afterwards (this should fail in Cloudformation)
# create a stack with default values but choose `Delete` as deletion policy
# delete the stack afterwards which should not fail

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
