### PR TITLE
Add maximumThroughputUnits option to template

### DIFF
--- a/azure/deploy-to-azure/event_hub.json
+++ b/azure/deploy-to-azure/event_hub.json
@@ -28,6 +28,20 @@
       "metadata": {
         "description": "Location for all resources."
       }
+    },
+    "isAutoInflateEnabled": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+          "description": "Whether or not to use Auto Inflate"
+      }
+    },
+    "maximumThroughputUnits": {
+      "type": "int",
+      "defaultValue": 0,
+      "metadata": {
+        "description": "The maximum number of throughput units"
+      }
     }
   },
   "resources": [
@@ -42,7 +56,10 @@
         "capacity": 1
       },
       "tags": {},
-      "properties": {},
+      "properties": {
+        "isAutoInflateEnabled":  "[parameters('isAutoInflateEnabled')]",
+        "maximumThroughputUnits": "[parameters('maximumThroughputUnits')]"
+      },
       "resources": [
         {
           "apiVersion": "2017-04-01",

--- a/azure/deploy-to-azure/parent_template.json
+++ b/azure/deploy-to-azure/parent_template.json
@@ -77,6 +77,20 @@
         "metadata": {
             "description": "The name of the diagnostic setting if sending Activity Logs"
         }
+    },
+    "isAutoInflateEnabled": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+          "description": "Whether or not to use Auto Inflate"
+      }
+    },
+    "maximumThroughputUnits": {
+      "type": "int",
+      "defaultValue": 0,
+      "metadata": {
+        "description": "The maximum number of throughput units"
+      }
     }
   },
   "variables": {
@@ -107,6 +121,12 @@
           },
           "location": {
             "value": "[parameters('resourcesLocation')]"
+          },
+          "isAutoInflateEnabled": {
+            "value": "[parameters('isAutoInflateEnabled')]"
+          },
+          "maximumThroughputUnits": {
+            "value": "[parameters('maximumThroughputUnits')]"
           }
         }
       }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Allow users to set the maximumThroughputUnits option in Eventhub

### Motivation

Set limit to Throughput when creating DD integration with Eventhub

### Testing Guidelines

installed in my test env 


### Types of changes

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [X] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
