### PR TITLE
[AWSC] Bump py version of RDS/VPC Lambdas, align API key decoding

### DIFF
--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -214,15 +214,12 @@ elif "DD_KMS_API_KEY" in os.environ:
         except UnicodeDecodeError as e:
             print(
                 "INFO DD_KMS_API_KEY: Could not decode key in utf-8, encoding in b64. Exception:",
-                e
+                e,
             )
             DD_API_KEY = base64.b64encode(DD_API_KEY)
             DD_API_KEY = DD_API_KEY.decode("utf-8")
         except Exception as e:
-            print(
-                "ERROR DD_KMS_API_KEY Unknown exception decoding key:",
-                e
-            )
+            print("ERROR DD_KMS_API_KEY Unknown exception decoding key:", e)
 elif "DD_API_KEY" in os.environ:
     logger.debug("Fetching the Datadog API key from environment variable DD_API_KEY")
     DD_API_KEY = os.environ["DD_API_KEY"]

--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -211,10 +211,18 @@ elif "DD_KMS_API_KEY" in os.environ:
         # need to re-encode this in base64
         try:
             DD_API_KEY = DD_API_KEY.decode("utf-8")
-        except:
-            print("INFO DD_KMS_API_KEY: Could not decode key in utf-8, encoding in b64")
+        except UnicodeDecodeError as e:
+            print(
+                "INFO DD_KMS_API_KEY: Could not decode key in utf-8, encoding in b64. Exception:",
+                e
+            )
             DD_API_KEY = base64.b64encode(DD_API_KEY)
             DD_API_KEY = DD_API_KEY.decode("utf-8")
+        except Exception as e:
+            print(
+                "ERROR DD_KMS_API_KEY Unknown exception decoding key:",
+                e
+            )
 elif "DD_API_KEY" in os.environ:
     logger.debug("Fetching the Datadog API key from environment variable DD_API_KEY")
     DD_API_KEY = os.environ["DD_API_KEY"]

--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -207,7 +207,14 @@ elif "DD_KMS_API_KEY" in os.environ:
         CiphertextBlob=base64.b64decode(ENCRYPTED)
     )["Plaintext"]
     if type(DD_API_KEY) is bytes:
-        DD_API_KEY = DD_API_KEY.decode("utf-8")
+        # If the CiphertextBlob was encrypted with AWS CLI, we
+        # need to re-encode this in base64
+        try:
+            DD_API_KEY = DD_API_KEY.decode("utf-8")
+        except:
+            print("INFO DD_KMS_API_KEY: Could not decode key in utf-8, encoding in b64")
+            DD_API_KEY = base64.b64encode(DD_API_KEY)
+            DD_API_KEY = DD_API_KEY.decode("utf-8")
 elif "DD_API_KEY" in os.environ:
     logger.debug("Fetching the Datadog API key from environment variable DD_API_KEY")
     DD_API_KEY = os.environ["DD_API_KEY"]

--- a/aws/rds_enhanced_monitoring/README.md
+++ b/aws/rds_enhanced_monitoring/README.md
@@ -273,7 +273,7 @@ d. **Not Recommended**: Plaintext
 
    - Create a `lambda_execution` role and attach this policy.
 
-   - Create a lambda function: skip the blueprint, name it `functionname`, set the runtime to `Python 3.7`, the handle to `lambda_function.lambda_handler`, and the role to `lambda_execution`.
+   - Create a lambda function: skip the blueprint, name it `functionname`, set the runtime to `Python 3.9`, the handle to `lambda_function.lambda_handler`, and the role to `lambda_execution`.
 
    - Copy the content of `functionname/lambda_function.py` in the code section
 

--- a/aws/rds_enhanced_monitoring/lambda_function.py
+++ b/aws/rds_enhanced_monitoring/lambda_function.py
@@ -71,7 +71,9 @@ def _datadog_keys():
             try:
                 DD_API_KEY = DD_API_KEY.decode("utf-8")
             except:
