### PR TITLE
related to JIRA CLOUDS-3364 added to check idsplit[3] in the S3 key t…

### DIFF
--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -426,13 +426,21 @@ def parse_service_arn(source, key, bucket, context):
             elbname = name.replace(".", "/")
             if len(idsplit) > 1:
                 partition = get_partition_from_region(region)
-                pattern = re.compile("^[0-9]{12}$") #regex to check for 12-digits only - AWS account id is 12 digit
-                if bool(pattern.match(idsplit[1])): #checking that id is 12-digit
+                pattern = re.compile(
+                    "^[0-9]{12}$"
+                )  # regex to check for 12-digits only - AWS account id is 12 digit
+                if bool(pattern.match(idsplit[1])):  # checking that id is 12-digit
                     idvalue = idsplit[1]
-                    return "arn:{}:elasticloadbalancing:{}:{}:loadbalancer/{}".format(partition, region, idvalue, elbname)
-                elif bool(pattern.match(idsplit[3])): #checking if idsplit[3] contains aws account id
+                    return "arn:{}:elasticloadbalancing:{}:{}:loadbalancer/{}".format(
+                        partition, region, idvalue, elbname
+                    )
+                elif bool(
+                    pattern.match(idsplit[3])
+                ):  # checking if idsplit[3] contains aws account id
                     idvalue = idsplit[3]
-                    return "arn:{}:elasticloadbalancing:{}:{}:loadbalancer/{}".format(partition, region, idvalue, elbname)
+                    return "arn:{}:elasticloadbalancing:{}:{}:loadbalancer/{}".format(
+                        partition, region, idvalue, elbname
+                    )
     if source == "s3":
         # For S3 access logs we use the bucket name to rebuild the arn
         if bucket:

--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -425,11 +425,14 @@ def parse_service_arn(source, key, bucket, context):
             name = keysplit[3]
             elbname = name.replace(".", "/")
             if len(idsplit) > 1:
-                idvalue = idsplit[1]
                 partition = get_partition_from_region(region)
-                return "arn:{}:elasticloadbalancing:{}:{}:loadbalancer/{}".format(
-                    partition, region, idvalue, elbname
-                )
+                pattern = re.compile("^[0-9]{12}$") #regex to check for 12-digits only - AWS account id is 12 digit
+                if bool(pattern.match(idsplit[1])): #checking that id is 12-digit
+                    idvalue = idsplit[1]
+                    return "arn:{}:elasticloadbalancing:{}:{}:loadbalancer/{}".format(partition, region, idvalue, elbname)
+                elif bool(pattern.match(idsplit[3])): #checking if idsplit[3] contains aws account id
+                    idvalue = idsplit[3]
+                    return "arn:{}:elasticloadbalancing:{}:{}:loadbalancer/{}".format(partition, region, idvalue, elbname)
     if source == "s3":
         # For S3 access logs we use the bucket name to rebuild the arn
         if bucket:

--- a/aws/logs_monitoring/tests/test_parsing.py
+++ b/aws/logs_monitoring/tests/test_parsing.py
@@ -373,7 +373,7 @@ class TestParseServiceArn(unittest.TestCase):
                 None,
                 None,
             ),
-            "arn:aws:elasticloadbalancing:us-east-1:777707077777:targetgroup/awseb-AWS-test1234",
+            "arn:aws:elasticloadbalancing:us-east-1:123456789123:targetgroup/awseb-AWS-test1234",
         )
 
     def test_elb_s3_key_multi_prefix_gov(self):

--- a/aws/logs_monitoring/tests/test_parsing.py
+++ b/aws/logs_monitoring/tests/test_parsing.py
@@ -369,11 +369,11 @@ class TestParseServiceArn(unittest.TestCase):
         self.assertEqual(
             parse_service_arn(
                 "elb",
-                "elasticloadbalancing/my-alb-name/AWSLogs/123456789123/elasticloadbalancing/us-east-1/2022/02/08/123456789123_elasticloadbalancing_us-east-1_app.my-alb-name.123456789aabcdef_20220208T1127Z_10.0.0.2_1abcdef2.log.gz",
+                "test/manager/AWSLogs/123456789123/elasticloadbalancing/us-east-1/2022/02/08/123456789123_elasticloadbalancing_us-east-1_app.my-alb-name.123456789aabcdef_20220208T1127Z_10.0.0.2_1abcdef2.log.gz",
                 None,
                 None,
             ),
-            "arn:aws:elasticloadbalancing:us-east-1:123456789123:loadbalancer/app/my-alb-name/123456789aabcdef",
+            "arn:aws:elasticloadbalancing:us-east-1:777707077777:targetgroup/awseb-AWS-test1234",
         )
 
     def test_elb_s3_key_multi_prefix_gov(self):

--- a/aws/logs_monitoring/tests/test_parsing.py
+++ b/aws/logs_monitoring/tests/test_parsing.py
@@ -373,7 +373,7 @@ class TestParseServiceArn(unittest.TestCase):
                 None,
                 None,
             ),
-            "arn:aws:elasticloadbalancing:us-east-1:123456789123:targetgroup/awseb-AWS-test1234",
+            "arn:aws:elasticloadbalancing:us-east-1:123456789123:loadbalancer/app/my-alb-name/123456789aabcdef",
         )
 
     def test_elb_s3_key_multi_prefix_gov(self):


### PR DESCRIPTION
…o check if the aws account id is in idsplit[3]

<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

There is a bug with regards to this[ line of code](https://github.com/DataDog/datadog-serverless-functions/blob/5873df78780faad6a5eb7bf644616737e8992219/aws/logs_monitoring/parsing.py#L401) parse_service_arn  
: 
The arn of the load balancer is based on the S3 bucket key and the logic is not fully correct : 
using the parse_service_arn definition above, the parsed arn  is different from the original arn

Sometimes, idvalue is located in idsplit[3] and not in  idsplit[1] 
### Motivation

CLOUDS-3364 - issue in missing tags for some ELB load balancers 

### Testing Guidelines

I tested locally and saw the arn of the load balancer is based on the S3 bucket key and the logic is incorrect :

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
