### PR TITLE
[azure][azi-1524] arm template separate api calls for filters

### DIFF
--- a/azure/deploy-to-azure/azure-integration/CreateUIDefinition-managementgroups.json
+++ b/azure/deploy-to-azure/azure-integration/CreateUIDefinition-managementgroups.json
@@ -87,7 +87,7 @@
                 "visible": true,
                 "options": {
                   "icon": "Info",
-                  "text": "The following steps involve navigating away from this template. Please read them carefully before continuing.\n\n1. Select the option to create a new app registration.\n2. Give it a name and account type (the account type doesn’t matter)\n3. Hit Register. This will take you away from this template screen.\n4. Create a Client Secret. \n5. Copy the Value of the Client Secret.\n6. Hit the X in the corner to return to this template."
+                  "text": "The following steps involve navigating away from this template. Please read them carefully before continuing.\n\n1. Select the option to create a new app registration.\n2. Give it a name and select any account type.\n3. Click 'Register'. This will open a new page to create a client secret.\n4. Click ‘+ New Client Secret’ to add a Client Secret.\n5. Copy the Value of the Client Secret.\n6. Click the close (X) button in the top-right corner to return to this template screen.\n7 Paste the value of the Client Secret in the corresponding field on this template."
                 }
               },
               {
@@ -137,7 +137,7 @@
                   "text": "To fill out the fields below, copy the API and App Keys from your Datadog org. If you launched this template from the Azure tile, you can copy the keys you selected directly from there. Otherwise you can find your API and App Keys in the Access section of the Organization Settings.",
                   "link": {
                     "label": "Learn more",
-                    "uri": "https://docs.datadoghq.com/account_management/org_settings/#access"
+                    "uri": "https://docs.datadoghq.com/account_management/org_settings/"
                   }
                 }
               },
@@ -266,8 +266,8 @@
               {
                 "name": "custom_metrics_enabled",
                 "type": "Microsoft.Common.CheckBox",
-                "label": "Custom Metrics",
-                "toolTip": "Whether or not to use custom metrics"
+                "label": "Collect Custom Metrics",
+                "toolTip": "This option will enable custom metric collection from all Application Insights instances. Note <a target='_blank' href='https://learn.microsoft.com/en-us/azure/azure-monitor/app/standard-metrics/'>Standard</a> App Insights metrics are collected automatically and are available under the 'azure.insights_components.*' namespace."
               }
             ],
             "visible": true

--- a/azure/deploy-to-azure/azure-integration/CreateUIDefinition-managementgroups.json
+++ b/azure/deploy-to-azure/azure-integration/CreateUIDefinition-managementgroups.json
@@ -240,6 +240,17 @@
                 "visible": true
               },
               {
+                "name": "appFilters",
+                "type": "Microsoft.Common.TextBox",
+                "label": "App Service Plan Filters",
+                "defaultValue": "",
+                "toolTip": "This comma-separated list of Azure tags (in the form key:value) defines a filter that we will use when collecting metrics from Azure. Only App Service Plans that match one of the defined labels will be imported into Datadog. The rest will be ignored.  Wildcards, such as ? (for single characters) and * (for multiple characters) can also be used. Hosts matching a given label can also be excluded by adding ! before the label.  Example: datadog:monitored,env:production,!env:staging,instance-type:c1.*",
+                "constraints": {
+                  "required": false
+                },
+                "visible": true
+              },
+              {
                 "name": "automute",
                 "type": "Microsoft.Common.CheckBox",
                 "label": "Automute",
@@ -275,6 +286,7 @@
       "datadogApiKey": "[steps('datadogConfig').datadogIntegration.datadogApiKey]",
       "datadogSite": "[steps('datadogConfig').datadogSite]",
       "hostFilters": "[steps('datadogConfig').metrics.hostFilters]",
+      "appFilters": "[steps('datadogConfig').metrics.appFilters]",
       "automute": "[steps('datadogConfig').metrics.automute]",
       "cspm_enabled": "[steps('datadogConfig').metrics.cspm_enabled]",
       "custom_metrics_enabled": "[steps('datadogConfig').metrics.custom_metrics_enabled]"

--- a/azure/deploy-to-azure/azure-integration/CreateUIDefinition-managementgroups.json
+++ b/azure/deploy-to-azure/azure-integration/CreateUIDefinition-managementgroups.json
@@ -240,7 +240,7 @@
                 "visible": true
               },
               {
-                "name": "appFilters",
+                "name": "appServicePlanFilters",
                 "type": "Microsoft.Common.TextBox",
                 "label": "App Service Plan Filters",
                 "defaultValue": "",
@@ -286,7 +286,7 @@
       "datadogApiKey": "[steps('datadogConfig').datadogIntegration.datadogApiKey]",
       "datadogSite": "[steps('datadogConfig').datadogSite]",
       "hostFilters": "[steps('datadogConfig').metrics.hostFilters]",
-      "appFilters": "[steps('datadogConfig').metrics.appFilters]",
+      "appServicePlanFilters": "[steps('datadogConfig').metrics.appServicePlanFilters]",
       "automute": "[steps('datadogConfig').metrics.automute]",
       "cspm_enabled": "[steps('datadogConfig').metrics.cspm_enabled]",
       "custom_metrics_enabled": "[steps('datadogConfig').metrics.custom_metrics_enabled]"

--- a/azure/deploy-to-azure/azure-integration/CreateUiDefinition.json
+++ b/azure/deploy-to-azure/azure-integration/CreateUiDefinition.json
@@ -18,7 +18,7 @@
         "visible": true,
         "options": {
           "icon": "Info",
-          "text": "The selection of subscription and resource group above defines where this template will be deployed. It has no impact on which subscriptions will be monitored by Datadog. You will define the subscription(s) you would like to monitor with Datadog in the 'Datadog Configuration' tab."
+          "text": "The selections above define where this template will be deployed. It has no impact on which subscriptions will be monitored by Datadog. You will define the subscription(s) you would like to monitor with Datadog in the 'Datadog Configuration' tab."
         }
       },
       {
@@ -47,7 +47,7 @@
                 "visible": true,
                 "options": {
                   "icon": "Info",
-                  "text": "The following steps involve navigating away from this template. Please read them carefully before continuing.\n\n1. Select the option to create a new app registration.\n2. Give it a name and account type (the account type doesn’t matter)\n3. Hit Register. This will take you away from this template screen.\n4. Create a Client Secret. \n5. Copy the Value of the Client Secret.\n6. Hit the X in the corner to return to this template."
+                  "text": "The following steps involve navigating away from this template. Please read them carefully before continuing.\n\n1. Select the option to create a new app registration.\n2. Give it a name and select any account type.\n3. Click 'Register'. This will open a new page to create a client secret.\n4. Click ‘+ New Client Secret’ to add a Client Secret.\n5. Copy the Value of the Client Secret.\n6. Click the close (X) button in the top-right corner to return to this template screen.\n7 Paste the value of the Client Secret in the corresponding field on this template."
                 }
               },
               {
@@ -97,7 +97,7 @@
                   "text": "To fill out the fields below, copy the API and App Keys from your Datadog org. If you launched this template from the Azure tile, you can copy the keys you selected directly from there. Otherwise you can find your API and App Keys in the Access section of the Organization Settings.",
                   "link": {
                     "label": "Learn more",
-                    "uri": "https://docs.datadoghq.com/account_management/org_settings/#access"
+                    "uri": "https://docs.datadoghq.com/account_management/org_settings/"
                   }
                 }
               },
@@ -242,8 +242,8 @@
               {
                 "name": "custom_metrics_enabled",
                 "type": "Microsoft.Common.CheckBox",
-                "label": "Custom Metrics",
-                "toolTip": "Whether or not to use custom metrics"
+                "label": "Collect Custom Metrics",
+                "toolTip": "This option will enable custom metric collection from all Application Insights instances. Note <a target='_blank' href='https://learn.microsoft.com/en-us/azure/azure-monitor/app/standard-metrics/'>Standard</a> App Insights metrics are collected automatically and are available under the 'azure.insights_components.*' namespace."
               }
             ],
             "visible": true

--- a/azure/deploy-to-azure/azure-integration/CreateUiDefinition.json
+++ b/azure/deploy-to-azure/azure-integration/CreateUiDefinition.json
@@ -261,7 +261,7 @@
       "datadogApiKey": "[steps('datadogConfig').datadogIntegration.datadogApiKey]",
       "datadogSite": "[steps('datadogConfig').datadogSite]",
       "hostFilters": "[steps('datadogConfig').integrationConfig.hostFilters]",
