### PR TITLE
feat(aws): set DD_SOURCE, DD_SERVICE, and DD_HOST for AWS Batch logs

### DIFF
--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -292,6 +292,9 @@ def find_cloudwatch_source(log_group):
     ):
         return "apigateway"
 
+    if log_group.startswith('/aws/batch/job'):
+        return "batch"
+
     if log_group.startswith("/aws/vendedlogs/states"):
         return "stepfunction"
 
@@ -516,6 +519,10 @@ def awslogs_handler(event, context, metadata):
 
     # Set service from custom tags, which may include the tags set on the log group
     metadata[DD_SERVICE] = get_service_from_tags(metadata)
+
+    if metadata[DD_SOURCE] == "batch":
+        metadata[DD_SERVICE] = aws_attributes["aws"]["awslogs"]["logStream"].split("/")[0]
+        metadata[DD_HOST] = aws_attributes["aws"]["awslogs"]["logStream"].split("/")[-1]
 
     # Set host as log group where cloudwatch is source
     if metadata[DD_SOURCE] == "cloudwatch" or metadata.get(DD_HOST, None) == None:

--- a/aws/logs_monitoring/tests/test_parsing.py
+++ b/aws/logs_monitoring/tests/test_parsing.py
@@ -865,6 +865,87 @@ class TestAWSLogsHandler(unittest.TestCase):
         )
 
     @patch("parsing.CloudwatchLogGroupTagsCache.get")
+    @patch("parsing.CloudwatchLogGroupTagsCache.release_s3_cache_lock")
+    @patch("parsing.CloudwatchLogGroupTagsCache.acquire_s3_cache_lock")
+    @patch("parsing.CloudwatchLogGroupTagsCache.write_cache_to_s3")
+    @patch("base_tags_cache.send_forwarder_internal_metrics")
+    @patch("parsing.CloudwatchLogGroupTagsCache.get_cache_from_s3")
+    def test_awslogs_handler_aws_batch(
+        self,
+        mock_get_s3_cache,
+        mock_forward_metrics,
+        mock_write_cache,
+        mock_acquire_lock,
+        mock_release_lock,
+        mock_cache_get,
+    ):
+        os.environ["DD_FETCH_LAMBDA_TAGS"] = "True"
+        os.environ["DD_FETCH_LOG_GROUP_TAGS"] = "True"
+        mock_acquire_lock.return_value = True
+        mock_cache_get.return_value = ["test_tag_key:test_tag_value"]
+        mock_get_s3_cache.return_value = (
+            {},
+            1000,
+        )
+
+        event = {
+            "awslogs": {
+                "data": base64.b64encode(
+                    gzip.compress(
+                        bytes(
+                            json.dumps(
+                                {
+                                    "messageType": "DATA_MESSAGE",
+                                    "owner": "425362996713",
+                                    "logGroup": "/aws/batch/job",
+                                    "logStream": "BatchJobName/default/abc123",
+                                    "subscriptionFilters": ["testFilter"],
+                                    "logEvents": [
+                                        {
+                                            "id": "37199773595581154154810589279545129148442535997644275712",
+                                            "timestamp": 1668095539607,
+                                            "message": '{"id":"1","type":"ExecutionStarted"}',
+                                        }
+                                    ],
+                                }
+                            ),
+                            "utf-8",
+                        )
+                    )
+                )
+            }
+        }
+        context = None
+        metadata = {"ddsource": "batch", "ddtags": "env:dev"}
+
+        self.assertEqual(
+            [
+                {
+                    "aws": {
+                        "awslogs": {
+                            "logGroup": "/aws/batch/job",
+                            "logStream": "BatchJobName/default/abc123",
+                            "owner": "425362996713",
+                        }
+                    },
+                    "id": "37199773595581154154810589279545129148442535997644275712",
+                    "message": '{"id":"1","type":"ExecutionStarted"}',
+                    "timestamp": 1668095539607,
+                }
+            ],
+            list(awslogs_handler(event, context, metadata)),
+        )
+        self.assertEqual(
+            {
+                "ddsource": "batch",
+                "ddtags": "env:dev,test_tag_key:test_tag_value",
+                "host": "abc123",
+                "service": "BatchJobName",
+            },
+            metadata,
+        )
+
+    @patch("parsing.CloudwatchLogGroupTagsCache.get")
     @patch("parsing.StepFunctionsTagsCache.get")
     @patch("parsing.StepFunctionsTagsCache.release_s3_cache_lock")
     @patch("parsing.StepFunctionsTagsCache.acquire_s3_cache_lock")


### PR DESCRIPTION
### What does this PR do?

This PR sets the `DD_SOURCE`, `DD_SERVICE`, and `DD_HOST` values for logs coming from AWS Batch.

### Motivation

All of our batch logs are lumped into one bucket. We'd like to be able to separate out our AWS Batch logs by job, using `DD_SERVICE` while having a simple value of `batch` for the `DD_SOURCE`. The `DD_HOST` is set to the use the Fargate container ID.

### Testing Guidelines

Build this and update the forwarder lambda to use the new zip. Ensure that AWS Batch logs come through appropriately.

### Types of changes

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [X] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [X] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [X] This PR passes the unit tests
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
