### PR TITLE
[DOCS-6793] Remove region param from Forwarder doc

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -100,7 +100,7 @@ resource "aws_cloudformation_stack" "datadog_forwarder" {
 }
 ```
 
-**Note**: Ensure that the `DdSite` parameter matches your [Datadog site][104]. Replace `<SITE>` with {{< region-param key="dd_site" code="true" >}}.
+**Note**: Ensure that the `DdSite` parameter matches your [Datadog site][104]. Select your site on the right side of this page. Replace `<SITE>` in the above sample configuration with {{< region-param key="dd_site" code="true" >}}.
 
 [101]: https://www.terraform.io/docs/providers/aws/r/cloudformation_stack
 [102]: https://app.datadoghq.com/organization-settings/api-keys

--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -93,14 +93,14 @@ resource "aws_cloudformation_stack" "datadog_forwarder" {
   capabilities = ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
   parameters   = {
     DdApiKeySecretArn  = "REPLACE ME WITH THE SECRETS ARN",
-    DdSite             = "{{< region-param key="dd_site" code="true" >}}",
+    DdSite             = "<SITE>",
     FunctionName       = "datadog-forwarder"
   }
   template_url = "https://datadog-cloudformation-template.s3.amazonaws.com/aws/forwarder/latest.yaml"
 }
 ```
 
-**Note**: Ensure that the `DdSite` parameter matches your [Datadog site][104]. Your Datadog site is {{< region-param key="dd_site" code="true" >}}.
+**Note**: Ensure that the `DdSite` parameter matches your [Datadog site][104]. Replace `<SITE>` with {{< region-param key="dd_site" code="true" >}}.
 
 [101]: https://www.terraform.io/docs/providers/aws/r/cloudformation_stack
 [102]: https://app.datadoghq.com/organization-settings/api-keys


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Remove region param from the Terraform section because the region param breaks when used in a code block within a tab.

[DOCS-6793](https://datadoghq.atlassian.net/browse/DOCS-6793)

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)


[DOCS-6793]: https://datadoghq.atlassian.net/browse/DOCS-6793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