-      "appFilters": "[steps('datadogConfig').metrics.appFilters]",
+      "appFilters": "[steps('datadogConfig').integrationConfig.appFilters]",
       "automute": "[steps('datadogConfig').integrationConfig.automute]",
       "cspm_enabled": "[steps('datadogConfig').integrationConfig.cspm_enabled]",
       "custom_metrics_enabled": "[steps('datadogConfig').integrationConfig.custom_metrics_enabled]"

--- a/azure/deploy-to-azure/azure-integration/CreateUiDefinition.json
+++ b/azure/deploy-to-azure/azure-integration/CreateUiDefinition.json
@@ -94,9 +94,9 @@
                 "type": "Microsoft.Common.TextBlock",
                 "visible": true,
                 "options": {
-                  "text": "To fill out the fields below, copy the API and App Keys from your Datadog org. If you launched this template from the Azure tile, you can copy the keys you selected directly from there.",
+                  "text": "To fill out the fields below, copy the API and App Keys from your Datadog org. If you launched this template from the Azure tile, you can copy the keys you selected directly from there. Otherwise you can find your API and App Keys in the Access section of the Organization Settings.",
                   "link": {
-                    "label": "Otherwise you can find your API and App Keys in the Access section of the Organization Settings.",
+                    "label": "Learn more",
                     "uri": "https://docs.datadoghq.com/account_management/org_settings/#access"
                   }
                 }

