### PR TITLE
[AWSX-597] fix(vuln): bump datadog-lambda from 4.77.0 to 5.87.0

### DIFF
--- a/aws/logs_monitoring/setup.py
+++ b/aws/logs_monitoring/setup.py
@@ -18,7 +18,7 @@ setup(
     keywords="datadog aws lambda layer",
     python_requires=">=3.10, <3.12",
     install_requires=[
-        "datadog-lambda==4.77.0",
+        "datadog-lambda==5.87.0",
         "requests-futures==1.0.0",
     ],
     extras_require={

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_customized_log_group_lambda_invocation.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_customized_log_group_lambda_invocation.json~snapshot
@@ -80,6 +80,8 @@
         "DD-EVP-ORIGIN-VERSION": "<redacted from snapshot>",
         "Host": "recorder:8080",
         "User-Agent": "<redacted from snapshot>",
+        "traceparent": "00-0000000000000000433534434534ef0d-91ed514f1e5c03b2-01",
+        "tracestate": "dd=s:2",
         "x-datadog-parent-id": "<redacted from snapshot>",
         "x-datadog-sampling-priority": "2",
         "x-datadog-trace-id": "4842834437835386637"
@@ -158,6 +160,8 @@
         "DD-API-KEY": "abcdefghijklmnopqrstuvwxyz012345",
         "Host": "recorder:8080",
         "User-Agent": "<redacted from snapshot>",
+        "traceparent": "00-0000000000000000433534434534ef0d-91ed514f1e5c03b2-01",
+        "tracestate": "dd=s:2",
         "x-datadog-parent-id": "<redacted from snapshot>",
         "x-datadog-sampling-priority": "2",
         "x-datadog-trace-id": "4842834437835386637"

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log.json~snapshot
@@ -52,6 +52,8 @@
         "DD-EVP-ORIGIN-VERSION": "<redacted from snapshot>",
         "Host": "recorder:8080",
         "User-Agent": "<redacted from snapshot>",
+        "traceparent": "00-0000000000000000433534434534ef0d-91ed514f1e5c03b2-01",
+        "tracestate": "dd=s:2",
         "x-datadog-parent-id": "<redacted from snapshot>",
         "x-datadog-sampling-priority": "2",
         "x-datadog-trace-id": "4842834437835386637"
@@ -130,6 +132,8 @@
         "DD-API-KEY": "abcdefghijklmnopqrstuvwxyz012345",
         "Host": "recorder:8080",
         "User-Agent": "<redacted from snapshot>",
+        "traceparent": "00-0000000000000000433534434534ef0d-91ed514f1e5c03b2-01",
+        "tracestate": "dd=s:2",
         "x-datadog-parent-id": "<redacted from snapshot>",
         "x-datadog-sampling-priority": "2",
         "x-datadog-trace-id": "4842834437835386637"

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_apigateway.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_apigateway.json~snapshot
@@ -57,6 +57,8 @@
         "DD-API-KEY": "abcdefghijklmnopqrstuvwxyz012345",
         "Host": "recorder:8080",
         "User-Agent": "<redacted from snapshot>",
+        "traceparent": "00-0000000000000000433534434534ef0d-91ed514f1e5c03b2-01",
+        "tracestate": "dd=s:2",
         "x-datadog-parent-id": "<redacted from snapshot>",
         "x-datadog-sampling-priority": "2",
         "x-datadog-trace-id": "4842834437835386637"

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_cloudtrail.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_cloudtrail.json~snapshot
@@ -90,6 +90,8 @@
         "DD-EVP-ORIGIN-VERSION": "<redacted from snapshot>",
         "Host": "recorder:8080",
         "User-Agent": "<redacted from snapshot>",
+        "traceparent": "00-0000000000000000433534434534ef0d-91ed514f1e5c03b2-01",
+        "tracestate": "dd=s:2",
         "x-datadog-parent-id": "<redacted from snapshot>",
         "x-datadog-sampling-priority": "2",
         "x-datadog-trace-id": "4842834437835386637"
@@ -168,6 +170,8 @@
         "DD-API-KEY": "abcdefghijklmnopqrstuvwxyz012345",
         "Host": "recorder:8080",
         "User-Agent": "<redacted from snapshot>",
+        "traceparent": "00-0000000000000000433534434534ef0d-91ed514f1e5c03b2-01",
+        "tracestate": "dd=s:2",
         "x-datadog-parent-id": "<redacted from snapshot>",
         "x-datadog-sampling-priority": "2",
         "x-datadog-trace-id": "4842834437835386637"

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_coldstart.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_coldstart.json~snapshot
@@ -85,6 +85,8 @@
         "DD-API-KEY": "abcdefghijklmnopqrstuvwxyz012345",
         "Host": "recorder:8080",
         "User-Agent": "<redacted from snapshot>",
+        "traceparent": "00-0000000000000000433534434534ef0d-91ed514f1e5c03b2-01",
+        "tracestate": "dd=s:2",
         "x-datadog-parent-id": "<redacted from snapshot>",
         "x-datadog-sampling-priority": "2",
         "x-datadog-trace-id": "4842834437835386637"

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_custom_tags.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_custom_tags.json~snapshot
@@ -33,6 +33,8 @@
         "DD-EVP-ORIGIN-VERSION": "<redacted from snapshot>",
         "Host": "recorder:8080",
         "User-Agent": "<redacted from snapshot>",
+        "traceparent": "00-0000000000000000433534434534ef0d-91ed514f1e5c03b2-01",
+        "tracestate": "dd=s:2",
         "x-datadog-parent-id": "<redacted from snapshot>",
         "x-datadog-sampling-priority": "2",
         "x-datadog-trace-id": "4842834437835386637"
@@ -97,6 +99,8 @@
         "DD-API-KEY": "abcdefghijklmnopqrstuvwxyz012345",
         "Host": "recorder:8080",
         "User-Agent": "<redacted from snapshot>",
+        "traceparent": "00-0000000000000000433534434534ef0d-91ed514f1e5c03b2-01",
+        "tracestate": "dd=s:2",
         "x-datadog-parent-id": "<redacted from snapshot>",
         "x-datadog-sampling-priority": "2",
         "x-datadog-trace-id": "4842834437835386637"

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_fsx_windows.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_fsx_windows.json~snapshot
@@ -33,6 +33,8 @@
         "DD-EVP-ORIGIN-VERSION": "<redacted from snapshot>",
         "Host": "recorder:8080",
         "User-Agent": "<redacted from snapshot>",
+        "traceparent": "00-0000000000000000433534434534ef0d-91ed514f1e5c03b2-01",
+        "tracestate": "dd=s:2",
         "x-datadog-parent-id": "<redacted from snapshot>",
         "x-datadog-sampling-priority": "2",
         "x-datadog-trace-id": "4842834437835386637"
@@ -111,6 +113,8 @@
         "DD-API-KEY": "abcdefghijklmnopqrstuvwxyz012345",
         "Host": "recorder:8080",
         "User-Agent": "<redacted from snapshot>",
+        "traceparent": "00-0000000000000000433534434534ef0d-91ed514f1e5c03b2-01",
+        "tracestate": "dd=s:2",
         "x-datadog-parent-id": "<redacted from snapshot>",
         "x-datadog-sampling-priority": "2",
         "x-datadog-trace-id": "4842834437835386637"

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_lambda_invocation.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_lambda_invocation.json~snapshot
@@ -366,6 +366,8 @@
         "DD-EVP-ORIGIN-VERSION": "<redacted from snapshot>",
         "Host": "recorder:8080",
         "User-Agent": "<redacted from snapshot>",
+        "traceparent": "00-0000000000000000433534434534ef0d-91ed514f1e5c03b2-01",
+        "tracestate": "dd=s:2",
         "x-datadog-parent-id": "<redacted from snapshot>",
         "x-datadog-sampling-priority": "2",
         "x-datadog-trace-id": "4842834437835386637"
@@ -947,6 +949,8 @@
         "DD-API-KEY": "abcdefghijklmnopqrstuvwxyz012345",
         "Host": "recorder:8080",
         "User-Agent": "<redacted from snapshot>",
+        "traceparent": "00-0000000000000000433534434534ef0d-91ed514f1e5c03b2-01",
+        "tracestate": "dd=s:2",
         "x-datadog-parent-id": "<redacted from snapshot>",
         "x-datadog-sampling-priority": "2",
         "x-datadog-trace-id": "4842834437835386637"

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_route53.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_route53.json~snapshot
@@ -33,6 +33,8 @@
         "DD-EVP-ORIGIN-VERSION": "<redacted from snapshot>",
         "Host": "recorder:8080",
         "User-Agent": "<redacted from snapshot>",
+        "traceparent": "00-0000000000000000433534434534ef0d-91ed514f1e5c03b2-01",
+        "tracestate": "dd=s:2",
         "x-datadog-parent-id": "<redacted from snapshot>",
         "x-datadog-sampling-priority": "2",
         "x-datadog-trace-id": "4842834437835386637"
@@ -111,6 +113,8 @@
         "DD-API-KEY": "abcdefghijklmnopqrstuvwxyz012345",
         "Host": "recorder:8080",
         "User-Agent": "<redacted from snapshot>",
+        "traceparent": "00-0000000000000000433534434534ef0d-91ed514f1e5c03b2-01",
+        "tracestate": "dd=s:2",
         "x-datadog-parent-id": "<redacted from snapshot>",
         "x-datadog-sampling-priority": "2",
         "x-datadog-trace-id": "4842834437835386637"

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_service_tag.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_service_tag.json~snapshot
@@ -33,6 +33,8 @@
         "DD-EVP-ORIGIN-VERSION": "<redacted from snapshot>",
         "Host": "recorder:8080",
         "User-Agent": "<redacted from snapshot>",
+        "traceparent": "00-0000000000000000433534434534ef0d-91ed514f1e5c03b2-01",
+        "tracestate": "dd=s:2",
         "x-datadog-parent-id": "<redacted from snapshot>",
         "x-datadog-sampling-priority": "2",
         "x-datadog-trace-id": "4842834437835386637"
@@ -97,6 +99,8 @@
         "DD-API-KEY": "abcdefghijklmnopqrstuvwxyz012345",
         "Host": "recorder:8080",
         "User-Agent": "<redacted from snapshot>",
+        "traceparent": "00-0000000000000000433534434534ef0d-91ed514f1e5c03b2-01",
+        "tracestate": "dd=s:2",
         "x-datadog-parent-id": "<redacted from snapshot>",
         "x-datadog-sampling-priority": "2",
         "x-datadog-trace-id": "4842834437835386637"

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_timeout.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_timeout.json~snapshot
@@ -102,6 +102,8 @@
         "DD-EVP-ORIGIN-VERSION": "<redacted from snapshot>",
         "Host": "recorder:8080",
         "User-Agent": "<redacted from snapshot>",
+        "traceparent": "00-0000000000000000433534434534ef0d-91ed514f1e5c03b2-01",
+        "tracestate": "dd=s:2",
         "x-datadog-parent-id": "<redacted from snapshot>",
         "x-datadog-sampling-priority": "2",
         "x-datadog-trace-id": "4842834437835386637"
@@ -180,6 +182,8 @@
         "DD-API-KEY": "abcdefghijklmnopqrstuvwxyz012345",
         "Host": "recorder:8080",
         "User-Agent": "<redacted from snapshot>",
+        "traceparent": "00-0000000000000000433534434534ef0d-91ed514f1e5c03b2-01",
+        "tracestate": "dd=s:2",
         "x-datadog-parent-id": "<redacted from snapshot>",
         "x-datadog-sampling-priority": "2",
         "x-datadog-trace-id": "4842834437835386637"

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/step_functions_log.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/step_functions_log.json~snapshot
@@ -33,6 +33,8 @@
         "DD-EVP-ORIGIN-VERSION": "<redacted from snapshot>",
         "Host": "recorder:8080",
         "User-Agent": "<redacted from snapshot>",
+        "traceparent": "00-0000000000000000433534434534ef0d-91ed514f1e5c03b2-01",
+        "tracestate": "dd=s:2",
         "x-datadog-parent-id": "<redacted from snapshot>",
         "x-datadog-sampling-priority": "2",
         "x-datadog-trace-id": "4842834437835386637"
@@ -125,6 +127,8 @@
         "DD-API-KEY": "abcdefghijklmnopqrstuvwxyz012345",
         "Host": "recorder:8080",
         "User-Agent": "<redacted from snapshot>",
+        "traceparent": "00-0000000000000000433534434534ef0d-91ed514f1e5c03b2-01",
+        "tracestate": "dd=s:2",
         "x-datadog-parent-id": "<redacted from snapshot>",
         "x-datadog-sampling-priority": "2",
         "x-datadog-trace-id": "4842834437835386637"


### PR DESCRIPTION
### What does this PR do?

Bump the `datadog-lambda` library dependency from `4.77.0` to its latest version `5.87.0` to address security concerns

### Motivation

Keep our dependencies up to date

### Testing Guidelines

Tested in our sandbox environment

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X ] Misc (docs, refactoring, dependency upgrade, etc.)
