### PR TITLE
fix: Add missing EKS log streams

### DIFF
--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -571,6 +571,12 @@ def awslogs_handler(event, context, metadata):
             metadata[DD_SOURCE] = "kubernetes.audit"
         elif logs["logStream"].startswith("kube-scheduler-"):
             metadata[DD_SOURCE] = "kube_scheduler"
+        elif logs["logStream"].startswith("kube-apiserver-"):
+            metadata[DD_SOURCE] = "kube-apiserver"
+        elif logs["logStream"].startswith("kube-controller-manager-"):
+            metadata[DD_SOURCE] = "kube-controller-manager"
+        elif logs["logStream"].startswith("authenticator-"):
+            metadata[DD_SOURCE] = "aws-iam-authenticator"
         # In case the conditions above don't match we maintain eks as the source
 
     # Create and send structured logs to Datadog


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
Adds support for some missing cloudwatch log streams for EKS clusters. `kube-apiserver` and `kube-controller-manager` are already recognised as standard sources in the integration-installed `glog pipeline`, so these will be parsed correctly.

The integration doesn't currently have any processing for the `eks` source, so changing the authenticator logs to have a specific source will have no impact, but allow for processing to be added correctly on the datadog server-side.

### Motivation

<!--- What inspired you to submit this pull request? --->

Our controller-manager logs for EKS are not currently being parsed correctly in Datadog

### Testing Guidelines

<!--- How did you test this pull request? --->

Not tested, but follows existing pattern, and checked against our current cloudwatch streams

### Additional Notes

<!--- Anything else we should know when reviewing? --->

Related to #372

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
