### PR TITLE
[AWS] Add support for Python 3.11, arm64 for RDS/VPC lambda

### DIFF
--- a/aws/logs_monitoring/cloudwatch_log_group_cache.py
+++ b/aws/logs_monitoring/cloudwatch_log_group_cache.py
@@ -82,12 +82,14 @@ def get_log_group_tags(log_group):
     formatted_tags = None
     if response is not None:
         formatted_tags = [
-            "{key}:{value}".format(
-                key=sanitize_aws_tag_string(k, remove_colons=True),
-                value=sanitize_aws_tag_string(v, remove_leading_digits=False),
+            (
+                "{key}:{value}".format(
+                    key=sanitize_aws_tag_string(k, remove_colons=True),
+                    value=sanitize_aws_tag_string(v, remove_leading_digits=False),
+                )
+                if v
+                else sanitize_aws_tag_string(k, remove_colons=True)
             )
-            if v
-            else sanitize_aws_tag_string(k, remove_colons=True)
             for k, v in response["tags"].items()
         ]
     return formatted_tags

--- a/aws/rds_enhanced_monitoring/README.md
+++ b/aws/rds_enhanced_monitoring/README.md
@@ -273,7 +273,7 @@ d. **Not Recommended**: Plaintext
 
    - Create a `lambda_execution` role and attach this policy.
 
-   - Create a lambda function: skip the blueprint, name it `functionname`, set the runtime to `Python 3.10`, the handle to `lambda_function.lambda_handler`, and the role to `lambda_execution`.
+   - Create a lambda function: skip the blueprint, name it `functionname`, set the Runtime to `Python 3.11`, the Architecture to `arm64`, the handle to `lambda_function.lambda_handler`, and the role to `lambda_execution`.
 
    - Copy the content of `functionname/lambda_function.py` in the code section
 

--- a/aws/rds_enhanced_monitoring/rds-enhanced-sam-template.yaml
+++ b/aws/rds_enhanced_monitoring/rds-enhanced-sam-template.yaml
@@ -18,7 +18,9 @@ Resources:
       Policies:
         KMSDecryptPolicy:
           KeyId: !Ref KMSKeyId
-      Runtime: python3.10
+      Architectures:
+        - arm64
+      Runtime: python3.11
       Timeout: 10
       KmsKeyArn:
         !Sub

--- a/aws/vpc_flow_log_monitoring/README.md
+++ b/aws/vpc_flow_log_monitoring/README.md
@@ -49,7 +49,7 @@ version, account, eni, source, destination, srcport, destport="22", protocol="6"
 
    - Create a `lambda_execution` role and attach this policy
 
-   - Create a lambda function: Skip the blueprint, name it `functionname`, set the Runtime to `Python 3.10`, the handle to `lambda_function.lambda_handler`, and the role to `lambda_execution`.
+   - Create a lambda function: Skip the blueprint, name it `functionname`, set the Runtime to `Python 3.11`, the Architecture to `arm64`,, the handle to `lambda_function.lambda_handler`, and the role to `lambda_execution`.
 
    - Copy the content of `functionname/lambda_function.py` in the code section, make sure to update the `KMS_ENCRYPTED_KEYS` environment variable with the encrypted key generated in step 1
 

--- a/aws/vpc_flow_log_monitoring/vpc-flow-log-sam-template.yaml
+++ b/aws/vpc_flow_log_monitoring/vpc-flow-log-sam-template.yaml
@@ -18,7 +18,9 @@ Resources:
       Policies:
         KMSDecryptPolicy:
           KeyId: !Ref KMSKeyId
-      Runtime: python3.10
+      Runtime: python3.11
+      Architectures:
+        - arm64
       Timeout: 10
       KmsKeyArn:
         !Sub


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Updates the Cloudformation SAM templates to support Python 3.11 and arm64 for the RDS and VPC lambdas.
Because there's a change in support architecture (from x86_64 to arm) and in runtime, it is advised to perform the update manually in 2 steps (AWS will throw an error otherwise)
* Update the runtime
* Update the architecture.
No code change otherwise

New installations from the Marketplace of applications or Cloudformation should work out of the box.


Tested all changes in our sandbox account.