### PR TITLE
[Azure] Handle logs with capitalized resource ID and add forwarder version tag

### DIFF
--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -473,18 +473,19 @@ class EventhubLogHandler {
         }
     }
 
+    createDDTags(tags) {
+        const forwarderNameTag =  'forwardername:' + this.context.executionContext.functionName;
+        const fowarderVersionTag = 'forwarderversion:' + VERSION;
+        var ddTags = tags.concat([DD_TAGS, forwarderNameTag, fowarderVersionTag]);
+        return ddTags.filter(Boolean).join(',');
+    }
+
     addTagsToJsonLog(record) {
         var metadata = this.extractMetadataFromResource(record);
         record['ddsource'] = metadata.source || DD_SOURCE;
         record['ddsourcecategory'] = DD_SOURCE_CATEGORY;
         record['service'] = DD_SERVICE;
-        record['ddtags'] = metadata.tags
-            .concat([
-                DD_TAGS,
-                'forwardername:' + this.context.executionContext.functionName
-            ])
-            .filter(Boolean)
-            .join(',');
+        record['ddtags'] = this.createDDTags(metadata.tags);
         return record;
     }
 
@@ -526,7 +527,7 @@ class EventhubLogHandler {
     extractMetadataFromResource(record) {
         var metadata = { tags: [], source: '' };
         var resourceId = this.getResourceId(record);
-        if (resourceId === null || id === '') {
+        if (resourceId === null || resourceId === '') {
             return metadata;
         }
         resourceId = this.createResourceIdArray(resourceId);

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -5,7 +5,7 @@
 
 var https = require('https');
 
-const VERSION = '0.5.7';
+const VERSION = '0.6.0';
 
 const STRING = 'string'; // example: 'some message'
 const STRING_ARRAY = 'string-array'; // example: ['one message', 'two message', ...]
@@ -493,16 +493,16 @@ class EventhubLogHandler {
         return this.addTagsToJsonLog(jsonLog);
     }
 
-    createResourceIdArray(record) {
-        // Convert the resource ID in the record to an array, handling beginning/ending slashes
-        var resourceId = record.resourceId.toLowerCase().split('/');
-        if (resourceId[0] === '') {
-            resourceId = resourceId.slice(1);
+    createResourceIdArray(resourceId) {
+        // Convert a valid resource ID to an array, handling beginning/ending slashes
+        var resourceIdArray = resourceId.toLowerCase().split('/');
+        if (resourceIdArray[0] === '') {
+            resourceIdArray = resourceIdArray.slice(1);
         }
-        if (resourceId[resourceId.length - 1] === '') {
-            resourceId.pop();
+        if (resourceIdArray[resourceIdArray.length - 1] === '') {
+            resourceIdArray.pop();
         }
-        return resourceId;
+        return resourceIdArray;
     }
 
     isSource(resourceIdPart) {
@@ -514,16 +514,22 @@ class EventhubLogHandler {
         return sourceType.replace('microsoft.', 'azure.');
     }
 
+    getResourceId(record) {
+        // Most logs have resourceId, but some logs have ResourceId instead
+        var id = record.resourceId || record.ResourceId;
+        if (typeof id !== 'string') {
+            return null;
+        }
+        return id;
+    }
+
     extractMetadataFromResource(record) {
         var metadata = { tags: [], source: '' };
-        if (
-            record.resourceId === undefined ||
-            typeof record.resourceId !== 'string'
-        ) {
+        var resourceId = this.getResourceId(record);
+        if (resourceId === null || id === '') {
             return metadata;
         }
-
-        var resourceId = this.createResourceIdArray(record);
+        resourceId = this.createResourceIdArray(resourceId);
 
         if (resourceId[0] === 'subscriptions') {
             if (resourceId.length > 1) {


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Handles logs with the resource ID key formatted as `ResourceId`. This allows the log forwarder to correctly set the source of the log. Previously, logs with `ResourceId` only had the default `source:azure`, now they will have the specific source (`source:azure.web`, `source:azure.storage`, etc).

Also adds an additional tag `forwarderversion` with the version of the log forwarder.

### Motivation

Handle audit logs with `ResourceId` correctly

### Testing Guidelines

Deployed to a test log forwarder. Observed that the audit logs now had their source correctly set. Logs also had the `forwarderversion` tag

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
