### PR TITLE
Revert Enhanced metrics changes

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -117,7 +117,7 @@ If you can't install the Forwarder using the provided CloudFormation template, y
 1. Create a Python 3.9 Lambda function using `aws-dd-forwarder-<VERSION>.zip` from the latest [releases][101].
 2. Save your [Datadog API key][102] in AWS Secrets Manager, set environment variable `DD_API_KEY_SECRET_ARN` with the secret ARN on the Lambda function, and add the `secretsmanager:GetSecretValue` permission to the Lambda execution role.
 3. If you need to forward logs from S3 buckets, add the `s3:GetObject` permission to the Lambda execution role.
-4. Set the environment variable `DD_ENHANCED_METRICS` to `false` on the Forwarder. This stops the Forwarder from generating enhanced metrics from other lambdas.
+4. Set the environment variable `DD_ENHANCED_METRICS` to `false` on the Forwarder. This stops the Forwarder from generating enhanced metrics itself, but it will still forward custom metrics from other lambdas.
 5. Some AWS accounts are configured such that triggers will not automatically create resource-based policies allowing Cloudwatch log groups to invoke the forwarder. Reference the [CloudWatchLogPermissions][103] to see which permissions are required for the forwarder to be invoked by Cloudwatch Log Events.
 6. [Configure triggers][104].
 7. Create an S3 bucket, and set environment variable `DD_S3_BUCKET_NAME` to the bucket name. Also provide `s3:GetObject`, `s3:PutObject`, and `s3:DeleteObject` permissions on this bucket to the Lambda execution role. This bucket is used to store the Lambda tags cache.

--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -44,7 +44,6 @@ from settings import (
     DD_HOST,
     DD_FORWARDER_VERSION,
     DD_ADDITIONAL_TARGET_LAMBDAS,
-    DD_ENHANCED_METRICS,
 )
 
 
@@ -99,8 +98,8 @@ def datadog_forwarder(event, context):
 
     if len(trace_payloads) > 0:
         forward_traces(trace_payloads)
-    if DD_ENHANCED_METRICS:
-        parse_and_submit_enhanced_metrics(logs)
+
+    parse_and_submit_enhanced_metrics(logs)
 
 
 lambda_handler = datadog_lambda_wrapper(datadog_forwarder)

--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -57,12 +57,6 @@ DD_API_KEY = "<YOUR_DATADOG_API_KEY>"
 #
 DD_FORWARD_LOG = get_env_var("DD_FORWARD_LOG", "true", boolean=True)
 
-## @param DD_ENHANCED_METRICS - boolean - optional -default: false
-## Change this value to `true` to send enhanced lambda metrics to Datadog
-## E.g. forwarded lambda logs will contribute to enhanced metrics for those lambdas
-#
-DD_ENHANCED_METRICS = get_env_var("DD_ENHANCED_METRICS", "false", boolean=True)
-
 ## @param DD_USE_TCP - boolean - optional -default: false
 ## Change this value to `true` to send your logs and metrics using the TCP network client
 ## By default, it uses the HTTP client.

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -486,7 +486,7 @@ Resources:
           Value: !FindInMap [Constants, DdForwarder, Version]
       Environment:
         Variables:
-          DD_ENHANCED_METRICS: "true"
+          DD_ENHANCED_METRICS: "false"
           DD_API_KEY_SECRET_ARN:
             Fn::If:
               - CreateDdApiKeySecret

--- a/aws/logs_monitoring/tools/integration_tests/docker-compose.yml
+++ b/aws/logs_monitoring/tools/integration_tests/docker-compose.yml
@@ -21,7 +21,6 @@ services:
       DD_TRACE_INTAKE_URL: http://recorder:8080
       DD_NO_SSL: "true"
       DD_SKIP_SSL_VALIDATION: "true"
-      DD_ENHANCED_METRICS: "true"
       DD_USE_TCP: "false"
       DD_USE_COMPRESSION: "false"
       DD_ADDITIONAL_TARGET_LAMBDAS: "${EXTERNAL_LAMBDAS}"


### PR DESCRIPTION
We've been asked to revert the changes made to `DD_ENHANCED_METRICS` for a few reasons.

Automatically generated enhanced metrics may be confusing but they are free of charge (since metrics starts with `aws.`, then don't count towards metric billing)
People only get billed for Datadog Serverless by `aws.lambda.enhanced.invocations` metric, which isn't generated by the forwarder (it's generated by our [datadog-lambda library](https://github.com/Datadog/datadog-lambda-python) when a function gets instrumented. This behavior isn't ideal, but it has no real customer impact (all free), and it's inevitable, because the forwarder has no way to know if the logs' origin lambda function is instrumented or not (aka, whether ppl expect the forwarder to generate enhanced metrics or not). That's why we landed in that slightly confusing, yet no harm behavior.

The forwarder reuses [datadog-lambda library](https://github.com/Datadog/datadog-lambda-python) (which would generate `aws.lambda.enhanced.invocations`) under the hood, therefore DD_ENHANCED_METRICS was originally default to false to prevent the forwarder from generating `aws.lambda.enhanced.invocations` for the forwarder itself.

To avoid potential regressions we decided along w/ our Serverless team to revert to the original behavior