### PR TITLE
Be more explicit about adding the cloudwatch logs endpoint to the VPC

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -241,7 +241,8 @@ You can run the Forwarder in a VPC private subnet and send data to Datadog over 
 
 1. Follow [these instructions][14] to add the Datadog `api`, `http-logs.intake`, and `trace.agent` endpoints to your VPC.
 2. Follow the [instructions][15] to add the AWS Secrets Manager and S3 endpoints to your VPC.
-3. When installing the Forwarder with the CloudFormation template:
+3. Follow the [instructions][15] to add a Cloudwatch Logs endpoint if you plan to forward Cloudwatch Logs.
+4. When installing the Forwarder with the CloudFormation template:
    1. Set `UseVPC` to `true`.
    2. Set `VPCSecurityGroupIds` and `VPCSubnetIds` based on your VPC settings.
    3. Set `DdFetchLambdaTags` to `false`, because AWS Resource Groups Tagging API doesn't support PrivateLink.


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adds details about adding the cloudwatch logs endpoint to the VPC.

### Motivation

I was setting up the lambda forwarder in a private subnet to forward EKS audit logs to Datadog. I noticed the docs mention  it requires a Secrets/S3 endpoint, but there i no mention of a Cloudwatch Logs endpoint. My task was timing out when `Starting new HTTPS connection (1): logs.us-west-2.amazonaws.com:443` and it took me a couple hours to find the right log in Cloudwatch since searching for logs there is brutal. I am hoping adding this little detail saves other time in the future.

### Testing Guidelines

N/A

### Additional Notes

N/A

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [X] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [X] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