--- a/azure/deploy-to-azure/azure-integration/CreateUiDefinition.json
+++ b/azure/deploy-to-azure/azure-integration/CreateUiDefinition.json
@@ -216,6 +216,17 @@
                 "visible": true
               },
               {
+                "name": "appFilters",
+                "type": "Microsoft.Common.TextBox",
+                "label": "App Service Plan Filters",
+                "defaultValue": "",
+                "toolTip": "This comma-separated list of Azure tags (in the form key:value) defines a filter that we will use when collecting metrics from Azure. Only App Service Plans that match one of the defined labels will be imported into Datadog. The rest will be ignored.  Wildcards, such as ? (for single characters) and * (for multiple characters) can also be used. Hosts matching a given label can also be excluded by adding ! before the label.  Example: datadog:monitored,env:production,!env:staging,instance-type:c1.*",
+                "constraints": {
+                  "required": false
+                },
+                "visible": true
+              },
+              {
                 "name": "automute",
                 "type": "Microsoft.Common.CheckBox",
                 "label": "Automute",
@@ -250,6 +261,7 @@
       "datadogApiKey": "[steps('datadogConfig').datadogIntegration.datadogApiKey]",
       "datadogSite": "[steps('datadogConfig').datadogSite]",
       "hostFilters": "[steps('datadogConfig').integrationConfig.hostFilters]",
+      "appFilters": "[steps('datadogConfig').metrics.appFilters]",
       "automute": "[steps('datadogConfig').integrationConfig.automute]",
       "cspm_enabled": "[steps('datadogConfig').integrationConfig.cspm_enabled]",
       "custom_metrics_enabled": "[steps('datadogConfig').integrationConfig.custom_metrics_enabled]"

--- a/azure/deploy-to-azure/azure-integration/CreateUiDefinition.json
+++ b/azure/deploy-to-azure/azure-integration/CreateUiDefinition.json
@@ -216,7 +216,7 @@
                 "visible": true
               },
               {
-                "name": "appFilters",
+                "name": "appServicePlanFilters",
                 "type": "Microsoft.Common.TextBox",
                 "label": "App Service Plan Filters",
                 "defaultValue": "",
@@ -261,7 +261,7 @@
       "datadogApiKey": "[steps('datadogConfig').datadogIntegration.datadogApiKey]",
       "datadogSite": "[steps('datadogConfig').datadogSite]",
       "hostFilters": "[steps('datadogConfig').integrationConfig.hostFilters]",
-      "appFilters": "[steps('datadogConfig').integrationConfig.appFilters]",
+      "appServicePlanFilters": "[steps('datadogConfig').integrationConfig.appServicePlanFilters]",
       "automute": "[steps('datadogConfig').integrationConfig.automute]",
       "cspm_enabled": "[steps('datadogConfig').integrationConfig.cspm_enabled]",
       "custom_metrics_enabled": "[steps('datadogConfig').integrationConfig.custom_metrics_enabled]"

--- a/azure/deploy-to-azure/azure-integration/CreateUiDefinition.json
+++ b/azure/deploy-to-azure/azure-integration/CreateUiDefinition.json
@@ -1,218 +1,263 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/0.1.2-preview/CreateUIDefinition.MultiVm.json#",
-    "handler": "Microsoft.Azure.CreateUIDef",
-    "version": "0.1.2-preview",
-    "parameters": {
-        "basics": [
-            {
-                "name": "location",
-                "type": "Microsoft.Common.TextBox",
-                "label": "Location",
-                "defaultValue": "global",
-                "toolTip": "Resources location",
-                "visible": false
-            },
-            {
-                "name": "infoServicePrincipal",
+  "$schema": "https://schema.management.azure.com/schemas/0.1.2-preview/CreateUIDefinition.MultiVm.json#",
+  "handler": "Microsoft.Azure.CreateUIDef",
+  "version": "0.1.2-preview",
+  "parameters": {
+    "basics": [
+      {
+        "name": "location",
+        "type": "Microsoft.Common.TextBox",
+        "label": "Location",
+        "defaultValue": "global",
+        "toolTip": "Resources location",
+        "visible": false
+      },
+      {
+        "name": "infoBox1",
+        "type": "Microsoft.Common.InfoBox",
+        "visible": true,
+        "options": {
+          "icon": "Info",
+          "text": "The selection of subscription and resource group above defines where this template will be deployed. It has no impact on which subscriptions will be monitored by Datadog. This selection is done in the 'Datadog Configuration' tab where you can define the subscription(s) you would like to monitor with Datadog."
+        }
+      },
+      {
+        "name": "armio",
+        "type": "Microsoft.Solutions.ArmApiControl",
+        "request": {
+          "method": "POST",
+          "path": "/providers/Microsoft.Management/getEntities?api-version=2020-05-01"
+        }
+      }
+    ],
+    "steps": [
+      {
+        "name": "servicePrincipal",
+        "type": "Microsoft.Common.Section",
+        "label": "Service Principal Creation",
+        "elements": [
+          {
+            "name": "createAppReg",
+            "type": "Microsoft.Common.Section",
+            "label": "Create Datadog App Registration",
+            "elements": [
+              {
+                "name": "infoBox1",
                 "type": "Microsoft.Common.InfoBox",
                 "visible": true,
                 "options": {
-                    "icon": "Warning",
-                    "text": "Create a new Service Principal, add a Client Secret to it and copy it, then Press the X on top right to return to this form and paste it in the Client Secret field below."
+                  "icon": "Warning",
+                  "text": "The following steps involve navigating away from this template. Please read them carefully before continuing.\n1. Select the option to create a new app registration.\n2. Give it a name and account type (the account type doesn’t matter)\n3. Hit Register. This will take you away from this template screen.\n4. Create a Client Secret. \n5. Copy the Value of the Client Secret.\n6. Hit the X in the corner to return to this template."
                 }
-            },
-            {
+              },
+              {
                 "name": "ServicePrincipal",
                 "type": "Microsoft.Common.ServicePrincipalSelector",
                 "label": {
-                    "servicePrincipalId": "Service Principal Id",
-                    "password": "Client secret",
-                    "sectionHeader": "Service Principal"
+                  "servicePrincipalId": "Service Principal Id",
+                  "password": "Client secret",
+                  "sectionHeader": "Service Principal"
                 },
                 "toolTip": {
-                    "servicePrincipalId": "Service Principal Id"
+                  "servicePrincipalId": "Service Principal Id"
                 },
                 "defaultValue": {
-                    "principalId": "<default guid>",
-                    "name": "(New) default App Id"
+                  "principalId": "<default guid>",
+                  "name": "(New) default App Id"
                 },
                 "constraints": {
-                    "required": true,
-                    "validationMessage": "Must be a valid client secret"
+                  "required": true,
+                  "validationMessage": "Must be a valid client secret"
                 },
                 "options": {
-                    "hideCertificate": true
+                  "hideCertificate": true
                 },
                 "visible": true
-            },
-            {
-                "name": "armio",
-                "type": "Microsoft.Solutions.ArmApiControl",
-                "request": {
-                    "method": "POST",
-                    "path": "/providers/Microsoft.Management/getEntities?api-version=2020-05-01"
+              }
+            ],
+            "visible": true
+          }
+        ]
+      },
+      {
+        "name": "datadogConfig",
+        "type": "Microsoft.Common.Section",
+        "label": "Datadog Configuration",
+        "elements": [
+          {
+            "name": "datadogIntegration",
+            "type": "Microsoft.Common.Section",
+            "label": "Datadog Integration Keys",
+            "elements": [
+              {
+                "name": "textBlock1",
+                "type": "Microsoft.Common.TextBlock",
+                "visible": true,
+                "options": {
+                  "text": "To fill out the fields below, copy the API and App Keys from your Datadog org. If you launched this template from the Azure tile, you can copy the keys you selected directly from there.",
+                  "link": {
+                    "label": "Otherwise you can find your API and App Keys in the Access section of the Organization Settings.",
+                    "uri": "https://docs.datadoghq.com/account_management/org_settings/#access"
+                  }
                 }
-            },
-            {
-                "name": "subscriptionsList",
-                "type": "Microsoft.Common.DropDown",
-                "label": "Subscriptions to monitor",
-                "toolTip": "The list of subscriptions to monitor",
-                "filterPlaceholder": "Select one or more subscriptions to monitor",
-                "filter": true,
-                "multiselect": true,
-                "selectAll": true,
-                "defaultValue": "[map(filter(steps('basics').armio.value,(i) => and(not(equals(i.type,'Microsoft.Management/managementGroups')),not(and(equals(i.properties.permissions,'noaccess'),equals(i.properties.inheritedPermissions,'noaccess'))))),(item) => item.properties.displayName)]",
-                "constraints": {
-                    "allowedValues": "[map(filter(steps('basics').armio.value, (i)=>and(   not(equals(i.type, 'Microsoft.Management/managementGroups')),   not(and(equals(i.properties.permissions, 'noaccess'),equals(i.properties.inheritedPermissions, 'noaccess')))  )), (item)=> parse(concat('{\"label\":\"', item.properties.displayName, '\",\"value\":\"', item.name, '\"}')))]",
-                    "required": false
-                },
-                "visible": true
-            },
-            {
+              },
+              {
                 "name": "datadogApplicationKey",
                 "type": "Microsoft.Common.PasswordBox",
                 "label": {
-                    "password": "Datadog Application Key",
-                    "confirmPassword": "Re-enter Datadog Application Key"
+                  "password": "Datadog Application Key",
+                  "confirmPassword": "Re-enter Datadog Application Key"
                 },
                 "toolTip": "Your Datadog Application key",
                 "constraints": {
-                    "required": true,
-                    "validationMessage": "Must be a valid Application Key"
+                  "required": true,
+                  "validationMessage": "Must be a valid Application Key"
                 },
                 "options": {
-                    "hideConfirmation": true
+                  "hideConfirmation": true
                 },
                 "visible": true
-            },
-            {
+              },
+              {
                 "name": "datadogApiKey",
                 "type": "Microsoft.Common.PasswordBox",
                 "label": {
-                    "password": "Datadog API Key",
-                    "confirmPassword": "Re-enter Datadog Api Key"
+                  "password": "Datadog API Key",
+                  "confirmPassword": "Re-enter Datadog Api Key"
                 },
                 "toolTip": "Your Datadog API key",
                 "constraints": {
-                    "required": true,
-                    "validationMessage": "Must be a valid API Key"
+                  "required": true,
+                  "validationMessage": "Must be a valid API Key"
                 },
                 "options": {
-                    "hideConfirmation": true
+                  "hideConfirmation": true
                 },
                 "visible": true
+              }
+            ],
+            "visible": true
+          },
+          {
+            "name": "subscriptionsList",
+            "type": "Microsoft.Common.DropDown",
+            "label": "Subscriptions to monitor",
+            "toolTip": "The list of subscriptions to monitor",
+            "filterPlaceholder": "Select one or more subscriptions to monitor",
+            "filter": true,
+            "multiselect": true,
+            "selectAll": true,
+            "defaultValue": "[map(filter(steps('basics').armio.value,(i) => and(not(equals(i.type,'Microsoft.Management/managementGroups')),not(and(equals(i.properties.permissions,'noaccess'),equals(i.properties.inheritedPermissions,'noaccess'))))),(item) => item.properties.displayName)]",
+            "constraints": {
+              "allowedValues": "[map(filter(steps('basics').armio.value, (i)=>and(   not(equals(i.type, 'Microsoft.Management/managementGroups')),   not(and(equals(i.properties.permissions, 'noaccess'),equals(i.properties.inheritedPermissions, 'noaccess')))  )), (item)=> parse(concat('{\"label\":\"', item.properties.displayName, '\",\"value\":\"', item.name, '\"}')))]",
+              "required": false
             },
-            {
-                "name": "datadogSite",
-                "type": "Microsoft.Common.DropDown",
-                "label": "Datadog Site",
-                "defaultValue": "US1",
-                "toolTip": "The datadog site where you usually login. For US3, search for and install the Datadog Resource from the Azure Marketplace instead of using this form",
+            "visible": true
+          },
+		  {
+				"name": "datadogSite",
+				"type": "Microsoft.Common.DropDown",
+				"label": "Datadog Site",
+				"defaultValue": "US1",
+				"toolTip": "The datadog site where you usually login. For US3, search for and install the Datadog Resource from the Azure Marketplace instead of using this form",
+				"constraints": {
+				"allowedValues": [
+					{
+					"label": "US1",
+					"value": "datadoghq.com"
+					},
+					{
+					"label": "US5",
+					"value": "us5.datadoghq.com"
+					},
+					{
+					"label": "EU1",
+					"value": "datadoghq.eu"
+					},
+					{
+					"label": "US1-FED",
+					"value": "ddog-gov.com"
+					},
+					{
+					"label": "Staging",
+					"value": "ddstaging.datadoghq.com"
+					}
+				],
+				"required": false
+				},
+				"visible": true
+		  },
+          {
+            "name": "metrics",
+            "type": "Microsoft.Common.Section",
+            "label": "Integration Configuration",
+            "elements": [
+              {
+                "name": "textBlock1",
+                "type": "Microsoft.Common.TextBlock",
+                "visible": true,
+                "options": {
+                  "text": "Metrics will be collected for all resoures, except Virtual Machines, Virtual Machine Scale Sets and App Service Plans which can be filtered by tags."
+                }
+              },
+              {
+                "name": "textBlock2",
+                "type": "Microsoft.Common.TextBlock",
+                "visible": true,
+                "options": {
+                  "text": "Optionally limit metrics collection to Virtual Machines, Virtual Machine Scale Sets and App Service Plans to hosts using tags."
+                }
+              },
+              {
+                "name": "hostFilters",
+                "type": "Microsoft.Common.TextBox",
+                "label": "Host Filters",
+                "defaultValue": "",
+                "toolTip": "This comma-separated list of Azure tags (in the form key:value) defines a filter that we will use when collecting metrics from Azure. Only hosts that match one of the defined labels will be imported into Datadog. The rest will be ignored.  Wildcards, such as ? (for single characters) and * (for multiple characters) can also be used. Hosts matching a given label can also be excluded by adding ! before the label.  Example: datadog:monitored,env:production,!env:staging,instance-type:c1.*",
                 "constraints": {
-                    "allowedValues": [
-                        {
-                            "label": "US1",
-                            "value": "datadoghq.com"
-                        },
-                        {
-                            "label": "US5",
-                            "value": "us5.datadoghq.com"
-                        },
-                        {
-                            "label": "EU1",
-                            "value": "datadoghq.eu"
-                        },
-                        {
-                            "label": "US1-FED",
-                            "value": "ddog-gov.com"
-                        },
-                        {
-                            "label": "Staging",
-                            "value": "ddstaging.datadoghq.com"
-                        }
-                    ],
-                    "required": false
+                  "required": false
                 },
                 "visible": true
-            }
-        ],
-        "steps": [
-            {
-                "name": "metrics",
-                "label": "Metrics",
-                "elements": [
-                    {
-                        "name": "metrics",
-                        "type": "Microsoft.Common.Section",
-                        "label": "Metrics",
-                        "elements": [
-                            {
-                                "name": "textBlock1",
-                                "type": "Microsoft.Common.TextBlock",
-                                "visible": true,
-                                "options": {
-                                    "text": "Metrics will be collected for all resoures, except Virtual Machines, Virtual Machine Scale Sets and App Service Plans which can be filtered by tags."
-                                }
-                            },
-                            {
-                                "name": "textBlock2",
-                                "type": "Microsoft.Common.TextBlock",
-                                "visible": true,
-                                "options": {
-                                    "text": "Optionally limit metrics collection to Virtual Machines, Virtual Machine Scale Sets and App Service Plans to hosts using tags."
-                                }
-                            },
-                            {
-                                "name": "hostFilters",
-                                "type": "Microsoft.Common.TextBox",
-                                "label": "Host Filters",
-                                "defaultValue": "",
-                                "toolTip": "This comma-separated list of Azure tags (in the form key:value) defines a filter that we will use when collecting metrics from Azure. Only hosts that match one of the defined labels will be imported into Datadog. The rest will be ignored.  Wildcards, such as ? (for single characters) and * (for multiple characters) can also be used. Hosts matching a given label can also be excluded by adding ! before the label.  Example: datadog:monitored,env:production,!env:staging,instance-type:c1.*",
-                                "constraints": {
-                                    "required": false
-                                },
-                                "visible": true
-                            },
-                            {
-                                "name": "automute",
-                                "type": "Microsoft.Common.CheckBox",
-                                "label": "Automute",
-                                "toolTip": "Whether or not to use automute for hosts",
-                                "defaultValue": "true"
-                            },
-                            {
-                                "name": "cspm_enabled",
-                                "type": "Microsoft.Common.CheckBox",
-                                "label": "Cloud Security Posture Management",
-                                "toolTip": "When enabled, Datadog performs configuration checks across your Azure environment by continuously scanning every resource. Use Datadog's executive reporting summaries to track conformance to industry benchmark criteria.",
-                                "defaultValue": "true"
-                            },
-                            {
-                                "name": "custom_metrics_enabled",
-                                "type": "Microsoft.Common.CheckBox",
-                                "label": "Custom Metrics",
-                                "toolTip": "Whether or not to use custom metrics"
-                            }
-                        ],
-                        "visible": true
-                    }
-                ]
-            }
-        ],
-        "outputs": {
-            "location": "[location()]",
-            "servicePrincipalClientId": "[basics('ServicePrincipal').appId]",
-            "servicePrincipalObjectId": "[first(basics('ServicePrincipal').objectId)]",
-            "servicePrincipalClientSecret": "[basics('ServicePrincipal').password]",
-            "subscriptionsList": "[basics('subscriptionsList')]",
-            "datadogApplicationKey": "[basics('datadogApplicationKey')]",
-            "datadogApiKey": "[basics('datadogApiKey')]",
-            "datadogSite": "[basics('datadogSite')]",
-            "hostFilters": "[steps('metrics').metrics.hostFilters]",
-            "automute": "[steps('metrics').metrics.automute]",
-            "cspm_enabled": "[steps('metrics').metrics.cspm_enabled]",
-            "custom_metrics_enabled": "[steps('metrics').metrics.custom_metrics_enabled]"
-        }
+              },
+              {
+                "name": "automute",
+                "type": "Microsoft.Common.CheckBox",
+                "label": "Automute",
+                "toolTip": "Whether or not to use automute for hosts",
+                "defaultValue": "true"
+              },
+              {
+                "name": "cspm_enabled",
+                "type": "Microsoft.Common.CheckBox",
+                "label": "Cloud Security Posture Management",
+                "toolTip": "When enabled, Datadog performs configuration checks across your Azure environment by continuously scanning every resource. Use Datadog's executive reporting summaries to track conformance to industry benchmark criteria.",
+                "defaultValue": "true"
+              },
+              {
+                "name": "custom_metrics_enabled",
+                "type": "Microsoft.Common.CheckBox",
+                "label": "Custom Metrics",
+                "toolTip": "Whether or not to use custom metrics"
+              }
+            ],
+            "visible": true
+          }
+        ]
+      }
+    ],
+    "outputs": {
+      "location": "[location()]",
+      "servicePrincipalClientId": "[steps('servicePrincipal').createAppReg.ServicePrincipal.appId]",
+      "servicePrincipalObjectId": "[first(steps('servicePrincipal').createAppReg.ServicePrincipal.objectId)]",
+      "servicePrincipalClientSecret": "[steps('servicePrincipal').createAppReg.ServicePrincipal.password]",
+      "subscriptionsList": "[steps('datadogConfig').subscriptionsList]",
+      "datadogApplicationKey": "[steps('datadogConfig').datadogIntegration.datadogApplicationKey]",
+      "datadogApiKey": "[steps('datadogConfig').datadogIntegration.datadogApiKey]",
+      "datadogSite": "[steps('datadogConfig').datadogSite]",
+      "hostFilters": "[steps('datadogConfig').metrics.hostFilters]",
+      "automute": "[steps('datadogConfig').metrics.automute]",
+      "cspm_enabled": "[steps('datadogConfig').metrics.cspm_enabled]",
+      "custom_metrics_enabled": "[steps('datadogConfig').metrics.custom_metrics_enabled]"
     }
+  }
 }

--- a/azure/deploy-to-azure/azure-integration/CreateUiDefinition.json
+++ b/azure/deploy-to-azure/azure-integration/CreateUiDefinition.json
@@ -82,12 +82,12 @@
       {
         "name": "datadogConfig",
         "type": "Microsoft.Common.Section",
-        "label": "Datadog Organization",
+        "label": "Datadog Configuration",
         "elements": [
           {
             "name": "datadogIntegration",
             "type": "Microsoft.Common.Section",
-            "label": "Datadog Integration Keys",
+            "label": "Datadog Organization",
             "elements": [
               {
                 "name": "textBlock1",

--- a/azure/deploy-to-azure/azure-integration/CreateUiDefinition.json
+++ b/azure/deploy-to-azure/azure-integration/CreateUiDefinition.json
@@ -197,15 +197,7 @@
                 "type": "Microsoft.Common.TextBlock",
                 "visible": true,
                 "options": {
-                  "text": "Metrics will be collected for all Azure resources by default."
-                }
-              },
-              {
-                "name": "textBlock2",
-                "type": "Microsoft.Common.TextBlock",
-                "visible": true,
-                "options": {
-                  "text": "Optionally, you can limit metric collection for Virtual Machines, Virtual Machine Scale Sets and App Service Plans using tags in order to control your Datadog costs.",
+                  "text": "Metrics will be collected for all Azure resources by default. Optionally, you can limit metric collection for Virtual Machines, Virtual Machine Scale Sets and App Service Plans using tags in order to control your Datadog costs.",
                   "link": {
                     "label": "Learn more",
                     "uri": "https://docs.datadoghq.com/account_management/billing/azure/"

--- a/azure/deploy-to-azure/azure-integration/CreateUiDefinition.json
+++ b/azure/deploy-to-azure/azure-integration/CreateUiDefinition.json
@@ -18,7 +18,7 @@
         "visible": true,
         "options": {
           "icon": "Info",
-          "text": "The selection of subscription and resource group above defines where this template will be deployed. It has no impact on which subscriptions will be monitored by Datadog. This selection is done in the 'Datadog Configuration' tab where you can define the subscription(s) you would like to monitor with Datadog."
+          "text": "The selection of subscription and resource group above defines where this template will be deployed. It has no impact on which subscriptions will be monitored by Datadog. You will define the subscription(s) you would like to monitor with Datadog in the 'Datadog Configuration' tab."
         }
       },
       {
@@ -34,7 +34,7 @@
       {
         "name": "servicePrincipal",
         "type": "Microsoft.Common.Section",
-        "label": "Service Principal Creation",
+        "label": "Service Principal",
         "elements": [
           {
             "name": "createAppReg",
@@ -47,7 +47,7 @@
                 "visible": true,
                 "options": {
                   "icon": "Warning",
-                  "text": "The following steps involve navigating away from this template. Please read them carefully before continuing.\n1. Select the option to create a new app registration.\n2. Give it a name and account type (the account type doesn’t matter)\n3. Hit Register. This will take you away from this template screen.\n4. Create a Client Secret. \n5. Copy the Value of the Client Secret.\n6. Hit the X in the corner to return to this template."
+                  "text": "The following steps involve navigating away from this template. Please read them carefully before continuing.\n\n1. Select the option to create a new app registration.\n2. Give it a name and account type (the account type doesn’t matter)\n3. Hit Register. This will take you away from this template screen.\n4. Create a Client Secret. \n5. Copy the Value of the Client Secret.\n6. Hit the X in the corner to return to this template."
                 }
               },
               {
@@ -138,22 +138,6 @@
             ],
             "visible": true
           },
-          {
-            "name": "subscriptionsList",
-            "type": "Microsoft.Common.DropDown",
-            "label": "Subscriptions to monitor",
-            "toolTip": "The list of subscriptions to monitor",
-            "filterPlaceholder": "Select one or more subscriptions to monitor",
-            "filter": true,
-            "multiselect": true,
-            "selectAll": true,
-            "defaultValue": "[map(filter(steps('basics').armio.value,(i) => and(not(equals(i.type,'Microsoft.Management/managementGroups')),not(and(equals(i.properties.permissions,'noaccess'),equals(i.properties.inheritedPermissions,'noaccess'))))),(item) => item.properties.displayName)]",
-            "constraints": {
-              "allowedValues": "[map(filter(steps('basics').armio.value, (i)=>and(   not(equals(i.type, 'Microsoft.Management/managementGroups')),   not(and(equals(i.properties.permissions, 'noaccess'),equals(i.properties.inheritedPermissions, 'noaccess')))  )), (item)=> parse(concat('{\"label\":\"', item.properties.displayName, '\",\"value\":\"', item.name, '\"}')))]",
-              "required": false
-            },
-            "visible": true
-          },
 		  {
 				"name": "datadogSite",
 				"type": "Microsoft.Common.DropDown",
@@ -188,7 +172,7 @@
 				"visible": true
 		  },
           {
-            "name": "metrics",
+            "name": "integrationConfig",
             "type": "Microsoft.Common.Section",
             "label": "Integration Configuration",
             "elements": [
@@ -230,15 +214,30 @@
                 "name": "cspm_enabled",
                 "type": "Microsoft.Common.CheckBox",
                 "label": "Cloud Security Posture Management",
-                "toolTip": "When enabled, Datadog performs configuration checks across your Azure environment by continuously scanning every resource. Use Datadog's executive reporting summaries to track conformance to industry benchmark criteria.",
-                "defaultValue": "true"
+                "toolTip": "When enabled, Datadog performs configuration checks across your Azure environment by continuously scanning every resource. Use Datadog's executive reporting summaries to track conformance to industry benchmark criteria."
               },
               {
                 "name": "custom_metrics_enabled",
                 "type": "Microsoft.Common.CheckBox",
                 "label": "Custom Metrics",
                 "toolTip": "Whether or not to use custom metrics"
-              }
+              },
+              {
+                "name": "subscriptionsList",
+                "type": "Microsoft.Common.DropDown",
+                "label": "Subscriptions to monitor",
+                "toolTip": "The list of subscriptions to monitor",
+                "filterPlaceholder": "Select one or more subscriptions to monitor",
+                "filter": true,
+                "multiselect": true,
+                "selectAll": true,
+                "defaultValue": "[map(filter(steps('basics').armio.value,(i) => and(not(equals(i.type,'Microsoft.Management/managementGroups')),not(and(equals(i.properties.permissions,'noaccess'),equals(i.properties.inheritedPermissions,'noaccess'))))),(item) => item.properties.displayName)]",
+                "constraints": {
+                  "allowedValues": "[map(filter(steps('basics').armio.value, (i)=>and(   not(equals(i.type, 'Microsoft.Management/managementGroups')),   not(and(equals(i.properties.permissions, 'noaccess'),equals(i.properties.inheritedPermissions, 'noaccess')))  )), (item)=> parse(concat('{\"label\":\"', item.properties.displayName, '\",\"value\":\"', item.name, '\"}')))]",
+                  "required": false
+                },
+                "visible": true
+          }
             ],
             "visible": true
           }
@@ -250,14 +249,14 @@
       "servicePrincipalClientId": "[steps('servicePrincipal').createAppReg.ServicePrincipal.appId]",
       "servicePrincipalObjectId": "[first(steps('servicePrincipal').createAppReg.ServicePrincipal.objectId)]",
       "servicePrincipalClientSecret": "[steps('servicePrincipal').createAppReg.ServicePrincipal.password]",
-      "subscriptionsList": "[steps('datadogConfig').subscriptionsList]",
+      "subscriptionsList": "[steps('datadogConfig').integrationConfig.subscriptionsList]",
       "datadogApplicationKey": "[steps('datadogConfig').datadogIntegration.datadogApplicationKey]",
       "datadogApiKey": "[steps('datadogConfig').datadogIntegration.datadogApiKey]",
       "datadogSite": "[steps('datadogConfig').datadogSite]",
-      "hostFilters": "[steps('datadogConfig').metrics.hostFilters]",
-      "automute": "[steps('datadogConfig').metrics.automute]",
-      "cspm_enabled": "[steps('datadogConfig').metrics.cspm_enabled]",
-      "custom_metrics_enabled": "[steps('datadogConfig').metrics.custom_metrics_enabled]"
+      "hostFilters": "[steps('datadogConfig').integrationConfig.hostFilters]",
+      "automute": "[steps('datadogConfig').integrationConfig.automute]",
+      "cspm_enabled": "[steps('datadogConfig').integrationConfig.cspm_enabled]",
+      "custom_metrics_enabled": "[steps('datadogConfig').integrationConfig.custom_metrics_enabled]"
     }
   }
 }

--- a/azure/deploy-to-azure/azure-integration/CreateUiDefinition.json
+++ b/azure/deploy-to-azure/azure-integration/CreateUiDefinition.json
@@ -46,7 +46,7 @@
                 "type": "Microsoft.Common.InfoBox",
                 "visible": true,
                 "options": {
-                  "icon": "Warning",
+                  "icon": "Info",
                   "text": "The following steps involve navigating away from this template. Please read them carefully before continuing.\n\n1. Select the option to create a new app registration.\n2. Give it a name and account type (the account type doesn’t matter)\n3. Hit Register. This will take you away from this template screen.\n4. Create a Client Secret. \n5. Copy the Value of the Client Secret.\n6. Hit the X in the corner to return to this template."
                 }
               },
@@ -82,7 +82,7 @@
       {
         "name": "datadogConfig",
         "type": "Microsoft.Common.Section",
-        "label": "Datadog Configuration",
+        "label": "Datadog Organization",
         "elements": [
           {
             "name": "datadogIntegration",
@@ -138,50 +138,66 @@
             ],
             "visible": true
           },
-		  {
-				"name": "datadogSite",
-				"type": "Microsoft.Common.DropDown",
-				"label": "Datadog Site",
-				"defaultValue": "US1",
-				"toolTip": "The datadog site where you usually login. For US3, search for and install the Datadog Resource from the Azure Marketplace instead of using this form",
-				"constraints": {
-				"allowedValues": [
-					{
-					"label": "US1",
-					"value": "datadoghq.com"
-					},
-					{
-					"label": "US5",
-					"value": "us5.datadoghq.com"
-					},
-					{
-					"label": "EU1",
-					"value": "datadoghq.eu"
-					},
-					{
-					"label": "US1-FED",
-					"value": "ddog-gov.com"
-					},
-					{
-					"label": "Staging",
-					"value": "ddstaging.datadoghq.com"
-					}
-				],
-				"required": false
-				},
-				"visible": true
-		  },
+          {
+            "name": "datadogSite",
+            "type": "Microsoft.Common.DropDown",
+            "label": "Datadog Site",
+            "defaultValue": "US1",
+            "toolTip": "The datadog site where you usually login. For US3, search for and install the Datadog Resource from the Azure Marketplace instead of using this form",
+            "constraints": {
+              "allowedValues": [
+                {
+                  "label": "US1",
+                  "value": "datadoghq.com"
+                },
+                {
+                  "label": "US5",
+                  "value": "us5.datadoghq.com"
+                },
+                {
+                  "label": "EU1",
+                  "value": "datadoghq.eu"
+                },
+                {
+                  "label": "US1-FED",
+                  "value": "ddog-gov.com"
+                },
+                {
+                  "label": "Staging",
+                  "value": "ddstaging.datadoghq.com"
+                }
+              ],
+              "required": false
+            },
+            "visible": true
+          },
           {
             "name": "integrationConfig",
             "type": "Microsoft.Common.Section",
             "label": "Integration Configuration",
             "elements": [
               {
+                "name": "subscriptionsList",
+                "type": "Microsoft.Common.DropDown",
+                "label": "Subscriptions to monitor",
+                "toolTip": "The list of subscriptions to monitor",
+                "filterPlaceholder": "Select one or more subscriptions to monitor",
+                "filter": true,
+                "multiselect": true,
+                "selectAll": true,
+                "defaultValue": "[map(filter(steps('basics').armio.value,(i) => and(not(equals(i.type,'Microsoft.Management/managementGroups')),not(and(equals(i.properties.permissions,'noaccess'),equals(i.properties.inheritedPermissions,'noaccess'))))),(item) => item.properties.displayName)]",
+                "constraints": {
+                  "allowedValues": "[map(filter(steps('basics').armio.value, (i)=>and(   not(equals(i.type, 'Microsoft.Management/managementGroups')),   not(and(equals(i.properties.permissions, 'noaccess'),equals(i.properties.inheritedPermissions, 'noaccess')))  )), (item)=> parse(concat('{\"label\":\"', item.properties.displayName, '\",\"value\":\"', item.name, '\"}')))]",
+                  "required": false
+                },
+                "visible": true
+              },
+              {
                 "name": "textBlock1",
                 "type": "Microsoft.Common.TextBlock",
                 "visible": true,
                 "options": {
-                  "text": "Metrics will be collected for all resoures, except Virtual Machines, Virtual Machine Scale Sets and App Service Plans which can be filtered by tags."
+                  "text": "Metrics will be collected for all Azure resources by default."
                 }
               },
               {
@@ -189,7 +205,11 @@
                 "type": "Microsoft.Common.TextBlock",
                 "visible": true,
                 "options": {
-                  "text": "Optionally limit metrics collection to Virtual Machines, Virtual Machine Scale Sets and App Service Plans to hosts using tags."
+                  "text": "Optionally, you can limit metric collection for Virtual Machines, Virtual Machine Scale Sets and App Service Plans using tags in order to control your Datadog costs.",
+                  "link": {
+                    "label": "Learn more",
+                    "uri": "https://docs.datadoghq.com/account_management/billing/azure/"
+                  }
                 }
               },
               {
@@ -221,23 +241,7 @@
                 "type": "Microsoft.Common.CheckBox",
                 "label": "Custom Metrics",
                 "toolTip": "Whether or not to use custom metrics"
-              },
-              {
-                "name": "subscriptionsList",
-                "type": "Microsoft.Common.DropDown",
-                "label": "Subscriptions to monitor",
-                "toolTip": "The list of subscriptions to monitor",
-                "filterPlaceholder": "Select one or more subscriptions to monitor",
-                "filter": true,
-                "multiselect": true,
-                "selectAll": true,
-                "defaultValue": "[map(filter(steps('basics').armio.value,(i) => and(not(equals(i.type,'Microsoft.Management/managementGroups')),not(and(equals(i.properties.permissions,'noaccess'),equals(i.properties.inheritedPermissions,'noaccess'))))),(item) => item.properties.displayName)]",
-                "constraints": {
-                  "allowedValues": "[map(filter(steps('basics').armio.value, (i)=>and(   not(equals(i.type, 'Microsoft.Management/managementGroups')),   not(and(equals(i.properties.permissions, 'noaccess'),equals(i.properties.inheritedPermissions, 'noaccess')))  )), (item)=> parse(concat('{\"label\":\"', item.properties.displayName, '\",\"value\":\"', item.name, '\"}')))]",
-                  "required": false
-                },
-                "visible": true
-          }
+              }
             ],
             "visible": true
           }

--- a/azure/deploy-to-azure/azure-integration/azuredeploy-managementgroups.json
+++ b/azure/deploy-to-azure/azure-integration/azuredeploy-managementgroups.json
@@ -58,6 +58,13 @@
                 "description": "Filter to include/exclude hosts"
             }
         },
+        "appFilters": {
+            "defaultValue": "",
+            "type": "String",
+            "metadata": {
+                "description": "Filter to include/exclude app_service_plan"
+            }
+        },
         "automute": {
             "defaultValue": true,
             "type": "Bool",
@@ -144,6 +151,9 @@
                     "hostFilters": {
                         "value": "[parameters('hostFilters')]"
                     },
+                    "appFilters": {
+                        "value": "[parameters('appFilters')]"
+                    },
                     "automute": {
                         "value": "[parameters('automute')]"
                     },
@@ -183,6 +193,9 @@
                             "type": "secureString"
                         },
                         "hostFilters": {
+                            "type": "string"
+                        },
+                        "appFilters":{
                             "type": "string"
                         },
                         "automute": {
@@ -231,10 +244,6 @@
                                         "secureValue": "[parameters('datadogApiKey')]"
                                     },
                                     {
-                                        "name": "hostFilters",
-                                        "value": "[parameters('hostFilters')]"
-                                    },
-                                    {
                                         "name": "automute",
                                         "value": "[parameters('automute')]"
                                     },
@@ -264,6 +273,7 @@
                             }
                         },
                         {
+                            "condition": "[not(empty(parameters('hostFilters')))]",
                             "type": "Microsoft.Resources/deploymentScripts",
                             "apiVersion": "2020-10-01",
                             "name": "[concat('datadog-host-filter-script-', parameters('newguid'))]",
@@ -310,6 +320,55 @@
                                 "azPowerShellVersion": "8.1",
                                 "scriptContent": "Invoke-WebRequest -SkipCertificateCheck -ContentType \"application/json\" -Method Post -Uri \"https://api.$Env:datadogSite/api/v1/integration/azure/filtering\" -Headers @{\"Accept\"=\"application/json\"; \"DD-APPLICATION-KEY\"=$Env:datadogApplicationKey; \"DD-API-KEY\"=$Env:datadogApiKey} -Body (@{\"client_id\"=$Env:clientId; \"tenant_id\"=$Env:tenantName; \"namespace\"=$Env:namespace; \"filters\"=$Env:hostFilters} | ConvertTo-Json )"
                             }
+                        },
+                        {
+                            "condition": "[not(empty(parameters('appFilters')))]",
+                            "type": "Microsoft.Resources/deploymentScripts",
+                            "apiVersion": "2020-10-01",
+                            "name": "[concat('datadog-app-filter-script-', parameters('newguid'))]",
+                            "location": "[parameters('location')]",
+                            "kind": "AzurePowerShell",
+                            "dependsOn": [
+                                "[resourceId('Microsoft.Resources/deploymentScripts', concat('datadog-integration-script-', parameters('newguid')))]"
+                            ],
+                            "properties": {
+                                "environmentVariables": [
+                                    {
+                                        "name": "datadogApplicationKey",
+                                        "secureValue": "[parameters('datadogApplicationKey')]"
+                                    },
+                                    {
+                                        "name": "datadogApiKey",
+                                        "secureValue": "[parameters('datadogApiKey')]"
+                                    },
+                                    {
+                                        "name": "datadogSite",
+                                        "value": "[parameters('datadogSite')]"
+                                    },
+                                    {
+                                        "name": "appFilters",
+                                        "value": "[parameters('appFilters')]"
+                                    },
+                                    {
+                                        "name": "namespace",
+                                        "value": "app_service_plan"
+                                    },
+                                    {
+                                        "name": "clientId",
+                                        "value": "[parameters('servicePrincipalClientId')]"
+                                    },
+                                    {
+                                        "name": "tenantName",
+                                        "value": "[subscription().tenantId]"
+                                    }
+                                ],
+                                "retentionInterval": "PT1H",
+                                "timeout": "PT2M",
+                                "containerSettings": {},
+                                "cleanupPreference": "Always",
+                                "azPowerShellVersion": "8.1",
+                                "scriptContent": "Invoke-WebRequest -SkipCertificateCheck -ContentType \"application/json\" -Method Post -Uri \"https://api.$Env:datadogSite/api/v1/integration/azure/filtering\" -Headers @{\"Accept\"=\"application/json\"; \"DD-APPLICATION-KEY\"=$Env:datadogApplicationKey; \"DD-API-KEY\"=$Env:datadogApiKey} -Body (@{\"client_id\"=$Env:clientId; \"tenant_id\"=$Env:tenantName; \"namespace\"=$Env:namespace; \"filters\"=$Env:appFilters} | ConvertTo-Json )"
+                            }
                         }
                     ]
                 }
