### PR TITLE
[serverless] recommend extension over forwarder

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -18,7 +18,7 @@ The Datadog Forwarder is an AWS Lambda function that ships logs from AWS to Data
 
 For additional information on sending AWS services logs with the Datadog Forwarder, read the [Send AWS Services Logs with the Datadog Lambda Function](https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/) guide.
 
-For serverless customers using the Forwarder to forward metrics, traces and logs from AWS Lambda logs to Datadog, we recommend [migrating to the Datadog Lambda Extension](https://docs.datadoghq.com/serverless/guide/extension_motivation/) to collect telemetry directly from the Lambda execution environments. The Forwarder is still available for use, but will only receive security updates after May 1st, 2023.
+For serverless customers using the Forwarder to forward metrics, traces and logs from AWS Lambda logs to Datadog, we recommend [migrating to the Datadog Lambda Extension](https://docs.datadoghq.com/serverless/guide/extension_motivation/) to collect telemetry directly from the Lambda execution environments. The Forwarder is still available for use, but will only receive security updates.
 
 ## Installation
 

--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -9,16 +9,16 @@ aliases:
   - /serverless/libraries_integrations/forwarder/
 ---
 
-The Datadog Forwarder is an AWS Lambda function that ships logs, custom metrics, and traces from your environment to Datadog. The Forwarder can:
+The Datadog Forwarder is an AWS Lambda function that ships logs from AWS to Datadog, specifically:
 
 - Forward CloudWatch, ELB, S3, CloudTrail, VPC, SNS, and CloudFront logs to Datadog
 - Forward S3 events to Datadog
 - Forward Kinesis data stream events to Datadog (only CloudWatch logs are supported)
-- Forward custom metrics from AWS Lambda functions using CloudWatch logs
-- Forward traces from AWS Lambda functions using CloudWatch logs
-- Generate and submit enhanced Lambda metrics (`aws.lambda.enhanced.*`) parsed from the AWS REPORT log: `duration`, `billed_duration`, `max_memory_used`, `timeouts`, `out_of_memory`, and `estimated_cost`
+- Forward metrics, traces and logs from AWS Lambda logs to Datadog (we recommend using the [Datadog Lambda Extension](https://github.com/DataDog/datadog-lambda-extension) instead)
 
 For additional information on sending AWS services logs with the Datadog Forwarder, read the [Send AWS Services Logs with the Datadog Lambda Function](https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/) guide.
+
+For serverless customers using the Forwarder to forward metrics, traces and logs from AWS Lambda logs to Datadog, we recommend [migrating to the Datadog Lambda Extension](https://docs.datadoghq.com/serverless/guide/extension_motivation/) to collect telemetry directly from the Lambda execution environments. The Forwarder is still available for use, but will only receive security updates after May 1st, 2023.
 
 ## Installation
 

--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -18,7 +18,7 @@ The Datadog Forwarder is an AWS Lambda function that ships logs from AWS to Data
 
 For additional information on sending AWS services logs with the Datadog Forwarder, read the [Send AWS Services Logs with the Datadog Lambda Function](https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/) guide.
 
-For serverless customers using the Forwarder to forward metrics, traces and logs from AWS Lambda logs to Datadog, we recommend [migrating to the Datadog Lambda Extension](https://docs.datadoghq.com/serverless/guide/extension_motivation/) to collect telemetry directly from the Lambda execution environments. The Forwarder is still available for use, but will only receive security updates.
+For serverless customers using the Forwarder to forward metrics, traces, and logs from AWS Lambda logs to Datadog, it is recommended that you [migrate to the Datadog Lambda Extension](https://docs.datadoghq.com/serverless/guide/extension_motivation/) to collect telemetry directly from the Lambda execution environments. The Forwarder is still available for use, but will only receive security updates.
 
 ## Installation
 

--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -14,7 +14,7 @@ The Datadog Forwarder is an AWS Lambda function that ships logs from AWS to Data
 - Forward CloudWatch, ELB, S3, CloudTrail, VPC, SNS, and CloudFront logs to Datadog
 - Forward S3 events to Datadog
 - Forward Kinesis data stream events to Datadog (only CloudWatch logs are supported)
-- Forward metrics, traces and logs from AWS Lambda logs to Datadog (we recommend using the [Datadog Lambda Extension](https://github.com/DataDog/datadog-lambda-extension) instead)
+- [Legacy] Forward metrics, traces and logs from AWS Lambda functions to Datadog (we now recommend using the [Datadog Lambda Extension](https://github.com/DataDog/datadog-lambda-extension) to monitor your Lambda functions)
 
 For additional information on sending AWS services logs with the Datadog Forwarder, read the [Send AWS Services Logs with the Datadog Lambda Function](https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/) guide.
 

--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -14,7 +14,7 @@ The Datadog Forwarder is an AWS Lambda function that ships logs from AWS to Data
 - Forward CloudWatch, ELB, S3, CloudTrail, VPC, SNS, and CloudFront logs to Datadog
 - Forward S3 events to Datadog
 - Forward Kinesis data stream events to Datadog (only CloudWatch logs are supported)
-- [Legacy] Forward metrics, traces and logs from AWS Lambda functions to Datadog (we now recommend using the [Datadog Lambda Extension](https://github.com/DataDog/datadog-lambda-extension) to monitor your Lambda functions)
+- Forward metrics, traces, and logs from AWS Lambda functions to Datadog. **Note**: Datadog recommends that you use the [Datadog Lambda Extension](https://github.com/DataDog/datadog-lambda-extension) to monitor your Lambda functions.
 
 For additional information on sending AWS services logs with the Datadog Forwarder, read the [Send AWS Services Logs with the Datadog Lambda Function](https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/) guide.
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Recommend serverless customers to use the Lambda extension instead of the Forwarder for reasons documented in https://docs.datadoghq.com/serverless/guide/extension_motivation/#advantages

### Motivation

Multiple customer feedback suggested that they are unsure whether they should use the forwarder or extension.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
