### PR TITLE
Update Lambda Log Forwarder docs troubleshooting - timestamps

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -191,8 +191,10 @@ You can also add additional logging or code for deeper investigation. Find instr
 
 Manually updating the `.zip` code of the Forwarder may cause conflicts with Cloudformation updates for Forwarder installations where the code is packaged in a Lambda layer (default installation choice from version `3.33.0`) and cause invocation errors. In this case, updating the stack through Cloudformation to the latest available twice in a row (first with `InstallAsLayer` set to `false`, and then to `true`) should solve the issue as it will remove any `.zip` remnants and install the latest layer available.
 
-
 If you still couldn't figure out, please create a ticket for [Datadog Support][10] with a copy of debugging logs.
+
+### JSON-formatted logs not appearing in Datadog
+If your logs contain an attribute that Datadog parses as a timestamp, you need to make sure that the timestamp is both current and in the correct format. To learn more about which attributes are parsed as timestamps, and how to make sure that timestamp is valid, visit the [Log Processors > Log date remapper documentation][24].
 
 ## Contributing
 
@@ -558,3 +560,4 @@ Additional helpful documentation, links, and articles:
 [21]: https://docs.datadoghq.com/logs/processing/pipelines/
 [22]: https://docs.datadoghq.com/agent/guide/private-link/
 [23]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/transform-aws-serverless.html
+[24]: https://docs.datadoghq.com/logs/log_configuration/processors/?tab=ui#log-date-remapper

--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -194,7 +194,7 @@ Manually updating the `.zip` code of the Forwarder may cause conflicts with Clou
 If you still couldn't figure out, please create a ticket for [Datadog Support][10] with a copy of debugging logs.
 
 ### JSON-formatted logs not appearing in Datadog
-If your logs contain an attribute that Datadog parses as a timestamp, you need to make sure that the timestamp is both current and in the correct format. To learn more about which attributes are parsed as timestamps, and how to make sure that the timestamp is valid, visit the [Log Processors > Log date remapper documentation][24].
+If your logs contain an attribute that Datadog parses as a timestamp, you need to make sure that the timestamp is both current and in the correct format. To learn more about which attributes are parsed as timestamps, and how to make sure that the timestamp is valid, visit the [Logs Processors > Log date remapper documentation][24].
 
 ## Contributing
 

--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -194,7 +194,7 @@ Manually updating the `.zip` code of the Forwarder may cause conflicts with Clou
 If you still couldn't figure out, please create a ticket for [Datadog Support][10] with a copy of debugging logs.
 
 ### JSON-formatted logs not appearing in Datadog
-If your logs contain an attribute that Datadog parses as a timestamp, you need to make sure that the timestamp is both current and in the correct format. To learn more about which attributes are parsed as timestamps, and how to make sure that timestamp is valid, visit the [Log Processors > Log date remapper documentation][24].
+If your logs contain an attribute that Datadog parses as a timestamp, you need to make sure that the timestamp is both current and in the correct format. To learn more about which attributes are parsed as timestamps, and how to make sure that the timestamp is valid, visit the [Log Processors > Log date remapper documentation][24].
 
 ## Contributing
 

--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -194,7 +194,7 @@ Manually updating the `.zip` code of the Forwarder may cause conflicts with Clou
 If you still couldn't figure out, please create a ticket for [Datadog Support][10] with a copy of debugging logs.
 
 ### JSON-formatted logs are not appearing in Datadog
-If your logs contain an attribute that Datadog parses as a timestamp, you need to make sure that the timestamp is both current and in the correct format. To learn more about which attributes are parsed as timestamps, and how to make sure that the timestamp is valid, visit the [Logs Processors > Log date remapper documentation][24].
+If your logs contain an attribute that Datadog parses as a timestamp, you need to make sure that the timestamp is both current and in the correct format. See [Log Date Remapper][24] to learn about which attributes are parsed as timestamps and how to make sure that the timestamp is valid.
 
 ## Contributing
 

--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -193,7 +193,7 @@ Manually updating the `.zip` code of the Forwarder may cause conflicts with Clou
 
 If you still couldn't figure out, please create a ticket for [Datadog Support][10] with a copy of debugging logs.
 
-### JSON-formatted logs not appearing in Datadog
+### JSON-formatted logs are not appearing in Datadog
 If your logs contain an attribute that Datadog parses as a timestamp, you need to make sure that the timestamp is both current and in the correct format. To learn more about which attributes are parsed as timestamps, and how to make sure that the timestamp is valid, visit the [Logs Processors > Log date remapper documentation][24].
 
 ## Contributing


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adds a section to the Datadog Lambda Forwarder documentation about valid timestamps, referencing the Logs timestamp remapper documentation
### Motivation

A customer support ticket where this was the root cause for logs not appearing in Datadog: https://datadog.zendesk.com/agent/tickets/1385418
### Testing Guidelines

Previewed the markdown locally, otherwise untested
### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
