### PR TITLE
[AWSMC-588] Support Bedrock log source

### DIFF
--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -381,6 +381,7 @@ def find_s3_source(key):
         "network-firewall",
         "cloudfront",
         "verified-access",
+        "bedrock",
     ]:
         if source in key:
             return source.replace("amazon_", "")
@@ -608,6 +609,10 @@ def awslogs_handler(event, context, metadata):
         elif logs["logStream"].startswith("authenticator-"):
             metadata[DD_SOURCE] = "aws-iam-authenticator"
         # In case the conditions above don't match we maintain eks as the source
+
+    # Bedrock allows using any custom logGroup, but creates the logStream with this name
+    if logs["logStream"] == "aws/bedrock/modelinvocations":
+        metadata[DD_SOURCE] = "amazon_bedrock"
 
     # Create and send structured logs to Datadog
     for log in logs["logEvents"]:

--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -612,7 +612,7 @@ def awslogs_handler(event, context, metadata):
 
     # Bedrock allows using any custom logGroup, but creates the logStream with this name
     if logs["logStream"] == "aws/bedrock/modelinvocations":
-        metadata[DD_SOURCE] = "amazon_bedrock"
+        metadata[DD_SOURCE] = "bedrock"
 
     # Create and send structured logs to Datadog
     for log in logs["logEvents"]:

--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -614,10 +614,6 @@ def awslogs_handler(event, context, metadata):
             metadata[DD_SOURCE] = "aws-iam-authenticator"
         # In case the conditions above don't match we maintain eks as the source
 
-    # Bedrock allows using any custom logGroup, but creates the logStream with this name
-    if logs["logStream"] == "aws/bedrock/modelinvocations":
-        metadata[DD_SOURCE] = "bedrock"
-
     # Create and send structured logs to Datadog
     for log in logs["logEvents"]:
         yield merge_dicts(log, aws_attributes)

--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -331,7 +331,7 @@ def find_cloudwatch_source(log_group):
         "elasticsearch",
         "transitgateway",
         "verified-access",
-        "bedrock"
+        "bedrock",
     ]:
         if source in log_group:
             return source


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Enables setting `bedrock` as the `source` tag for logs coming from s3 or Cloudwatch log groups 

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->
Tested by building the layer and using with a deployed Forwarder Lambda, configuring Model Invocation logs for both S3 and CloudWatch for Bedrock in the AWS account, and running some test model invocations to produce logs. Verified that both S3 and CloudWatch logs were received in the org with the `source` and `service` tags correctly set to `bedrock`.
![image](https://github.com/DataDog/datadog-serverless-functions/assets/5915468/953c4cc6-e4c7-46f9-8ab8-fd8f51fc27da)

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
