### PR TITLE
fix: Allow setting the service from the log group tags

### DIFF
--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -495,8 +495,6 @@ def awslogs_handler(event, context, metadata):
         source = "transitgateway"
     metadata[DD_SOURCE] = parse_event_source(event, source)
 
-    metadata[DD_SERVICE] = get_service_from_tags(metadata)
-
     # Build aws attributes
     aws_attributes = {
         "aws": {
@@ -515,6 +513,9 @@ def awslogs_handler(event, context, metadata):
             if not metadata[DD_CUSTOM_TAGS]
             else metadata[DD_CUSTOM_TAGS] + "," + ",".join(formatted_tags)
         )
+
+    # Set service from custom tags, which may include the tags set on the log group
+    metadata[DD_SERVICE] = get_service_from_tags(metadata)
 
     # Set host as log group where cloudwatch is source
     if metadata[DD_SOURCE] == "cloudwatch" or metadata.get(DD_HOST, None) == None:


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

Moves setting the service from the tags after the tags have been augmented by the log group tags

### Motivation

<!--- What inspired you to submit this pull request? --->

We're trying to set the `service` tag on a log group, and it's not being used

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
