### PR TITLE
[serverless] Assign `env` from span metadata to trace payload env

### DIFF
--- a/aws/logs_monitoring/trace_forwarder/internal/apm/model.go
+++ b/aws/logs_monitoring/trace_forwarder/internal/apm/model.go
@@ -177,7 +177,7 @@ func AddTagsToTracePayloads(tracePayloads []*pb.TracePayload, tags string) {
 	}
 
 	for _, tracePayload := range tracePayloads {
-		if env != "" && tracePayload.Env == "none" {
+		if env != "" && env != "none" {
 			tracePayload.Env = env
 		}
 		for _, trace := range tracePayload.Traces {

--- a/aws/logs_monitoring/trace_forwarder/internal/apm/testdata/span_env_tag.json
+++ b/aws/logs_monitoring/trace_forwarder/internal/apm/testdata/span_env_tag.json
@@ -1,0 +1,74 @@
+{
+    "comment": "Tests an env span tag is applied to the trace",
+    "tags": "env:none",
+    "trace": {
+        "traces": [
+            [
+                {
+                    "trace_id": "D4823CE178FE9CF9",
+                    "parent_id": "0000000000000000",
+                    "span_id": "6673D011C71C0A03",
+                    "service": "aws.lambda",
+                    "resource": "span-env-tag",
+                    "name": "aws.lambda",
+                    "error": 0,
+                    "start": 1688673307300342740,
+                    "duration": 824010,
+                    "meta": {
+                        "runtime-id": "dc08a941c30e4d77bdfb38130b4c21d6",
+                        "_dd.origin": "lambda",
+                        "env": "testing",
+                        "cold_start": "false",
+                        "function_arn": "arn:aws:lambda:sa-east-1:601427279990:function:span-env-tag",
+                        "function_version": "$LATEST",
+                        "request_id": "ee57944a-e9dd-4fa2-ad06-6b3df3d343ee",
+                        "resource_names": "span-env-tag",
+                        "functionname": "span-env-tag",
+                        "datadog_lambda": "4.68.0",
+                        "dd_trace": "1.7.5",
+                        "span.name": "aws.lambda",
+                        "customer.id": "123456",
+                        "_dd.p.dm": "-0"
+                    },
+                    "metrics": {
+                        "_dd.agent_psr": 1.0,
+                        "process_id": 8,
+                        "_dd.top_level": 1,
+                        "_sampling_priority_v1": 1
+                    },
+                    "type": "serverless"
+                },
+                {
+                    "trace_id": "D4823CE178FE9CF9",
+                    "parent_id": "6673D011C71C0A03",
+                    "span_id": "DF5FABA84AAA07A3",
+                    "service": "aws.lambda",
+                    "resource": "hello.world",
+                    "name": "hello.world",
+                    "error": 0,
+                    "start": 1688673307300529845,
+                    "duration": 33430,
+                    "meta": {
+                        "_dd.origin": "lambda",
+                        "env": "testing"
+                    }
+                },
+                {
+                    "trace_id": "D4823CE178FE9CF9",
+                    "parent_id": "6673D011C71C0A03",
+                    "span_id": "5AC3DA05BA91424A",
+                    "service": "aws.lambda",
+                    "resource": "lambda_function.get_message",
+                    "name": "lambda_function.get_message",
+                    "error": 0,
+                    "start": 1688673307300920603,
+                    "duration": 22773,
+                    "meta": {
+                        "_dd.origin": "lambda",
+                        "env": "testing"
+                    }
+                }
+            ]
+        ]
+    }
+}

--- a/aws/logs_monitoring/trace_forwarder/internal/apm/testdata/span_env_tag.json~snapshot
+++ b/aws/logs_monitoring/trace_forwarder/internal/apm/testdata/span_env_tag.json~snapshot
@@ -1,0 +1,88 @@
+([]*pb.TracePayload) (len=1) {
+ (*pb.TracePayload)({
+  HostName: (string) "",
+  Env: (string) (len=7) "testing",
+  Traces: ([]*pb.APITrace) (len=1) {
+   (*pb.APITrace)({
+    TraceID: (uint64) 15312868622108368121,
+    Spans: ([]*pb.Span) (len=3) {
+     (*pb.Span)({
+      Service: (string) (len=10) "aws.lambda",
+      Name: (string) (len=10) "aws.lambda",
+      Resource: (string) (len=12) "span-env-tag",
+      TraceID: (uint64) 15312868622108368121,
+      SpanID: (uint64) 7382472988963899907,
+      ParentID: (uint64) 0,
+      Start: (int64) 1688673307300342800,
+      Duration: (int64) 824010,
+      Error: (int32) 0,
+      Meta: (map[string]string) (len=14) {
+       (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
+       (string) (len=8) "_dd.p.dm": (string) (len=2) "-0",
+       (string) (len=10) "cold_start": (string) (len=5) "false",
+       (string) (len=11) "customer.id": (string) (len=6) "123456",
+       (string) (len=14) "datadog_lambda": (string) (len=6) "4.68.0",
+       (string) (len=8) "dd_trace": (string) (len=5) "1.7.5",
+       (string) (len=3) "env": (string) (len=7) "testing",
+       (string) (len=12) "function_arn": (string) (len=59) "arn:aws:lambda:sa-east-1:601427279990:function:span-env-tag",
+       (string) (len=16) "function_version": (string) (len=7) "$LATEST",
+       (string) (len=12) "functionname": (string) (len=12) "span-env-tag",
+       (string) (len=10) "request_id": (string) (len=36) "ee57944a-e9dd-4fa2-ad06-6b3df3d343ee",
+       (string) (len=14) "resource_names": (string) (len=12) "span-env-tag",
+       (string) (len=10) "runtime-id": (string) (len=32) "dc08a941c30e4d77bdfb38130b4c21d6",
+       (string) (len=9) "span.name": (string) (len=10) "aws.lambda"
+      },
+      Metrics: (map[string]float64) (len=8) {
+       (string) (len=13) "_dd.agent_psr": (float64) 1,
+       (string) (len=13) "_dd.top_level": (float64) 1,
+       (string) (len=21) "_sampling_priority_v1": (float64) 1,
+       (string) (len=58) "_sublayers.duration.by_service.sublayer_service:aws.lambda": (float64) 824010,
+       (string) (len=52) "_sublayers.duration.by_type.sublayer_type:serverless": (float64) 767807,
+       (string) (len=21) "_sublayers.span_count": (float64) 3,
+       (string) (len=10) "_top_level": (float64) 1,
+       (string) (len=10) "process_id": (float64) 8
+      },
+      Type: (string) (len=10) "serverless"
+     }),
+     (*pb.Span)({
+      Service: (string) (len=10) "aws.lambda",
+      Name: (string) (len=11) "hello.world",
+      Resource: (string) (len=11) "hello.world",
+      TraceID: (uint64) 15312868622108368121,
+      SpanID: (uint64) 16095772332540954531,
+      ParentID: (uint64) 7382472988963899907,
+      Start: (int64) 1688673307300530000,
+      Duration: (int64) 33430,
+      Error: (int32) 0,
+      Meta: (map[string]string) (len=2) {
+       (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
+       (string) (len=3) "env": (string) (len=7) "testing"
+      },
+      Metrics: (map[string]float64) <nil>,
+      Type: (string) ""
+     }),
+     (*pb.Span)({
+      Service: (string) (len=10) "aws.lambda",
+      Name: (string) (len=27) "lambda_function.get_message",
+      Resource: (string) (len=27) "lambda_function.get_message",
+      TraceID: (uint64) 15312868622108368121,
+      SpanID: (uint64) 6540310802011865674,
+      ParentID: (uint64) 7382472988963899907,
+      Start: (int64) 1688673307300920600,
+      Duration: (int64) 22773,
+      Error: (int32) 0,
+      Meta: (map[string]string) (len=2) {
+       (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
+       (string) (len=3) "env": (string) (len=7) "testing"
+      },
+      Metrics: (map[string]float64) <nil>,
+      Type: (string) ""
+     })
+    },
+    StartTime: (int64) 1688673307300342800,
+    EndTime: (int64) 0
+   })
+  },
+  Transactions: ([]*pb.Span) <nil>
+ })
+}


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
Checks the span metadata for an `env` tag and assigns it to the TracePayload.

### Motivation

<!--- What inspired you to submit this pull request? --->
SLES-1219 - Fixes an issue where trace metrics are incorrectly tagged with `env:none` even when traces and logs have the correct `env` tag. 

### Testing Guidelines

<!--- How did you test this pull request? --->
Tested manually. Unit tests + integration tests are passing.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
