### PR TITLE
Bumping the log monitor lambda version to resolve CVE-2022-40899

### DIFF
--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -225,7 +225,7 @@ DD_SOURCE = "ddsource"
 DD_CUSTOM_TAGS = "ddtags"
 DD_SERVICE = "service"
 DD_HOST = "host"
-DD_FORWARDER_VERSION = "3.66.0"
+DD_FORWARDER_VERSION = "3.67.0"
 
 # Additional target lambda invoked async with event data
 DD_ADDITIONAL_TARGET_LAMBDAS = get_env_var("DD_ADDITIONAL_TARGET_LAMBDAS", default=None)

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -3,7 +3,7 @@ Description: Pushes logs, metrics and traces from AWS to Datadog.
 Mappings:
   Constants:
     DdForwarder:
-      Version: 3.66.0
+      Version: 3.67.0
       LayerVersion: 28
 Parameters:
   DdApiKey:


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

The Datadog log monitor lambda version 3.66.0 contains a vulnerability found in [CVE-2022-40899](https://github.com/advisories/GHSA-v3c5-jqr6-7qm8). Rebuilding the lambda has picked up the fixed package version for the vulnerability and resolves the finding. 

_Note: I'm not sure what the process for releasing new versions are for Datadog but I figured I could make this pull requests for visibility of the vulnerability. Please feel free to close this pull requests if this is not how Datadog handles security vulnerabilities._ 

<!--- A brief description of the change being made with this pull request. --->

### Motivation
To resolve a security vulnerability found in our Datadog log monitor lambdas. Currently we have the log monitor deployed across 5 AWS environments and need this vulnerability fixed. 
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

I have built the log monitoring lambda on my local machine to verify that rebuilding the lambda will pull in the fixed package version for CVE-2022-40899. Please see the screenshot below:

![cve-2022-40899](https://user-images.githubusercontent.com/42552579/212970549-440c1835-a6a7-48b4-a4a6-562cb24e4db6.png)


<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
