### PR TITLE
Add OpenSearch to source identification

### DIFF
--- a/aws/logs_monitoring/parsing.py
+++ b/aws/logs_monitoring/parsing.py
@@ -331,6 +331,13 @@ def find_cloudwatch_source(log_group):
     if log_group.startswith("/aws/appsync/"):
         return "appsync"
 
+    # e.g. /aws/OpenSearchService/domains/*/SEARCH_SLOW_LOGS
+    # e.g. /aws/OpenSearchService/domains/*/INDEX_SLOW_LOGS
+    # e.g. /aws/OpenSearchService/domains/*/ES_APPLICATION_LOGS
+    # e.g. /aws/OpenSearchService/domains/*/AUDIT_LOGS
+    if log_group.startswith("/aws/opensearchservice/domains/"):
+        return "elasticsearch"
+
     for source in [
         "/aws/lambda",  # e.g. /aws/lambda/helloDatadog
         "/aws/codebuild",  # e.g. /aws/codebuild/my-project

--- a/aws/logs_monitoring/tests/test_parsing.py
+++ b/aws/logs_monitoring/tests/test_parsing.py
@@ -273,6 +273,15 @@ class TestParseEventSource(unittest.TestCase):
             "appsync",
         )
 
+    def test_opensearch_event(self):
+        self.assertEqual(
+            parse_event_source(
+                {"awslogs": "logs"},
+                "/aws/OpenSearchService/domains/my-opensearch-cluster/ES_APPLICATION_LOGS",
+            ),
+            "elasticsearch",
+        )
+
     def test_cloudfront_event(self):
         self.assertEqual(
             parse_event_source(


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adds support for identifying the source of OpenSearch logs from Cloudwatch log groups. More on OpenSearch logs can be found at: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/createdomain-configure-slow-logs.html

### Motivation

If forwarded to Datadog, the source identification for these currently defaults to cloudwatch

### Testing Guidelines

A new test has been added.

### Additional Notes

I'm not sure if the returned source should be `elasticsearch` or `opensearch`. I know from [reading the docs](https://docs.datadoghq.com/integrations/elastic/?s=elasticsearch#overview) Datadog knows how to parse ElasticSearch logs (assuming when `source:elasticsearch` is set on a log event) but I'm not sure if OpenSearch logs are different enough to need to parse differently (and if Datadog has some out of the box parsing rules for `source:opensearch`.

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