@@ -318,10 +377,5 @@
             "resourceGroup": "[parameters('resourcegroup')]"
         }
     ],
-    "outputs": {
-        "mysubscription": {
-            "type": "string",
-            "value": "[parameters('subscriptionID')]"
-        }
-    }
+    "outputs": {}
 }

--- a/azure/deploy-to-azure/azure-integration/azuredeploy-managementgroups.json
+++ b/azure/deploy-to-azure/azure-integration/azuredeploy-managementgroups.json
@@ -260,7 +260,55 @@
                                 "containerSettings": {},
                                 "cleanupPreference": "Always",
                                 "azPowerShellVersion": "8.1",
-                                "scriptContent": "Invoke-WebRequest -SkipCertificateCheck -ContentType \"application/json\" -Method Post -Uri \"https://api.$Env:datadogSite/api/v1/integration/azure\" -Headers @{\"Accept\"=\"application/json\"; \"DD-APPLICATION-KEY\"=$Env:datadogApplicationKey; \"DD-API-KEY\"=$Env:datadogApiKey} -Body (@{\"automute\"=[bool]::Parse($Env:automute); \"cspm_enabled\"=[bool]::Parse($Env:cspm_enabled); \"custom_metrics_enabled\"=[bool]::Parse($Env:custom_metrics_enabled); \"client_id\"=$Env:clientId; \"client_secret\"=$Env:clientSecret; \"host_filters\"=$Env:hostFilters; \"tenant_name\"=$Env:tenantName} | ConvertTo-Json )"
+                                "scriptContent": "Invoke-WebRequest -SkipCertificateCheck -ContentType \"application/json\" -Method Post -Uri \"https://api.$Env:datadogSite/api/v1/integration/azure\" -Headers @{\"Accept\"=\"application/json\"; \"DD-APPLICATION-KEY\"=$Env:datadogApplicationKey; \"DD-API-KEY\"=$Env:datadogApiKey} -Body (@{\"automute\"=[bool]::Parse($Env:automute); \"cspm_enabled\"=[bool]::Parse($Env:cspm_enabled); \"custom_metrics_enabled\"=[bool]::Parse($Env:custom_metrics_enabled); \"client_id\"=$Env:clientId; \"client_secret\"=$Env:clientSecret; \"tenant_name\"=$Env:tenantName} | ConvertTo-Json )"
+                            }
+                        },
+                        {
+                            "type": "Microsoft.Resources/deploymentScripts",
+                            "apiVersion": "2020-10-01",
+                            "name": "[concat('datadog-host-filter-script-', parameters('newguid'))]",
+                            "location": "[parameters('location')]",
+                            "kind": "AzurePowerShell",
+                            "dependsOn": [
+                                "[resourceId('Microsoft.Resources/deploymentScripts', concat('datadog-integration-script-', parameters('newguid')))]"
+                            ],
+                            "properties": {
+                                "environmentVariables": [
+                                    {
+                                        "name": "datadogApplicationKey",
+                                        "secureValue": "[parameters('datadogApplicationKey')]"
+                                    },
+                                    {
+                                        "name": "datadogApiKey",
+                                        "secureValue": "[parameters('datadogApiKey')]"
+                                    },
+                                    {
+                                        "name": "datadogSite",
+                                        "value": "[parameters('datadogSite')]"
+                                    },
+                                    {
+                                        "name": "hostFilters",
+                                        "value": "[parameters('hostFilters')]"
+                                    },
+                                    {
+                                        "name": "namespace",
+                                        "value": "host"
+                                    },
+                                    {
+                                        "name": "clientId",
+                                        "value": "[parameters('servicePrincipalClientId')]"
+                                    },
+                                    {
+                                        "name": "tenantName",
+                                        "value": "[subscription().tenantId]"
+                                    }
+                                ],
+                                "retentionInterval": "PT1H",
+                                "timeout": "PT2M",
+                                "containerSettings": {},
+                                "cleanupPreference": "Always",
+                                "azPowerShellVersion": "8.1",
+                                "scriptContent": "Invoke-WebRequest -SkipCertificateCheck -ContentType \"application/json\" -Method Post -Uri \"https://api.$Env:datadogSite/api/v1/integration/azure/filtering\" -Headers @{\"Accept\"=\"application/json\"; \"DD-APPLICATION-KEY\"=$Env:datadogApplicationKey; \"DD-API-KEY\"=$Env:datadogApiKey} -Body (@{\"client_id\"=$Env:clientId; \"tenant_id\"=$Env:tenantName; \"namespace\"=$Env:namespace; \"filters\"=$Env:hostFilters} | ConvertTo-Json )"
                             }
                         }
                     ]
