### PR TITLE
[AWSC] Updating Python version 3.8 -> 3.9

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
     steps:
       - name: Checkout source
         uses: actions/checkout@v3

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -5,6 +5,7 @@ on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       max-parallel: 4
       matrix:

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
     steps:
       - name: Checkout source
         uses: actions/checkout@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.7
+          python-version: 3.9
 
       - name: Install pip
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
     steps:
       - name: Checkout source
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
     steps:
       - name: Checkout source
         uses: actions/checkout@v3

--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -114,7 +114,7 @@ resource "aws_cloudformation_stack" "datadog_forwarder" {
 
 If you can't install the Forwarder using the provided CloudFormation template, you can install the Forwarder manually following the steps below. Feel free to open an issue or pull request to let us know if there is anything we can improve to make the template work for you.
 
-1. Create a Python 3.8 Lambda function using `aws-dd-forwarder-<VERSION>.zip` from the latest [releases][101].
+1. Create a Python 3.9 Lambda function using `aws-dd-forwarder-<VERSION>.zip` from the latest [releases][101].
 2. Save your [Datadog API key][102] in AWS Secrets Manager, set environment variable `DD_API_KEY_SECRET_ARN` with the secret ARN on the Lambda function, and add the `secretsmanager:GetSecretValue` permission to the Lambda execution role.
 3. If you need to forward logs from S3 buckets, add the `s3:GetObject` permission to the Lambda execution role.
 4. Set the environment variable `DD_ENHANCED_METRICS` to `false` on the Forwarder. This stops the Forwarder from generating enhanced metrics itself, but it will still forward custom metrics from other lambdas.
@@ -135,6 +135,10 @@ If you can't install the Forwarder using the provided CloudFormation template, y
 1. Find the [datadog-forwarder (if you didn't rename it)][5] CloudFormation stack. If you installed the Forwarder as part of the [Datadog AWS integration stack][6], make sure to update the nested Forwarder stack instead of the root stack.
 2. Find the actual Forwarder Lambda function from the CloudFormation stack's "Resources" tab, navigate to its configuration page. Note down the value of the tag `dd_forwarder_version`, such as `3.3.0`, in case you run into issues with the new version and need to rollback.
 3. Update the stack using template `https://datadog-cloudformation-template.s3.amazonaws.com/aws/forwarder/latest.yaml`. You can also replace `latest` with a specific version, such as `3.0.2.yaml`, if needed. Make sure to review the changesets before applying the update.
+
+### Upgrade an older version to +3.74.0
+
+Since version 3.74.0 the Lambda function has been updated to require **Python 3.9**. If upgrading an older forwarder installation to 3.74.0 or above, ensure the AWS Lambda function is configured to use Python 3.9
 
 ### Upgrade an older version to +3.49.0
 

--- a/aws/logs_monitoring/setup.py
+++ b/aws/logs_monitoring/setup.py
@@ -14,9 +14,10 @@ setup(
     classifiers=[
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     keywords="datadog aws lambda layer",
-    python_requires=">=3.7, <3.9",
+    python_requires=">=3.7, <3.10",
     install_requires=["datadog-lambda==3.39.0", "requests-futures==1.0.0"],
     extras_require={
         "dev": ["nose2==0.9.1", "flake8==3.7.9", "requests==2.22.0", "boto3==1.10.33"]

--- a/aws/logs_monitoring/setup.py
+++ b/aws/logs_monitoring/setup.py
@@ -12,7 +12,6 @@ setup(
     author="Datadog, Inc.",
     author_email="dev@datadoghq.com",
     classifiers=[
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
     ],

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -478,7 +478,7 @@ Resources:
 
       MemorySize:
         Ref: MemorySize
-      Runtime: python3.8
+      Runtime: python3.9
       Timeout:
         Ref: Timeout
       Tags:
@@ -876,7 +876,7 @@ Resources:
     Properties:
       Description: Copies Datadog Forwarder zip to the destination S3 bucket
       Handler: index.handler
-      Runtime: python3.8
+      Runtime: python3.9
       Timeout: 300
       Code:
         ZipFile: |

--- a/aws/logs_monitoring/tools/add_new_region.sh
+++ b/aws/logs_monitoring/tools/add_new_region.sh
@@ -12,7 +12,7 @@ set -e
 
 OLD_REGION='us-east-1'
 
-PYTHON_VERSIONS_FOR_AWS_CLI=("python3.8")
+PYTHON_VERSIONS_FOR_AWS_CLI=("python3.9")
 LAYER_NAMES=("Datadog-Forwarder")
 NEW_REGION=$1
 

--- a/aws/logs_monitoring/tools/build_bundle.sh
+++ b/aws/logs_monitoring/tools/build_bundle.sh
@@ -22,7 +22,7 @@ else
     VERSION=$1
 fi
 
-PYTHON_VERSION="${PYTHON_VERSION:-3.8}"
+PYTHON_VERSION="${PYTHON_VERSION:-3.9}"
 FORWARDER_PREFIX="aws-dd-forwarder"
 FORWARDER_DIR="../.forwarder"
 

--- a/aws/logs_monitoring/tools/integration_tests/cache_test_lambda/serverless.yml
+++ b/aws/logs_monitoring/tools/integration_tests/cache_test_lambda/serverless.yml
@@ -1,7 +1,7 @@
 service: integration-tests
 provider:
   name: aws
-  runtime: python3.8
+  runtime: python3.9
 
 functions:
   cache_test_lambda:

--- a/aws/logs_monitoring/tools/integration_tests/docker-compose.yml
+++ b/aws/logs_monitoring/tools/integration_tests/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   forwarder:
-    image: datadog-log-forwarder:${PYTHON_RUNTIME:-python3.9}
+    image: datadog-log-forwarder:${PYTHON_RUNTIME}
     command: lambda_function.lambda_handler
     environment:
       AWS_ACCOUNT_ID: ${AWS_ACCOUNT_ID:-0000000000}

--- a/aws/logs_monitoring/tools/integration_tests/docker-compose.yml
+++ b/aws/logs_monitoring/tools/integration_tests/docker-compose.yml
@@ -1,8 +1,8 @@
-version: "3.8"
+version: "3.9"
 
 services:
   forwarder:
-    image: datadog-log-forwarder:${PYTHON_RUNTIME:-python3.8}
+    image: datadog-log-forwarder:${PYTHON_RUNTIME:-python3.9}
     command: lambda_function.lambda_handler
     environment:
       AWS_ACCOUNT_ID: ${AWS_ACCOUNT_ID:-0000000000}

--- a/aws/logs_monitoring/tools/integration_tests/integration_tests.sh
+++ b/aws/logs_monitoring/tools/integration_tests/integration_tests.sh
@@ -8,6 +8,7 @@
 set -e
 
 PYTHON_VERSION="python3.9"
+PYTHON_SHORT_VERSION="3.9"
 SKIP_FORWARDER_BUILD=false
 UPDATE_SNAPSHOTS=false
 LOG_LEVEL=info
@@ -42,6 +43,7 @@ do
 		# Must be 3.8 or 3.9
 		-v=*|--python-version=*)
 		PYTHON_VERSION="python${arg#*=}"
+		PYTHON_SHORT_VERSION="${arg#*=}"
 		shift
 		;;
 
@@ -153,7 +155,7 @@ if [ $PYTHON_VERSION == "python3.8" ]; then
 	echo "Building Docker Image for Forwarder"
 	docker buildx build --platform linux/amd64 --file "${INTEGRATION_TESTS_DIR}/forwarder/Dockerfile" -t "datadog-log-forwarder:$PYTHON_VERSION" ../../.forwarder --no-cache \
 			--build-arg forwarder='aws-dd-forwarder-0.0.0' \
-			--build-arg image="lambci/lambda:${PYTHON_VERSION}"
+			--build-arg image="mlupin/docker-lambda:${PYTHON_VERSION}-build-x86_64"
 fi
 # --build-arg image="lambci/lambda:${PYTHON_VERSION}"
 # Build Docker image of Forwarder for tests 3.9 compatibility
@@ -162,7 +164,7 @@ if [ $PYTHON_VERSION == "python3.9" ]; then
 	echo "Building Docker Image for Forwarder"
 	docker buildx build --platform linux/amd64 --file "${INTEGRATION_TESTS_DIR}/forwarder/Dockerfile" -t "datadog-log-forwarder:$PYTHON_VERSION" ../../.forwarder --no-cache \
 			--build-arg forwarder='aws-dd-forwarder-0.0.0' \
-			--build-arg image="public.ecr.aws/lambda/python:3.9-x86_64"
+			--build-arg image="public.ecr.aws/lambda/python:${PYTHON_SHORT_VERSION}-x86_64"
 fi
 
 echo "Running integration tests for ${PYTHON_VERSION}"

--- a/aws/logs_monitoring/tools/integration_tests/integration_tests.sh
+++ b/aws/logs_monitoring/tools/integration_tests/integration_tests.sh
@@ -152,7 +152,7 @@ cd $INTEGRATION_TESTS_DIR
 echo "Building Docker Image for Forwarder"
 docker buildx build --platform linux/amd64 --file "${INTEGRATION_TESTS_DIR}/forwarder/Dockerfile" -t "datadog-log-forwarder:$PYTHON_VERSION" ../../.forwarder --no-cache \
     --build-arg forwarder='aws-dd-forwarder-0.0.0' \
-    --build-arg image="lambci/lambda:${PYTHON_VERSION}"
+    --build-arg image="mlupin/docker-lambda:${PYTHON_VERSION}-build"
 
 echo "Running integration tests for ${PYTHON_VERSION}"
 LOG_LEVEL=${LOG_LEVEL} \

--- a/aws/logs_monitoring/tools/integration_tests/integration_tests.sh
+++ b/aws/logs_monitoring/tools/integration_tests/integration_tests.sh
@@ -43,7 +43,6 @@ do
 		# Must be 3.8 or 3.9
 		-v=*|--python-version=*)
 		PYTHON_VERSION="python${arg#*=}"
-		PYTHON_SHORT_VERSION="${arg#*=}"
 		shift
 		;;
 
@@ -150,15 +149,22 @@ fi
 
 cd $INTEGRATION_TESTS_DIR
 
-# Build Docker image of Forwarder
-# See https://github.com/lambci/lambci/issues/138
-echo "Building Docker Image for Forwarder with tag datadog-log-forwarder:$PYTHON_VERSION"
-docker buildx build --platform linux/amd64 --file "${INTEGRATION_TESTS_DIR}/forwarder/Dockerfile" -t "datadog-log-forwarder:$PYTHON_VERSION" ../../.forwarder --no-cache \
-		--build-arg forwarder='aws-dd-forwarder-0.0.0' \
-		--build-arg image="lambci/lambda:${PYTHON_VERSION}"
-
+if [ $PYTHON_VERSION == "python3.8" ]; then
+# Build Docker image of Forwarder for tests 3.8 compatibility
+	echo "Building Docker Image for Forwarder with tag datadog-log-forwarder:$PYTHON_VERSION"
+	docker buildx build --platform linux/amd64 --file "${INTEGRATION_TESTS_DIR}/forwarder/Dockerfile" -t "datadog-log-forwarder:$PYTHON_VERSION" ../../.forwarder --no-cache \
+    --build-arg forwarder='aws-dd-forwarder-0.0.0' \
+    --build-arg image="lambci/lambda:${PYTHON_VERSION}"
+fi
 # --build-arg image="lambci/lambda:${PYTHON_VERSION}"
-# --build-arg image="mlupin/docker-lambda:${PYTHON_VERSION}-build-x86_64"
+# Build Docker image of Forwarder for tests 3.9 compatibility
+# See https://github.com/lambci/lambci/issues/138
+if [ $PYTHON_VERSION == "python3.9" ]; then
+	echo "Building Docker Image for Forwarder with tag datadog-log-forwarder:$PYTHON_VERSION"
+	docker buildx build --platform linux/amd64 --file "${INTEGRATION_TESTS_DIR}/forwarder/Dockerfile" -t "datadog-log-forwarder:$PYTHON_VERSION" ../../.forwarder --no-cache \
+    --build-arg forwarder='aws-dd-forwarder-0.0.0' \
+    --build-arg image="mlupin/docker-lambda:${PYTHON_VERSION}-x86_64"
+fi
 
 echo "Running integration tests for ${PYTHON_VERSION}"
 LOG_LEVEL=${LOG_LEVEL} \

--- a/aws/logs_monitoring/tools/integration_tests/integration_tests.sh
+++ b/aws/logs_monitoring/tools/integration_tests/integration_tests.sh
@@ -150,22 +150,15 @@ fi
 
 cd $INTEGRATION_TESTS_DIR
 
-# Build Docker image of Forwarder for tests 3.8 compatibility
-if [ $PYTHON_VERSION == "python3.8" ]; then
-	echo "Building Docker Image for Forwarder with tag datadog-log-forwarder:$PYTHON_VERSION"
-	docker buildx build --platform linux/amd64 --file "${INTEGRATION_TESTS_DIR}/forwarder/Dockerfile" -t "datadog-log-forwarder:$PYTHON_VERSION" ../../.forwarder --no-cache \
-			--build-arg forwarder='aws-dd-forwarder-0.0.0' \
-			--build-arg image="mlupin/docker-lambda:${PYTHON_VERSION}-build-x86_64"
-fi
-# --build-arg image="lambci/lambda:${PYTHON_VERSION}"
-# Build Docker image of Forwarder for tests 3.9 compatibility
+# Build Docker image of Forwarder
 # See https://github.com/lambci/lambci/issues/138
-if [ $PYTHON_VERSION == "python3.9" ]; then
-	echo "Building Docker Image for Forwarder with tag datadog-log-forwarder:$PYTHON_VERSION"
-	docker buildx build --platform linux/amd64 --file "${INTEGRATION_TESTS_DIR}/forwarder/Dockerfile" -t "datadog-log-forwarder:$PYTHON_VERSION" ../../.forwarder --no-cache \
-			--build-arg forwarder='aws-dd-forwarder-0.0.0' \
-			--build-arg image="public.ecr.aws/lambda/python:${PYTHON_SHORT_VERSION}-x86_64"
-fi
+echo "Building Docker Image for Forwarder with tag datadog-log-forwarder:$PYTHON_VERSION"
+docker buildx build --platform linux/amd64 --file "${INTEGRATION_TESTS_DIR}/forwarder/Dockerfile" -t "datadog-log-forwarder:$PYTHON_VERSION" ../../.forwarder --no-cache \
+		--build-arg forwarder='aws-dd-forwarder-0.0.0' \
+		--build-arg image="lambci/lambda:${PYTHON_VERSION}"
+
+# --build-arg image="lambci/lambda:${PYTHON_VERSION}"
+# --build-arg image="mlupin/docker-lambda:${PYTHON_VERSION}-build-x86_64"
 
 echo "Running integration tests for ${PYTHON_VERSION}"
 LOG_LEVEL=${LOG_LEVEL} \

--- a/aws/logs_monitoring/tools/integration_tests/integration_tests.sh
+++ b/aws/logs_monitoring/tools/integration_tests/integration_tests.sh
@@ -152,7 +152,7 @@ cd $INTEGRATION_TESTS_DIR
 
 # Build Docker image of Forwarder for tests 3.8 compatibility
 if [ $PYTHON_VERSION == "python3.8" ]; then
-	echo "Building Docker Image for Forwarder"
+	echo "Building Docker Image for Forwarder with tag datadog-log-forwarder:$PYTHON_VERSION"
 	docker buildx build --platform linux/amd64 --file "${INTEGRATION_TESTS_DIR}/forwarder/Dockerfile" -t "datadog-log-forwarder:$PYTHON_VERSION" ../../.forwarder --no-cache \
 			--build-arg forwarder='aws-dd-forwarder-0.0.0' \
 			--build-arg image="mlupin/docker-lambda:${PYTHON_VERSION}-build-x86_64"
@@ -161,7 +161,7 @@ fi
 # Build Docker image of Forwarder for tests 3.9 compatibility
 # See https://github.com/lambci/lambci/issues/138
 if [ $PYTHON_VERSION == "python3.9" ]; then
-	echo "Building Docker Image for Forwarder"
+	echo "Building Docker Image for Forwarder with tag datadog-log-forwarder:$PYTHON_VERSION"
 	docker buildx build --platform linux/amd64 --file "${INTEGRATION_TESTS_DIR}/forwarder/Dockerfile" -t "datadog-log-forwarder:$PYTHON_VERSION" ../../.forwarder --no-cache \
 			--build-arg forwarder='aws-dd-forwarder-0.0.0' \
 			--build-arg image="public.ecr.aws/lambda/python:${PYTHON_SHORT_VERSION}-x86_64"

--- a/aws/logs_monitoring/tools/integration_tests/integration_tests.sh
+++ b/aws/logs_monitoring/tools/integration_tests/integration_tests.sh
@@ -155,14 +155,14 @@ if [ $PYTHON_VERSION == "python3.8" ]; then
 			--build-arg forwarder='aws-dd-forwarder-0.0.0' \
 			--build-arg image="lambci/lambda:${PYTHON_VERSION}"
 fi
-
+# --build-arg image="lambci/lambda:${PYTHON_VERSION}"
 # Build Docker image of Forwarder for tests 3.9 compatibility
 # See https://github.com/lambci/lambci/issues/138
 if [ $PYTHON_VERSION == "python3.9" ]; then
 	echo "Building Docker Image for Forwarder"
 	docker buildx build --platform linux/amd64 --file "${INTEGRATION_TESTS_DIR}/forwarder/Dockerfile" -t "datadog-log-forwarder:$PYTHON_VERSION" ../../.forwarder --no-cache \
 			--build-arg forwarder='aws-dd-forwarder-0.0.0' \
-			--build-arg image="public.ecr.aws/lambda/python:3.9"
+			--build-arg image="public.ecr.aws/lambda/python:3.9-x86_64"
 fi
 
 echo "Running integration tests for ${PYTHON_VERSION}"

--- a/aws/logs_monitoring/tools/integration_tests/integration_tests.sh
+++ b/aws/logs_monitoring/tools/integration_tests/integration_tests.sh
@@ -162,7 +162,7 @@ if [ $PYTHON_VERSION == "python3.9" ]; then
 	echo "Building Docker Image for Forwarder"
 	docker buildx build --platform linux/amd64 --file "${INTEGRATION_TESTS_DIR}/forwarder/Dockerfile" -t "datadog-log-forwarder:$PYTHON_VERSION" ../../.forwarder --no-cache \
 			--build-arg forwarder='aws-dd-forwarder-0.0.0' \
-			--build-arg image="mlupin/docker-lambda:${PYTHON_VERSION}-build"
+			--build-arg image="public.ecr.aws/lambda/python:3.9"
 fi
 
 echo "Running integration tests for ${PYTHON_VERSION}"

--- a/aws/logs_monitoring/tools/integration_tests/integration_tests.sh
+++ b/aws/logs_monitoring/tools/integration_tests/integration_tests.sh
@@ -7,7 +7,7 @@
 
 set -e
 
-PYTHON_VERSION="python3.8"
+PYTHON_VERSION="python3.9"
 SKIP_FORWARDER_BUILD=false
 UPDATE_SNAPSHOTS=false
 LOG_LEVEL=info
@@ -39,7 +39,7 @@ do
 
 		# -v or --python-version
 		# The version of the Python Lambda runtime to use
-		# Must be 3.7 or 3.8
+		# Must be 3.7, 3.8 or 3.9
 		-v=*|--python-version=*)
 		PYTHON_VERSION="python${arg#*=}"
 		shift
@@ -78,8 +78,8 @@ do
 	esac
 done
 
-if [ $PYTHON_VERSION != "python3.7" ] && [ $PYTHON_VERSION != "python3.8" ]; then
-    echo "Must use either Python 3.7 or 3.8"
+if [ $PYTHON_VERSION != "python3.7" ] && [ $PYTHON_VERSION != "python3.8" ] && [ $PYTHON_VERSION != "python3.9" ]; then
+    echo "Must use either Python 3.7, 3.8 or 3.9"
     exit 1
 fi
 

--- a/aws/logs_monitoring/tools/integration_tests/integration_tests.sh
+++ b/aws/logs_monitoring/tools/integration_tests/integration_tests.sh
@@ -8,7 +8,6 @@
 set -e
 
 PYTHON_VERSION="python3.9"
-PYTHON_SHORT_VERSION="3.9"
 SKIP_FORWARDER_BUILD=false
 UPDATE_SNAPSHOTS=false
 LOG_LEVEL=info
@@ -156,9 +155,10 @@ if [ $PYTHON_VERSION == "python3.8" ]; then
     --build-arg forwarder='aws-dd-forwarder-0.0.0' \
     --build-arg image="lambci/lambda:${PYTHON_VERSION}"
 fi
-# --build-arg image="lambci/lambda:${PYTHON_VERSION}"
-# Build Docker image of Forwarder for tests 3.9 compatibility
-# See https://github.com/lambci/lambci/issues/138
+
+# Build Docker image of Forwarder for tests >= 3.9 compatibility
+# See https://github.com/lambci/lambci/issues/138, previous image not supported anymore
+# and we need the DOCKER_LAMBDA_STAY_OPEN=1 option,so relying on a fork
 if [ $PYTHON_VERSION == "python3.9" ]; then
 	echo "Building Docker Image for Forwarder with tag datadog-log-forwarder:$PYTHON_VERSION"
 	docker buildx build --platform linux/amd64 --file "${INTEGRATION_TESTS_DIR}/forwarder/Dockerfile" -t "datadog-log-forwarder:$PYTHON_VERSION" ../../.forwarder --no-cache \

--- a/aws/logs_monitoring/tools/integration_tests/recorder/Dockerfile
+++ b/aws/logs_monitoring/tools/integration_tests/recorder/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.9
 
 RUN pip install protobuf
 

--- a/aws/logs_monitoring/tools/integration_tests/tester/Dockerfile
+++ b/aws/logs_monitoring/tools/integration_tests/tester/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.9
 
 COPY . .
 RUN pip install "deepdiff<6"

--- a/aws/logs_monitoring/tools/integration_tests/tester/test_snapshots.py
+++ b/aws/logs_monitoring/tools/integration_tests/tester/test_snapshots.py
@@ -36,7 +36,7 @@ class TestForwarderSnapshots(unittest.TestCase):
         return f'{{"awslogs": {{"data": "{encoded_data}"}}}}'
 
     def send_log_event(self, event):
-        print(forwarder_url)
+        print(forwarder_url, event)
         request = urllib.request.Request(forwarder_url, data=event.encode("utf-8"))
         urllib.request.urlopen(request)
 

--- a/aws/logs_monitoring/tools/integration_tests/tester/test_snapshots.py
+++ b/aws/logs_monitoring/tools/integration_tests/tester/test_snapshots.py
@@ -36,7 +36,6 @@ class TestForwarderSnapshots(unittest.TestCase):
         return f'{{"awslogs": {{"data": "{encoded_data}"}}}}'
 
     def send_log_event(self, event):
-        print(forwarder_url, event)
         request = urllib.request.Request(forwarder_url, data=event.encode("utf-8"))
         urllib.request.urlopen(request)
 

--- a/aws/logs_monitoring/tools/integration_tests/tester/test_snapshots.py
+++ b/aws/logs_monitoring/tools/integration_tests/tester/test_snapshots.py
@@ -36,6 +36,7 @@ class TestForwarderSnapshots(unittest.TestCase):
         return f'{{"awslogs": {{"data": "{encoded_data}"}}}}'
 
     def send_log_event(self, event):
+        print(forwarder_url)
         request = urllib.request.Request(forwarder_url, data=event.encode("utf-8"))
         urllib.request.urlopen(request)
 

--- a/aws/logs_monitoring/tools/publish_layers.sh
+++ b/aws/logs_monitoring/tools/publish_layers.sh
@@ -13,7 +13,7 @@ set -e
 # Makes sure any subprocesses will be terminated with this process
 trap "pkill -P $$; exit 1;" INT
 
-PYTHON_VERSIONS_FOR_AWS_CLI=("python3.8")
+PYTHON_VERSIONS_FOR_AWS_CLI=("python3.9")
 LAYER_PATHS=(".forwarder/aws-dd-forwarder-${FORWARDER_VERSION}-layer.zip")
 AVAILABLE_LAYERS=("Datadog-Forwarder")
 AVAILABLE_REGIONS=$(aws ec2 describe-regions | jq -r '.[] | .[] | .RegionName')


### PR DESCRIPTION
### What does this PR do?

Updates the Datadog forwarder lambda layer to python version 3.9, and updates the Datadog forwarder lambda to use 3.9 as well.
Modifies tests and README as well to ensure clients are aware of the runtime change
NOTE: Had to change the forwarder integration tests docker image due to a deprecation (see [issue](https://github.com/lambci/lambci/issues/138)). We now rely on a fork of the previous repository we used, since we need the custom options `DOCKER_LAMBDA_STAY_OPEN: 1` to be able to run integration tests. We should still rely on the last supported image (3.8) for backward compatibility for a while

### Testing Guidelines

Updates via the CloudFormation template will succeed as the new layer version will only work with 3.8 and the CF template will update the function to version 3.9. 
Tested by bundling up the new lambda layer and using it with a lambda using python 3.9


### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
