### PR TITLE
[SLS-3847] Revert stats computation to backend

### DIFF
--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_lambda_invocation.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_lambda_invocation.json~snapshot
@@ -382,6 +382,7 @@
               {
                 "duration": "458278320",
                 "meta": {
+                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -407,6 +408,7 @@
               {
                 "duration": "13428",
                 "meta": {
+                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -432,6 +434,7 @@
               {
                 "duration": "35645",
                 "meta": {
+                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -457,6 +460,7 @@
               {
                 "duration": "9277",
                 "meta": {
+                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -482,6 +486,7 @@
               {
                 "duration": "26367",
                 "meta": {
+                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -507,6 +512,7 @@
               {
                 "duration": "127197",
                 "meta": {
+                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -532,6 +538,7 @@
               {
                 "duration": "499751709",
                 "meta": {
+                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -560,6 +567,7 @@
               {
                 "duration": "218750",
                 "meta": {
+                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -588,6 +596,7 @@
               {
                 "duration": "460493896",
                 "meta": {
+                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -617,6 +626,7 @@
               {
                 "duration": "479066650",
                 "meta": {
+                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -653,6 +663,7 @@
               {
                 "duration": "577401367",
                 "meta": {
+                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -688,6 +699,7 @@
               {
                 "duration": "578297119",
                 "meta": {
+                  "_dd.compute_stats": "1",
                   "_dd.origin": "lambda",
                   "account_id": "0000000000",
                   "aws_account": "0000000000",
@@ -737,20 +749,6 @@
         "User-Agent": "<redacted from snapshot>"
       },
       "path": "/api/v0.2/traces",
-      "verb": "POST"
-    },
-    {
-      "data": null,
-      "headers": {
-        "Accept-Encoding": "gzip",
-        "Content-Encoding": "gzip",
-        "Content-Length": "<redacted from snapshot>",
-        "Content-Type": "application/json",
-        "Dd-Api-Key": "abcdefghijklmnopqrstuvwxyz012345",
-        "Host": "recorder:8080",
-        "User-Agent": "<redacted from snapshot>"
-      },
-      "path": "/api/v0.2/stats",
       "verb": "POST"
     },
     {

--- a/aws/logs_monitoring/trace_forwarder/cmd/trace/main.go
+++ b/aws/logs_monitoring/trace_forwarder/cmd/trace/main.go
@@ -33,6 +33,7 @@ type (
 )
 
 // Configure will set up the bindings
+//
 //export Configure
 func Configure(rootURL, apiKey string, InsecureSkipVerify bool) {
 	// Need to make a copy of these values, otherwise the underlying memory
@@ -57,6 +58,7 @@ func Configure(rootURL, apiKey string, InsecureSkipVerify bool) {
 }
 
 // returns 0 on success, 1 on error
+//
 //export ForwardTraces
 func ForwardTraces(serializedTraces string) int {
 	rawTracePayloads, err := unmarshalSerializedTraces(serializedTraces)
@@ -145,16 +147,10 @@ func sendTracesToIntake(tracePayloads []*pb.TracePayload) error {
 			fmt.Printf("Failed to send traces with error %v\n", err)
 			hadErr = true
 		}
-		stats := apm.ComputeAPMStats(tracePayload)
-		err = edgeConnection.SendStats(context.Background(), stats, 3)
-		if err != nil {
-			fmt.Printf("Failed to send trace stats with error %v\n", err)
-			hadErr = true
-		}
 	}
 
 	if hadErr {
-		return errors.New("Failed to send traces or stats to intake")
+		return errors.New("Failed to send traces to intake")
 	}
 	return nil
 }

--- a/aws/logs_monitoring/trace_forwarder/internal/apm/model.go
+++ b/aws/logs_monitoring/trace_forwarder/internal/apm/model.go
@@ -45,6 +45,7 @@ type (
 
 const (
 	originMetadataKey       = "_dd.origin"
+	computeStatsKey         = "_dd.compute_stats"
 	parentSourceMetadataKey = "_dd.parent_source"
 	sourceXray              = "xray"
 	envMetadataKey          = "env"
@@ -85,6 +86,10 @@ func ParseTrace(content string) ([]*pb.TracePayload, error) {
 				sp.Meta = map[string]string{}
 			}
 			sp.Meta[originMetadataKey] = "lambda"
+
+			// Instruct the span intake pipeline to compute stats
+			// in the APM backend.
+			sp.Meta[computeStatsKey] = "1"
 
 			// Use the env tag if it's present in the span metadata
 			if envValue, ok := sp.Meta[envMetadataKey]; ok {

--- a/aws/logs_monitoring/trace_forwarder/internal/apm/testdata/basic.json~snapshot
+++ b/aws/logs_monitoring/trace_forwarder/internal/apm/testdata/basic.json~snapshot
@@ -16,7 +16,8 @@
       Start: (int64) 1586269922931758000,
       Duration: (int64) 254812000,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=6) {
+      Meta: (map[string]string) (len=7) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=10) "cold_start": (string) (len=5) "false",
        (string) (len=12) "function_arn": (string) (len=68) "arn:aws:lambda:us-east-1:172597598159:function:hello-dog-dev-hello36",
@@ -45,7 +46,8 @@
       Start: (int64) 1586269922945357000,
       Duration: (int64) 138997000,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=5) {
+      Meta: (map[string]string) (len=6) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=11) "http.method": (string) (len=3) "GET",
        (string) (len=16) "http.status_code": (string) (len=3) "200",
@@ -68,7 +70,8 @@
       Start: (int64) 1586269923086220000,
       Duration: (int64) 100232000,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=1) {
+      Meta: (map[string]string) (len=2) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda"
       },
       Metrics: (map[string]float64) <nil>,

--- a/aws/logs_monitoring/trace_forwarder/internal/apm/testdata/inferred_span.json~snapshot
+++ b/aws/logs_monitoring/trace_forwarder/internal/apm/testdata/inferred_span.json~snapshot
@@ -16,7 +16,8 @@
       Start: (int64) 1636820292450000100,
       Duration: (int64) 149992638,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=11) {
+      Meta: (map[string]string) (len=12) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=28) "_inferred_span.synchronisity": (string) (len=4) "sync",
        (string) (len=25) "_inferred_span.tag_source": (string) (len=4) "self",
@@ -58,7 +59,8 @@
       Start: (int64) 1636820292466458000,
       Duration: (int64) 133507715,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=16) {
+      Meta: (map[string]string) (len=17) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=10) "cold_start": (string) (len=5) "false",
        (string) (len=14) "datadog_lambda": (string) (len=6) "3.49.0",
@@ -101,7 +103,8 @@
       Start: (int64) 1636820292466887200,
       Duration: (int64) 19825652,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=9) {
+      Meta: (map[string]string) (len=10) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=9) "aws.agent": (string) (len=8) "botocore",
        (string) (len=13) "aws.operation": (string) (len=11) "SendMessage",
@@ -129,7 +132,8 @@
       Start: (int64) 1636820292487212000,
       Duration: (int64) 21565856,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=10) {
+      Meta: (map[string]string) (len=11) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=9) "aws.agent": (string) (len=8) "botocore",
        (string) (len=13) "aws.operation": (string) (len=7) "Publish",
@@ -158,7 +162,8 @@
       Start: (int64) 1636820292508904400,
       Duration: (int64) 6481144,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=8) {
+      Meta: (map[string]string) (len=9) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=9) "aws.agent": (string) (len=8) "botocore",
        (string) (len=13) "aws.operation": (string) (len=7) "PutItem",
@@ -185,7 +190,8 @@
       Start: (int64) 1636820292515487000,
       Duration: (int64) 7799031,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=9) {
+      Meta: (map[string]string) (len=10) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=9) "aws.agent": (string) (len=8) "botocore",
        (string) (len=13) "aws.operation": (string) (len=9) "PutRecord",
@@ -213,7 +219,8 @@
       Start: (int64) 1636820292523388000,
       Duration: (int64) 13733007,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=7) {
+      Meta: (map[string]string) (len=8) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=9) "aws.agent": (string) (len=8) "botocore",
        (string) (len=13) "aws.operation": (string) (len=9) "PutEvents",
@@ -239,7 +246,8 @@
       Start: (int64) 1636820292538263000,
       Duration: (int64) 38689743,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=8) {
+      Meta: (map[string]string) (len=9) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=9) "aws.agent": (string) (len=8) "botocore",
        (string) (len=13) "aws.operation": (string) (len=9) "PutObject",
@@ -266,7 +274,8 @@
       Start: (int64) 1636820292579315000,
       Duration: (int64) 20111883,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=8) {
+      Meta: (map[string]string) (len=9) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=9) "aws.agent": (string) (len=8) "botocore",
        (string) (len=13) "aws.operation": (string) (len=6) "Invoke",

--- a/aws/logs_monitoring/trace_forwarder/internal/apm/testdata/inferred_span_service_tag.json~snapshot
+++ b/aws/logs_monitoring/trace_forwarder/internal/apm/testdata/inferred_span_service_tag.json~snapshot
@@ -16,7 +16,8 @@
       Start: (int64) 1636820292450000100,
       Duration: (int64) 149992638,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=11) {
+      Meta: (map[string]string) (len=12) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=27) "_inferred_span.syncronicity": (string) (len=4) "sync",
        (string) (len=25) "_inferred_span.tag_source": (string) (len=4) "self",
@@ -58,7 +59,8 @@
       Start: (int64) 1636820292466458000,
       Duration: (int64) 133507715,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=17) {
+      Meta: (map[string]string) (len=18) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=10) "cold_start": (string) (len=5) "false",
        (string) (len=14) "datadog_lambda": (string) (len=6) "3.49.0",
@@ -102,7 +104,8 @@
       Start: (int64) 1636820292466887200,
       Duration: (int64) 19825652,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=10) {
+      Meta: (map[string]string) (len=11) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=9) "aws.agent": (string) (len=8) "botocore",
        (string) (len=13) "aws.operation": (string) (len=11) "SendMessage",
@@ -131,7 +134,8 @@
       Start: (int64) 1636820292487212000,
       Duration: (int64) 21565856,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=11) {
+      Meta: (map[string]string) (len=12) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=9) "aws.agent": (string) (len=8) "botocore",
        (string) (len=13) "aws.operation": (string) (len=7) "Publish",
@@ -161,7 +165,8 @@
       Start: (int64) 1636820292508904400,
       Duration: (int64) 6481144,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=9) {
+      Meta: (map[string]string) (len=10) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=9) "aws.agent": (string) (len=8) "botocore",
        (string) (len=13) "aws.operation": (string) (len=7) "PutItem",
@@ -189,7 +194,8 @@
       Start: (int64) 1636820292515487000,
       Duration: (int64) 7799031,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=10) {
+      Meta: (map[string]string) (len=11) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=9) "aws.agent": (string) (len=8) "botocore",
        (string) (len=13) "aws.operation": (string) (len=9) "PutRecord",
@@ -218,7 +224,8 @@
       Start: (int64) 1636820292523388000,
       Duration: (int64) 13733007,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=8) {
+      Meta: (map[string]string) (len=9) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=9) "aws.agent": (string) (len=8) "botocore",
        (string) (len=13) "aws.operation": (string) (len=9) "PutEvents",
@@ -245,7 +252,8 @@
       Start: (int64) 1636820292538263000,
       Duration: (int64) 38689743,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=9) {
+      Meta: (map[string]string) (len=10) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=9) "aws.agent": (string) (len=8) "botocore",
        (string) (len=13) "aws.operation": (string) (len=9) "PutObject",
@@ -273,7 +281,8 @@
       Start: (int64) 1636820292579315000,
       Duration: (int64) 20111883,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=9) {
+      Meta: (map[string]string) (len=10) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=9) "aws.agent": (string) (len=8) "botocore",
        (string) (len=13) "aws.operation": (string) (len=6) "Invoke",

--- a/aws/logs_monitoring/trace_forwarder/internal/apm/testdata/service_rename.json~snapshot
+++ b/aws/logs_monitoring/trace_forwarder/internal/apm/testdata/service_rename.json~snapshot
@@ -16,7 +16,8 @@
       Start: (int64) 1586269721581541000,
       Duration: (int64) 555729248,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=4) {
+      Meta: (map[string]string) (len=5) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=8) "language": (string) (len=10) "javascript",
        (string) (len=2) "my": (string) (len=5) "value",
@@ -38,7 +39,8 @@
       Start: (int64) 1586269722137387000,
       Duration: (int64) 11963,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=4) {
+      Meta: (map[string]string) (len=5) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=8) "language": (string) (len=10) "javascript",
        (string) (len=2) "my": (string) (len=5) "value",
@@ -60,7 +62,8 @@
       Start: (int64) 1586269722137368600,
       Duration: (int64) 32959,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=4) {
+      Meta: (map[string]string) (len=5) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=8) "language": (string) (len=10) "javascript",
        (string) (len=2) "my": (string) (len=5) "value",
@@ -82,7 +85,8 @@
       Start: (int64) 1586269722137421600,
       Duration: (int64) 9033,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=4) {
+      Meta: (map[string]string) (len=5) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=8) "language": (string) (len=10) "javascript",
        (string) (len=2) "my": (string) (len=5) "value",
@@ -104,7 +108,8 @@
       Start: (int64) 1586269722137407200,
       Duration: (int64) 25391,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=4) {
+      Meta: (map[string]string) (len=5) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=8) "language": (string) (len=10) "javascript",
        (string) (len=2) "my": (string) (len=5) "value",