@@ -270,5 +318,10 @@
             "resourceGroup": "[parameters('resourcegroup')]"
         }
     ],
-    "outputs": {}
+    "outputs": {
+        "mysubscription": {
+            "type": "string",
+            "value": "[parameters('subscriptionID')]"
+        }
+    }
 }

--- a/azure/deploy-to-azure/azure-integration/azuredeploy-managementgroups.json
+++ b/azure/deploy-to-azure/azure-integration/azuredeploy-managementgroups.json
@@ -58,7 +58,7 @@
                 "description": "Filter to include/exclude hosts"
             }
         },
-        "appFilters": {
+        "appServicePlanFilters": {
             "defaultValue": "",
             "type": "String",
             "metadata": {
@@ -151,8 +151,8 @@
                     "hostFilters": {
                         "value": "[parameters('hostFilters')]"
                     },
-                    "appFilters": {
-                        "value": "[parameters('appFilters')]"
+                    "appServicePlanFilters": {
+                        "value": "[parameters('appServicePlanFilters')]"
                     },
                     "automute": {
                         "value": "[parameters('automute')]"
@@ -195,7 +195,7 @@
                         "hostFilters": {
                             "type": "string"
                         },
-                        "appFilters":{
+                        "appServicePlanFilters":{
                             "type": "string"
                         },
                         "automute": {
@@ -322,7 +322,7 @@
                             }
                         },
                         {
-                            "condition": "[not(empty(parameters('appFilters')))]",
+                            "condition": "[not(empty(parameters('appServicePlanFilters')))]",
                             "type": "Microsoft.Resources/deploymentScripts",
                             "apiVersion": "2020-10-01",
                             "name": "[concat('datadog-app-filter-script-', parameters('newguid'))]",
@@ -346,8 +346,8 @@
                                         "value": "[parameters('datadogSite')]"
                                     },
                                     {
-                                        "name": "appFilters",
-                                        "value": "[parameters('appFilters')]"
+                                        "name": "appServicePlanFilters",
+                                        "value": "[parameters('appServicePlanFilters')]"
                                     },
                                     {
                                         "name": "namespace",
@@ -367,7 +367,7 @@
                                 "containerSettings": {},
                                 "cleanupPreference": "Always",
                                 "azPowerShellVersion": "8.1",
-                                "scriptContent": "Invoke-WebRequest -SkipCertificateCheck -ContentType \"application/json\" -Method Post -Uri \"https://api.$Env:datadogSite/api/v1/integration/azure/filtering\" -Headers @{\"Accept\"=\"application/json\"; \"DD-APPLICATION-KEY\"=$Env:datadogApplicationKey; \"DD-API-KEY\"=$Env:datadogApiKey} -Body (@{\"client_id\"=$Env:clientId; \"tenant_id\"=$Env:tenantName; \"namespace\"=$Env:namespace; \"filters\"=$Env:appFilters} | ConvertTo-Json )"
+                                "scriptContent": "Invoke-WebRequest -SkipCertificateCheck -ContentType \"application/json\" -Method Post -Uri \"https://api.$Env:datadogSite/api/v1/integration/azure/filtering\" -Headers @{\"Accept\"=\"application/json\"; \"DD-APPLICATION-KEY\"=$Env:datadogApplicationKey; \"DD-API-KEY\"=$Env:datadogApiKey} -Body (@{\"client_id\"=$Env:clientId; \"tenant_id\"=$Env:tenantName; \"namespace\"=$Env:namespace; \"filters\"=$Env:appServicePlanFilters} | ConvertTo-Json )"
                             }
                         }
                     ]

--- a/azure/deploy-to-azure/azure-integration/azuredeploy.json
+++ b/azure/deploy-to-azure/azure-integration/azuredeploy.json
@@ -176,14 +176,6 @@
                         "secureValue": "[parameters('datadogApiKey')]"
                     },
                     {
-                        "name": "hostFilters",
-                        "value": "[parameters('hostFilters')]"
-                    },
-                    {
-                        "name": "appFilters",
-                        "value": "[parameters('appFilters')]"
-                    },
-                    {
                         "name": "automute",
                         "value": "[parameters('automute')]"
                     },
@@ -209,7 +201,7 @@
                 "containerSettings": {},
                 "cleanupPreference": "Always",
                 "azPowerShellVersion": "8.1",
-                "scriptContent": "Invoke-WebRequest -SkipCertificateCheck -ContentType \"application/json\" -Method Post -Uri \"https://api.$Env:datadogSite/api/v1/integration/azure\" -Headers @{\"Accept\"=\"application/json\"; \"DD-APPLICATION-KEY\"=$Env:datadogApplicationKey; \"DD-API-KEY\"=$Env:datadogApiKey} -Body (@{\"automute\"=[bool]::Parse($Env:automute); \"cspm_enabled\"=[bool]::Parse($Env:cspm_enabled); \"custom_metrics_enabled\"=[bool]::Parse($Env:custom_metrics_enabled); \"client_id\"=$Env:clientId; \"client_secret\"=$Env:clientSecret; \"host_filters\"=$Env:hostFilters; \"tenant_name\"=$Env:tenantName} | ConvertTo-Json )"
+                "scriptContent": "Invoke-WebRequest -SkipCertificateCheck -ContentType \"application/json\" -Method Post -Uri \"https://api.$Env:datadogSite/api/v1/integration/azure\" -Headers @{\"Accept\"=\"application/json\"; \"DD-APPLICATION-KEY\"=$Env:datadogApplicationKey; \"DD-API-KEY\"=$Env:datadogApiKey} -Body (@{\"automute\"=[bool]::Parse($Env:automute); \"cspm_enabled\"=[bool]::Parse($Env:cspm_enabled); \"custom_metrics_enabled\"=[bool]::Parse($Env:custom_metrics_enabled); \"client_id\"=$Env:clientId; \"client_secret\"=$Env:clientSecret; \"tenant_name\"=$Env:tenantName} | ConvertTo-Json )"
             }
         },
         {

--- a/azure/deploy-to-azure/azure-integration/azuredeploy.json
+++ b/azure/deploy-to-azure/azure-integration/azuredeploy.json
@@ -53,6 +53,13 @@
                 "description": "Filter to include/exclude hosts"
             }
         },