-                print("INFO DD_KMS_API_KEY: Could not decode key in utf-8, encoding in b64")
+                print(
+                    "INFO DD_KMS_API_KEY: Could not decode key in utf-8, encoding in b64"
+                )
                 DD_API_KEY = base64.b64encode(DD_API_KEY)
                 DD_API_KEY = DD_API_KEY.decode("utf-8")
         return {"api_key": DD_API_KEY}

--- a/aws/rds_enhanced_monitoring/lambda_function.py
+++ b/aws/rds_enhanced_monitoring/lambda_function.py
@@ -70,12 +70,18 @@ def _datadog_keys():
             # need to re-encode this in base64
             try:
                 DD_API_KEY = DD_API_KEY.decode("utf-8")
-            except:
+            except UnicodeDecodeError as e:
                 print(
-                    "INFO DD_KMS_API_KEY: Could not decode key in utf-8, encoding in b64"
+                    "INFO DD_KMS_API_KEY: Could not decode key in utf-8, encoding in b64. Exception:",
+                    e
                 )
                 DD_API_KEY = base64.b64encode(DD_API_KEY)
                 DD_API_KEY = DD_API_KEY.decode("utf-8")
+            except Exception as e:
+                print(
+                    "ERROR DD_KMS_API_KEY Unknown exception decoding key:",
+                    e
+                )
         return {"api_key": DD_API_KEY}
 
     if "DD_API_KEY" in os.environ:

--- a/aws/rds_enhanced_monitoring/lambda_function.py
+++ b/aws/rds_enhanced_monitoring/lambda_function.py
@@ -73,15 +73,12 @@ def _datadog_keys():
             except UnicodeDecodeError as e:
                 print(
                     "INFO DD_KMS_API_KEY: Could not decode key in utf-8, encoding in b64. Exception:",
-                    e
+                    e,
                 )
                 DD_API_KEY = base64.b64encode(DD_API_KEY)
                 DD_API_KEY = DD_API_KEY.decode("utf-8")
             except Exception as e:
-                print(
-                    "ERROR DD_KMS_API_KEY Unknown exception decoding key:",
-                    e
-                )
+                print("ERROR DD_KMS_API_KEY Unknown exception decoding key:", e)
         return {"api_key": DD_API_KEY}
 
     if "DD_API_KEY" in os.environ:

--- a/aws/rds_enhanced_monitoring/rds-enhanced-sam-template.yaml
+++ b/aws/rds_enhanced_monitoring/rds-enhanced-sam-template.yaml
@@ -18,7 +18,7 @@ Resources:
       Policies:
         KMSDecryptPolicy:
           KeyId: !Ref KMSKeyId
-      Runtime: python3.7
+      Runtime: python3.9
       Timeout: 10
       KmsKeyArn:
         !Sub

--- a/aws/vpc_flow_log_monitoring/README.md
+++ b/aws/vpc_flow_log_monitoring/README.md
@@ -49,7 +49,7 @@ version, account, eni, source, destination, srcport, destport="22", protocol="6"
 
    - Create a `lambda_execution` role and attach this policy
 
-   - Create a lambda function: Skip the blueprint, name it `functionname`, set the Runtime to `Python 2.7`, the handle to `lambda_function.lambda_handler`, and the role to `lambda_execution`.
+   - Create a lambda function: Skip the blueprint, name it `functionname`, set the Runtime to `Python 3.9`, the handle to `lambda_function.lambda_handler`, and the role to `lambda_execution`.
 
    - Copy the content of `functionname/lambda_function.py` in the code section, make sure to update the `KMS_ENCRYPTED_KEYS` environment variable with the encrypted key generated in step 1
 

--- a/aws/vpc_flow_log_monitoring/lambda_function.py
+++ b/aws/vpc_flow_log_monitoring/lambda_function.py
@@ -76,12 +76,18 @@ def _datadog_keys():
             # need to re-encode this in base64
             try:
                 DD_API_KEY = DD_API_KEY.decode("utf-8")
-            except:
+            except UnicodeDecodeError as e:
                 print(
-                    "INFO DD_KMS_API_KEY: Could not decode key in utf-8, encoding in b64"
+                    "INFO DD_KMS_API_KEY: Could not decode key in utf-8, encoding in b64. Exception:",
+                    e
                 )
                 DD_API_KEY = base64.b64encode(DD_API_KEY)
                 DD_API_KEY = DD_API_KEY.decode("utf-8")
