### PR TITLE
Add missing break statement

### DIFF
--- a/aws/rds_enhanced_monitoring/lambda_function.py
+++ b/aws/rds_enhanced_monitoring/lambda_function.py
@@ -352,6 +352,7 @@ class Stats(object):
                     print(
                         "INFO Submitted data with status: {}".format(response.getcode())
                     )
+                    break
             except HTTPError as e:
                 if e.code in (500, 502, 503, 504):
                     if attempt == self.max_attempts:


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Break statement will be executed when flush() succeeds.

### Motivation

Without break statement lambda function will submit the same metrics 5 times in a row.

### Testing Guidelines

I tested this by deploying to my lambda function.

Before fix: metrics are submitted 5 times.
```
2024-02-08T10:06:49.242+09:00	START RequestId: a98d2fbb-d93b-4cd8-a627-c0a816d72ba0 Version: $LATEST
2024-02-08T10:06:50.491+09:00	INFO Submitted data with status: 202
2024-02-08T10:06:51.733+09:00	INFO Submitted data with status: 202
2024-02-08T10:06:52.980+09:00	INFO Submitted data with status: 202
2024-02-08T10:06:54.216+09:00	INFO Submitted data with status: 202
2024-02-08T10:06:55.454+09:00	INFO Submitted data with status: 202
2024-02-08T10:06:55.475+09:00	END RequestId: a98d2fbb-d93b-4cd8-a627-c0a816d72ba0
```
After fix: metrics are submitted only once.
```
2024-02-08T10:22:08.831+09:00	START RequestId: 1541446c-d918-48c7-869f-41232832c8eb Version: $LATEST
2024-02-08T10:22:10.329+09:00	INFO Submitted data with status: 202
2024-02-08T10:22:10.352+09:00	END RequestId: 1541446c-d918-48c7-869f-41232832c8eb
```

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
