### PR TITLE
fix oom error string for python in unit test

### DIFF
--- a/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/tests/test_enhanced_lambda_metrics.py
@@ -301,7 +301,7 @@ class TestEnhancedLambdaMetrics(unittest.TestCase):
             len(create_out_of_memory_enhanced_metric(node_out_of_memory_error)), 1
         )
 
-        python_out_of_memory_error = "fatal error: runtime: out of memory"
+        python_out_of_memory_error = "MemoryError"
         self.assertEqual(
             len(create_out_of_memory_enhanced_metric(python_out_of_memory_error)), 1
         )


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

Update oom error string of python from `fatal error: runtime: out of memory`(Go) to `MemoryError` in the unit test.

### Motivation

<!--- What inspired you to submit this pull request? --->

The oom error string of python must be `MemoryError` according to this code.
https://github.com/DataDog/datadog-serverless-functions/blob/bf8892b39278f6420f45b74f942db78fbd0b21e6/aws/logs_monitoring/enhanced_lambda_metrics.py#LL55C6-L55C17

### Testing Guidelines

<!--- How did you test this pull request? --->

No behavioral changes.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
