### PR TITLE
[AWSC-101] Patch Forwarder for CVEs

### DIFF
--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -225,7 +225,7 @@ DD_SOURCE = "ddsource"
 DD_CUSTOM_TAGS = "ddtags"
 DD_SERVICE = "service"
 DD_HOST = "host"
-DD_FORWARDER_VERSION = "3.66.0"
+DD_FORWARDER_VERSION = "3.67.0"
 
 # Additional target lambda invoked async with event data
 DD_ADDITIONAL_TARGET_LAMBDAS = get_env_var("DD_ADDITIONAL_TARGET_LAMBDAS", default=None)

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -3,7 +3,7 @@ Description: Pushes logs, metrics and traces from AWS to Datadog.
 Mappings:
   Constants:
     DdForwarder:
-      Version: 3.66.0
+      Version: 3.67.0
       LayerVersion: 28
 Parameters:
   DdApiKey:


### PR DESCRIPTION
### What does this PR do?

This PR increases the version of the forwarder to 3.67.0 to address 2 security vulnerabilities. Rebuilding the lambda fixes both dependencies as it upgrades them to versions considered safe. 
```
raphael .forwarder % unzip -l aws-dd-forwarder-3.67.0.zip | grep -m 3 "certifi"                                                                                       
        0  01-25-2023 14:35   certifi-2022.12.7.dist-info/
     1012  01-25-2023 14:35   certifi-2022.12.7.dist-info/RECORD
     1052  01-25-2023 14:35   certifi-2022.12.7.dist-info/LICENSE
raphael .forwarder % unzip -l aws-dd-forwarder-3.67.0.zip | grep -m 3 "future" 
        0  01-25-2023 14:35   future-0.18.3.dist-info/
    31208  01-25-2023 14:35   future-0.18.3.dist-info/RECORD
       92  01-25-2023 14:35   future-0.18.3.dist-info/WHEEL
```


### Motivation

Resolving 2 security vulnerabilities listed here:
* [CVE-2022-40899](https://nvd.nist.gov/vuln/detail/CVE-2022-40899)
Issue discovered in Python Charmers Future 0.18.2. Bumped to 0.18.3
* [CVE-2022-23491](https://nvd.nist.gov/vuln/detail/CVE-2022-23491). See [note](https://github.com/certifi/python-certifi/security/advisories/GHSA-43fp-rhv2-5gv8)
Issue discovered in versions >= 2017.11.05 and <2022.12.07. Bumped to 2022.12.07


### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
