### PR TITLE
[AWSC] Fix security vulnerability for SSL/TLS version

### DIFF
--- a/aws/logs_monitoring/logs.py
+++ b/aws/logs_monitoring/logs.py
@@ -262,7 +262,9 @@ class DatadogTCPClient(object):
     def _connect(self):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         if self._use_ssl:
-            sock = ssl.create_default_context().wrap_socket(
+            context = ssl.create_default_context()
+            context.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1
+            sock = context.wrap_socket(
                 sock, server_hostname=self.host
             )
         sock.connect((self.host, self.port))

--- a/aws/logs_monitoring/logs.py
+++ b/aws/logs_monitoring/logs.py
@@ -264,9 +264,8 @@ class DatadogTCPClient(object):
         if self._use_ssl:
             context = ssl.create_default_context()
             context.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1
-            sock = context.wrap_socket(
-                sock, server_hostname=self.host
-            )
+            context.minimum_version = ssl.TLSVersion.TLSv1_2
+            sock = context.wrap_socket(sock, server_hostname=self.host)
         sock.connect((self.host, self.port))
         self._sock = sock
 


### PR DESCRIPTION
### What does this PR do?

Aim of this PR is to fix the vulnerability described [here](https://github.com/DataDog/datadog-serverless-functions/security/code-scanning/3)

### Motivation

All versions of SSL, and TLS versions 1.0 and 1.1 are known to be vulnerable to attacks. Using TLS 1.2 or above is strongly recommended. This change ensures that the options for the default context used when creating the socket do not contain a version known to be vulnerable.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
