### PR TITLE
[AWSC] Fix decoding of API key under DD_KMS_API_KEY

### DIFF
--- a/aws/rds_enhanced_monitoring/lambda_function.py
+++ b/aws/rds_enhanced_monitoring/lambda_function.py
@@ -66,6 +66,12 @@ def _datadog_keys():
             )["Plaintext"]
 
         if type(DD_API_KEY) is bytes:
+            # If the CiphertextBlob was encrypted with AWS CLI, we
+            # need to re-encode this in base64
+            try:
+                DD_API_KEY = base64.b64encode(DD_API_KEY)
+            except:
+                print("INFO DD_KMS_API_KEY: Could not encode key in base64")
             DD_API_KEY = DD_API_KEY.decode("utf-8")
         return {"api_key": DD_API_KEY}
 

--- a/aws/rds_enhanced_monitoring/lambda_function.py
+++ b/aws/rds_enhanced_monitoring/lambda_function.py
@@ -69,10 +69,11 @@ def _datadog_keys():
             # If the CiphertextBlob was encrypted with AWS CLI, we
             # need to re-encode this in base64
             try:
-                DD_API_KEY = base64.b64encode(DD_API_KEY)
+                DD_API_KEY = DD_API_KEY.decode("utf-8")
             except:
-                print("INFO DD_KMS_API_KEY: Could not encode key in base64")
-            DD_API_KEY = DD_API_KEY.decode("utf-8")
+                print("INFO DD_KMS_API_KEY: Could not decode key in utf-8, encoding in b64")
+                DD_API_KEY = base64.b64encode(DD_API_KEY)
+                DD_API_KEY = DD_API_KEY.decode("utf-8")
         return {"api_key": DD_API_KEY}
 
     if "DD_API_KEY" in os.environ:


### PR DESCRIPTION
### What does this PR do?

Fix a case where the Datadog API key is encrypted by the AWS CLI encrypt command, and decrypted using the boto SDK.
In this specific case, we need to encode the returned PlainText from the `decrypt` call in order to decode it further

### Motivation

Support ticket

### Testing Guidelines

Tested in our own sandbox environment after reproducing the issue

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