+        "appFilters": {
+            "defaultValue": "",
+            "type": "String",
+            "metadata": {
+                "description": "Filter to include/exclude app_service_plan"
+            }
+        },
         "automute": {
             "type": "bool",
             "defaultValue": true,
@@ -173,6 +180,10 @@
                         "value": "[parameters('hostFilters')]"
                     },
                     {
+                        "name": "appFilters",
+                        "value": "[parameters('appFilters')]"
+                    },
+                    {
                         "name": "automute",
                         "value": "[parameters('automute')]"
                     },
@@ -199,6 +210,104 @@
                 "cleanupPreference": "Always",
                 "azPowerShellVersion": "8.1",
                 "scriptContent": "Invoke-WebRequest -SkipCertificateCheck -ContentType \"application/json\" -Method Post -Uri \"https://api.$Env:datadogSite/api/v1/integration/azure\" -Headers @{\"Accept\"=\"application/json\"; \"DD-APPLICATION-KEY\"=$Env:datadogApplicationKey; \"DD-API-KEY\"=$Env:datadogApiKey} -Body (@{\"automute\"=[bool]::Parse($Env:automute); \"cspm_enabled\"=[bool]::Parse($Env:cspm_enabled); \"custom_metrics_enabled\"=[bool]::Parse($Env:custom_metrics_enabled); \"client_id\"=$Env:clientId; \"client_secret\"=$Env:clientSecret; \"host_filters\"=$Env:hostFilters; \"tenant_name\"=$Env:tenantName} | ConvertTo-Json )"