@@ -126,7 +131,8 @@
       Start: (int64) 1586269722137314000,
       Duration: (int64) 120117,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=3) {
+      Meta: (map[string]string) (len=4) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=8) "language": (string) (len=10) "javascript",
        (string) (len=2) "my": (string) (len=5) "value"
@@ -147,7 +153,8 @@
       Start: (int64) 1586269721581080000,
       Duration: (int64) 556922119,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=5) {
+      Meta: (map[string]string) (len=6) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=11) "dns.address": (string) (len=13) "172.217.9.196",
        (string) (len=12) "dns.hostname": (string) (len=14) "www.google.com",
@@ -171,7 +178,8 @@
       Start: (int64) 1586269721580981500,
       Duration: (int64) 613575195,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=7) {
+      Meta: (map[string]string) (len=8) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=2) "my": (string) (len=5) "value",
        (string) (len=8) "out.host": (string) (len=14) "www.google.com",
@@ -203,7 +211,8 @@
       Start: (int64) 1586269721580333800,
       Duration: (int64) 654928711,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=6) {
+      Meta: (map[string]string) (len=7) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=11) "http.method": (string) (len=3) "GET",
        (string) (len=16) "http.status_code": (string) (len=3) "200",
@@ -233,7 +242,8 @@
       Start: (int64) 1586269721580143000,
       Duration: (int64) 674647949,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=7) {
+      Meta: (map[string]string) (len=8) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=10) "cold_start": (string) (len=5) "false",
        (string) (len=12) "function_arn": (string) (len=74) "arn:aws:lambda:us-east-1:172597598159:function:hello-dog-node-dev-hello10x",