+            except Exception as e:
+                print(
+                    "ERROR DD_KMS_API_KEY Unknown exception decoding key:",
+                    e
+                )
         return {"api_key": DD_API_KEY}
 
     if "DD_API_KEY" in os.environ:

--- a/aws/vpc_flow_log_monitoring/lambda_function.py
+++ b/aws/vpc_flow_log_monitoring/lambda_function.py
@@ -79,15 +79,12 @@ def _datadog_keys():
             except UnicodeDecodeError as e:
                 print(
                     "INFO DD_KMS_API_KEY: Could not decode key in utf-8, encoding in b64. Exception:",
-                    e
+                    e,
                 )
                 DD_API_KEY = base64.b64encode(DD_API_KEY)
                 DD_API_KEY = DD_API_KEY.decode("utf-8")
             except Exception as e:
-                print(
-                    "ERROR DD_KMS_API_KEY Unknown exception decoding key:",
-                    e
-                )
+                print("ERROR DD_KMS_API_KEY Unknown exception decoding key:", e)
         return {"api_key": DD_API_KEY}
 
     if "DD_API_KEY" in os.environ:

--- a/aws/vpc_flow_log_monitoring/lambda_function.py
+++ b/aws/vpc_flow_log_monitoring/lambda_function.py
@@ -72,7 +72,14 @@ def _datadog_keys():
             )["Plaintext"]
 
         if type(DD_API_KEY) is bytes:
-            DD_API_KEY = DD_API_KEY.decode("utf-8")
+            # If the CiphertextBlob was encrypted with AWS CLI, we
+            # need to re-encode this in base64
+            try:
+                DD_API_KEY = DD_API_KEY.decode("utf-8")
+            except:
+                print("INFO DD_KMS_API_KEY: Could not decode key in utf-8, encoding in b64")
+                DD_API_KEY = base64.b64encode(DD_API_KEY)
+                DD_API_KEY = DD_API_KEY.decode("utf-8")
         return {"api_key": DD_API_KEY}
 
     if "DD_API_KEY" in os.environ:

--- a/aws/vpc_flow_log_monitoring/lambda_function.py
+++ b/aws/vpc_flow_log_monitoring/lambda_function.py
@@ -77,7 +77,9 @@ def _datadog_keys():
             try:
                 DD_API_KEY = DD_API_KEY.decode("utf-8")
             except:
-                print("INFO DD_KMS_API_KEY: Could not decode key in utf-8, encoding in b64")
+                print(
+                    "INFO DD_KMS_API_KEY: Could not decode key in utf-8, encoding in b64"
+                )
                 DD_API_KEY = base64.b64encode(DD_API_KEY)
                 DD_API_KEY = DD_API_KEY.decode("utf-8")
         return {"api_key": DD_API_KEY}

--- a/aws/vpc_flow_log_monitoring/vpc-flow-log-sam-template.yaml
+++ b/aws/vpc_flow_log_monitoring/vpc-flow-log-sam-template.yaml
@@ -18,7 +18,7 @@ Resources:
       Policies:
         KMSDecryptPolicy:
           KeyId: !Ref KMSKeyId
-      Runtime: python3.7
+      Runtime: python3.9
       Timeout: 10
       KmsKeyArn:
         !Sub


### PR DESCRIPTION
### What does this PR do?

Bumps the runtime version of the RDS enhanced metrics and VPC Flow Logs monitoring Lambdas from Python 3.7 to Python 3.9. Tested in our Sandbox environment. 
[What's new in Python 3.8](https://docs.python.org/3/whatsnew/3.8.html)
[What's new in Python 3.9](https://docs.python.org/3/whatsnew/3.9.html)

Also aligns the decoding of the API key of the Datadog Forwarder / VPC Flow logs Lambda with this [PR](https://github.com/DataDog/datadog-serverless-functions/pull/668). When creating the CypherTextBlob through the AWS CLI, we may encounter errors when decoding it with the current code. This should fix that.

### Motivation

Aligning python version across provided Lambdas to a supported one. 

### Testing Guidelines

Tested in our sandbox

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
