### PR TITLE
Fix Lambda Logger documentation around VPC usage

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -227,7 +227,7 @@ You can run the Forwarder in a VPC private subnet and send data to Datadog over 
 1. Follow the [instructions](https://docs.datadoghq.com/agent/guide/private-link/?tab=logs#create-your-vpc-endpoint) to add the Datadog `api`, `http-logs.intake` and `trace.agent` endpoints to your VPC.
 2. Follow the [instructions](https://docs.aws.amazon.com/vpc/latest/userguide/vpce-interface.html#create-interface-endpoint) to add the AWS Secrets Manager and S3 endpoints to your VPC.
 3. When installing the Forwarder with the CloudFormation template,
-   1. set `UseVPC` to `true`
+   1. set `DdUseVPC` to `true`
    2. set `VPCSecurityGroupIds` and `VPCSubnetIds` based on your VPC settings
    3. set `DdFetchLambdaTags` to `false`, because AWS Resource Groups Tagging API doesn't support PrivateLink
 


### PR DESCRIPTION


<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

`UseVPC` is not allowed to be passed in, `DdUseVPC` works (and appears elsewhere in the docs).
<!--- A brief description of the change being made with this pull request. --->

### Motivation

The documentation was misleading.
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

Running on a private stack with the documented change.
<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