+            }
+        },
+        {
+            "condition": "[not(empty(parameters('hostFilters')))]",
+            "type": "Microsoft.Resources/deploymentScripts",
+            "apiVersion": "2020-10-01",
+            "name": "[concat('datadog-host-filter-script-', parameters('newguid'))]",
+            "location": "[parameters('location')]",
+            "kind": "AzurePowerShell",
+            "dependsOn": [
+                "[resourceId('Microsoft.Resources/deploymentScripts', concat('datadog-integration-script-', parameters('newguid')))]"
+            ],
+            "properties": {
+                "environmentVariables": [
+                    {
+                        "name": "datadogApplicationKey",
+                        "secureValue": "[parameters('datadogApplicationKey')]"
+                    },
+                    {
+                        "name": "datadogApiKey",
+                        "secureValue": "[parameters('datadogApiKey')]"
+                    },
+                    {
+                        "name": "datadogSite",
+                        "value": "[parameters('datadogSite')]"
+                    },
+                    {
+                        "name": "hostFilters",
+                        "value": "[parameters('hostFilters')]"
+                    },
+                    {
+                        "name": "namespace",
+                        "value": "host"
+                    },
+                    {
+                        "name": "clientId",
+                        "value": "[parameters('servicePrincipalClientId')]"
+                    },
+                    {
+                        "name": "tenantName",
+                        "value": "[subscription().tenantId]"
+                    }
+                ],
+                "retentionInterval": "PT1H",
+                "timeout": "PT2M",
+                "containerSettings": {},
+                "cleanupPreference": "Always",
+                "azPowerShellVersion": "8.1",
+                "scriptContent": "Invoke-WebRequest -SkipCertificateCheck -ContentType \"application/json\" -Method Post -Uri \"https://api.$Env:datadogSite/api/v1/integration/azure/filtering\" -Headers @{\"Accept\"=\"application/json\"; \"DD-APPLICATION-KEY\"=$Env:datadogApplicationKey; \"DD-API-KEY\"=$Env:datadogApiKey} -Body (@{\"client_id\"=$Env:clientId; \"tenant_id\"=$Env:tenantName; \"namespace\"=$Env:namespace; \"filters\"=$Env:hostFilters} | ConvertTo-Json )"
+            }
+        },
+        {
+            "condition": "[not(empty(parameters('appFilters')))]",
+            "type": "Microsoft.Resources/deploymentScripts",
+            "apiVersion": "2020-10-01",
+            "name": "[concat('datadog-app-filter-script-', parameters('newguid'))]",
+            "location": "[parameters('location')]",
+            "kind": "AzurePowerShell",
+            "dependsOn": [
+                "[resourceId('Microsoft.Resources/deploymentScripts', concat('datadog-integration-script-', parameters('newguid')))]"
+            ],
+            "properties": {
+                "environmentVariables": [
+                    {
+                        "name": "datadogApplicationKey",
+                        "secureValue": "[parameters('datadogApplicationKey')]"
+                    },
+                    {
+                        "name": "datadogApiKey",
+                        "secureValue": "[parameters('datadogApiKey')]"
+                    },
+                    {
+                        "name": "datadogSite",
+                        "value": "[parameters('datadogSite')]"
+                    },
+                    {
+                        "name": "appFilters",
+                        "value": "[parameters('appFilters')]"
+                    },
+                    {
+                        "name": "namespace",
+                        "value": "app_service_plan"
+                    },
+                    {
+                        "name": "clientId",
+                        "value": "[parameters('servicePrincipalClientId')]"
+                    },
+                    {
+                        "name": "tenantName",
+                        "value": "[subscription().tenantId]"
+                    }
+                ],
+                "retentionInterval": "PT1H",
+                "timeout": "PT2M",
+                "containerSettings": {},
+                "cleanupPreference": "Always",
+                "azPowerShellVersion": "8.1",
+                "scriptContent": "Invoke-WebRequest -SkipCertificateCheck -ContentType \"application/json\" -Method Post -Uri \"https://api.$Env:datadogSite/api/v1/integration/azure/filtering\" -Headers @{\"Accept\"=\"application/json\"; \"DD-APPLICATION-KEY\"=$Env:datadogApplicationKey; \"DD-API-KEY\"=$Env:datadogApiKey} -Body (@{\"client_id\"=$Env:clientId; \"tenant_id\"=$Env:tenantName; \"namespace\"=$Env:namespace; \"filters\"=$Env:appFilters} | ConvertTo-Json )"
             }
         }
     ],