--- a/aws/logs_monitoring/trace_forwarder/internal/apm/testdata/span_env_tag.json~snapshot
+++ b/aws/logs_monitoring/trace_forwarder/internal/apm/testdata/span_env_tag.json~snapshot
@@ -16,7 +16,8 @@
       Start: (int64) 1688673307300342800,
       Duration: (int64) 824010,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=14) {
+      Meta: (map[string]string) (len=15) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=8) "_dd.p.dm": (string) (len=2) "-0",
        (string) (len=10) "cold_start": (string) (len=5) "false",
@@ -54,7 +55,8 @@
       Start: (int64) 1688673307300530000,
       Duration: (int64) 33430,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=2) {
+      Meta: (map[string]string) (len=3) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=3) "env": (string) (len=7) "testing"
       },
@@ -71,7 +73,8 @@
       Start: (int64) 1688673307300920600,
       Duration: (int64) 22773,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=2) {
+      Meta: (map[string]string) (len=3) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=3) "env": (string) (len=7) "testing"
       },

--- a/aws/logs_monitoring/trace_forwarder/internal/apm/testdata/xray_reparent.json~snapshot
+++ b/aws/logs_monitoring/trace_forwarder/internal/apm/testdata/xray_reparent.json~snapshot
@@ -16,7 +16,8 @@
       Start: (int64) 1586269922945357000,
       Duration: (int64) 138997000,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=4) {
+      Meta: (map[string]string) (len=5) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda",
        (string) (len=11) "http.method": (string) (len=3) "GET",
        (string) (len=16) "http.status_code": (string) (len=3) "200",
@@ -38,7 +39,8 @@
       Start: (int64) 1586269923086220000,
       Duration: (int64) 100232000,
       Error: (int32) 0,
-      Meta: (map[string]string) (len=1) {
+      Meta: (map[string]string) (len=2) {
+       (string) (len=17) "_dd.compute_stats": (string) (len=1) "1",
        (string) (len=10) "_dd.origin": (string) (len=6) "lambda"
       },
       Metrics: (map[string]float64) (len=1) {


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Reverts stats computation changes made in #557 and #606.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

SLE-3847
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

Integration and Unit testing
<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
