### PR TITLE
Change UseVPC to DdUseVPC in PrivateLink documentation

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -261,7 +261,7 @@ You can run the Forwarder in a VPC private subnet and send data to Datadog over 
 1. Follow [these instructions][14] to add the Datadog `api`, `http-logs.intake`, and `trace.agent` endpoints to your VPC.
 2. Follow the [instructions][15] to add the AWS Secrets Manager and S3 endpoints to your VPC.
 3. When installing the Forwarder with the CloudFormation template:
-   1. Set `UseVPC` to `true`.
+   1. Set `DdUseVPC` to `true`.
    2. Set `VPCSecurityGroupIds` and `VPCSubnetIds` based on your VPC settings.
    3. Set `DdFetchLambdaTags` to `false`, because AWS Resource Groups Tagging API doesn't support PrivateLink.
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Fixes documentation for the PrivateLink configuration, as I ran into this today. Also mentioned in https://github.com/DataDog/datadog-serverless-functions/issues/636.

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [X] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