--- a/azure/deploy-to-azure/azure-integration/azuredeploy.json
+++ b/azure/deploy-to-azure/azure-integration/azuredeploy.json
@@ -53,7 +53,7 @@
                 "description": "Filter to include/exclude hosts"
             }
         },
-        "appFilters": {
+        "appServicePlanFilters": {
             "defaultValue": "",
             "type": "String",
             "metadata": {
@@ -254,7 +254,7 @@
             }
         },
         {
-            "condition": "[not(empty(parameters('appFilters')))]",
+            "condition": "[not(empty(parameters('appServicePlanFilters')))]",
             "type": "Microsoft.Resources/deploymentScripts",
             "apiVersion": "2020-10-01",
             "name": "[concat('datadog-app-filter-script-', parameters('newguid'))]",
@@ -278,8 +278,8 @@
                         "value": "[parameters('datadogSite')]"
                     },
                     {
-                        "name": "appFilters",
-                        "value": "[parameters('appFilters')]"
+                        "name": "appServicePlanFilters",
+                        "value": "[parameters('appServicePlanFilters')]"
                     },
                     {
                         "name": "namespace",
@@ -299,7 +299,7 @@
                 "containerSettings": {},
                 "cleanupPreference": "Always",
                 "azPowerShellVersion": "8.1",
-                "scriptContent": "Invoke-WebRequest -SkipCertificateCheck -ContentType \"application/json\" -Method Post -Uri \"https://api.$Env:datadogSite/api/v1/integration/azure/filtering\" -Headers @{\"Accept\"=\"application/json\"; \"DD-APPLICATION-KEY\"=$Env:datadogApplicationKey; \"DD-API-KEY\"=$Env:datadogApiKey} -Body (@{\"client_id\"=$Env:clientId; \"tenant_id\"=$Env:tenantName; \"namespace\"=$Env:namespace; \"filters\"=$Env:appFilters} | ConvertTo-Json )"
+                "scriptContent": "Invoke-WebRequest -SkipCertificateCheck -ContentType \"application/json\" -Method Post -Uri \"https://api.$Env:datadogSite/api/v1/integration/azure/filtering\" -Headers @{\"Accept\"=\"application/json\"; \"DD-APPLICATION-KEY\"=$Env:datadogApplicationKey; \"DD-API-KEY\"=$Env:datadogApiKey} -Body (@{\"client_id\"=$Env:clientId; \"tenant_id\"=$Env:tenantName; \"namespace\"=$Env:namespace; \"filters\"=$Env:appServicePlanFilters} | ConvertTo-Json )"
             }
         }
     ],


### PR DESCRIPTION
Saving host filters and app_service_plan filters are each a separate API call to app registration call.
These 2 filter request are dependent on app registration request succeeding and they only happen if the filter values are provided.

Corresponding UIDefinition.json changes.