### PR TITLE
[AZI-1463] make deployment names unique

### DIFF
--- a/azure/deploy-to-azure/parent_template.json
+++ b/azure/deploy-to-azure/parent_template.json
@@ -73,7 +73,7 @@
     },
     "diagnosticSettingName": {
         "type": "string",
-        "defaultValue": "datadog-activity-logs-diagnostic-setting",
+        "defaultValue": "[concat('datadog-activity-logs-diagnostic-setting-', newGuid())]",
         "metadata": {
             "description": "The name of the diagnostic setting if sending Activity Logs"
         }

--- a/azure/deploy-to-azure/parent_template.json
+++ b/azure/deploy-to-azure/parent_template.json
@@ -31,7 +31,7 @@
     },
     "eventHubName": {
       "type": "string",
-      "defaultValue": "datadog-eventhub",
+      "defaultValue": "[concat('datadog-eventhub-', newGuid())]",
       "metadata": {
         "description": "Name of Event Hub"
       }
@@ -52,7 +52,7 @@
     },
     "functionName": {
       "type": "string",
-      "defaultValue": "datadog-function",
+      "defaultValue": "[concat('datadog-function-', newGuid())]",
       "metadata": {
         "description": "The name of the function."
       }

--- a/azure/deploy-to-azure/parent_template.json
+++ b/azure/deploy-to-azure/parent_template.json
@@ -84,7 +84,7 @@
       "metadata": {
           "description": "Just a Guid to append to deployment script name"
       }
-  }
+    }
   },
   "variables": {
     "eventHubTemplateLink": "https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/master/azure/deploy-to-azure/event_hub.json",

--- a/azure/deploy-to-azure/parent_template.json
+++ b/azure/deploy-to-azure/parent_template.json
@@ -31,7 +31,7 @@
     },
     "eventHubName": {
       "type": "string",
-      "defaultValue": "[concat('datadog-eventhub-', newGuid())]",
+      "defaultValue": "datadog-eventhub",
       "metadata": {
         "description": "Name of Event Hub"
       }
@@ -52,7 +52,7 @@
     },
     "functionName": {
       "type": "string",
-      "defaultValue": "[concat('datadog-function-', newGuid())]",
+      "defaultValue": "datadog-function",
       "metadata": {
         "description": "The name of the function."
       }
@@ -73,7 +73,7 @@
     },
     "diagnosticSettingName": {
         "type": "string",
-        "defaultValue": "[concat('datadog-activity-logs-diagnostic-setting-', newGuid())]",
+        "defaultValue": "datadog-activity-logs-diagnostic-setting",
         "metadata": {
             "description": "The name of the diagnostic setting if sending Activity Logs"
         }
@@ -155,7 +155,7 @@
     {
       "condition": "[parameters('sendActivityLogs')]",
       "type": "Microsoft.Resources/deployments",
-      "name": "activityLogDiagnosticSettingsTemplate",
+      "name": "[concat('activityLogDiagnosticSettingsTemplate-', newGuid())]",
       "apiVersion": "2018-05-01",
       "properties": {
         "mode": "Incremental",

--- a/azure/deploy-to-azure/parent_template.json
+++ b/azure/deploy-to-azure/parent_template.json
@@ -77,7 +77,14 @@
         "metadata": {
             "description": "The name of the diagnostic setting if sending Activity Logs"
         }
-    }
+    },
+    "newguid": {
+      "type": "string",
+      "defaultValue": "[newGuid()]",
+      "metadata": {
+          "description": "Just a Guid to append to deployment script name"
+      }
+  }
   },
   "variables": {
     "eventHubTemplateLink": "https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/master/azure/deploy-to-azure/event_hub.json",
@@ -155,7 +162,7 @@
     {
       "condition": "[parameters('sendActivityLogs')]",
       "type": "Microsoft.Resources/deployments",
-      "name": "[concat('activityLogDiagnosticSettingsTemplate-', newGuid())]",
+      "name": "[concat('activityLogDiagnosticSettingsTemplate-', parameters('newguid'))]",
       "apiVersion": "2018-05-01",
       "properties": {
         "mode": "Incremental",

--- a/azure/deploy-to-azure/parent_template.json
+++ b/azure/deploy-to-azure/parent_template.json
@@ -73,17 +73,10 @@
     },
     "diagnosticSettingName": {
         "type": "string",
-        "defaultValue": "datadog-activity-logs-diagnostic-setting",
+        "defaultValue": "[concat('datadog-activity-logs-diagnostic-setting-', uniqueString(newGuid()))]",
         "metadata": {
             "description": "The name of the diagnostic setting if sending Activity Logs"
         }
-    },
-    "newguid": {
-      "type": "string",
-      "defaultValue": "[newGuid()]",
-      "metadata": {
-          "description": "Just a Guid to append to deployment script name"
-      }
     }
   },
   "variables": {
@@ -162,7 +155,7 @@
     {
       "condition": "[parameters('sendActivityLogs')]",
       "type": "Microsoft.Resources/deployments",
-      "name": "[concat('activityLogDiagnosticSettingsTemplate-', parameters('newguid'))]",
+      "name": "[concat(parameters('diagnosticSettingName'), '-Template')]",
       "apiVersion": "2018-05-01",
       "properties": {
         "mode": "Incremental",


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
This PR ensures that the `activityLogDiagnosticSettingsTemplate ` is actually unique. This was done by adding a call to `newGuid()` to the default value.

### Motivation

<!--- What inspired you to submit this pull request? --->
This PR is in response to a bug that a customer found in the script, and [this task](https://datadoghq.atlassian.net/browse/AZI-1463) which was created in response 

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
