### PR TITLE
Correctly catch non-ASCII characters when filtering AWS logs

### DIFF
--- a/aws/logs_monitoring/logs.py
+++ b/aws/logs_monitoring/logs.py
@@ -52,7 +52,7 @@ def forward_logs(logs):
     if logger.isEnabledFor(logging.DEBUG):
         logger.debug(f"Forwarding {len(logs)} logs")
     logs_to_forward = filter_logs(
-        list(map(json.dumps, logs)),
+        [json.dumps(log, ensure_ascii=False) for log in logs],
         include_pattern=INCLUDE_AT_MATCH,
         exclude_pattern=EXCLUDE_AT_MATCH,
     )


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
By default, `json.dumps()` has `ensure_ascii=True`, which escapes any non-ascii characters. This was preventing RegEx from matching on those characters. This changes that. 

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

Set the environment `EXCLUDE_AT_MATCH=[^\u0001-\u007F]+` and sent logs containing:
- ひらがな
- カタカナ
- 漢字
All three were successfully excluded. Before this, they would bypass the filter. 

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
