### PR TITLE
Fix num batches sent log

### DIFF
--- a/azure/blobs_logs_monitoring/index.js
+++ b/azure/blobs_logs_monitoring/index.js
@@ -174,7 +174,7 @@ class HTTPClient {
         var resolvedPromises = await Promise.all(
             promises.map(p => p.catch(e => this.context.log.error(e)))
         );
-        this.context.log(`Num batches sent (including retries): ${this.numBatchesSent}. Num batches retried: ${this.numBatchesRetried}`); // Log the counter after all promises have resolved
+        this.context.log(`Num batches sent: ${this.numBatchesSent}. Num batches retried: ${this.numBatchesRetried}`); // Log the counter after all promises have resolved
         return resolvedPromises;
     }
 

--- a/azure/blobs_logs_monitoring/index.js
+++ b/azure/blobs_logs_monitoring/index.js
@@ -93,7 +93,7 @@ class Batcher {
         var sizeBytes = 0;
         var sizeCount = 0;
         var droppedLogs = 0;
-        this.context.log.warn("Batcher batch() called with num items " + items.length);
+        this.context.log("Batcher batch() called with num items " + items.length);
         for (var i = 0; i < items.length; i++) {
             var item = items[i];
             var itemSizeBytes = this.getSizeInBytes(item);

--- a/azure/blobs_logs_monitoring/index.js
+++ b/azure/blobs_logs_monitoring/index.js
@@ -93,7 +93,7 @@ class Batcher {
         var sizeBytes = 0;
         var sizeCount = 0;
         var droppedLogs = 0;
-        this.context.log("Batcher batch() called with num items " + items.length);
+        this.context.log.warn("Batcher batch() called with num items " + items.length);
         for (var i = 0; i < items.length; i++) {
             var item = items[i];
             var itemSizeBytes = this.getSizeInBytes(item);

--- a/azure/test/blobs_logs_monitoring.test.js
+++ b/azure/test/blobs_logs_monitoring.test.js
@@ -576,21 +576,21 @@ describe('Azure Activity Log Monitoring', function() {
 describe('Batching', function() {
     describe('#batch', function() {
         it('should return two batches because of size', function() {
-            batcher = new client.Batcher(15, 15, 1);
+            batcher = new client.Batcher(fakeContext(), 15, 15, 1);
             logs = [{ hi: 'bye' }, 'bleh'];
             actual = batcher.batch(logs);
             expected = [[{ hi: 'bye' }], ['bleh']];
             assert.deepEqual(actual, expected);
         });
         it('should return two batches because of batch size bytes', function() {
-            batcher = new client.Batcher(5, 12, 10);
+            batcher = new client.Batcher(fakeContext(), 5, 12, 10);
             logs = [{ hi: 'bye' }, 'bleh'];
             actual = batcher.batch(logs);
             expected = [[{ hi: 'bye' }], ['bleh']];
             assert.deepEqual(actual, expected);
         });
         it('should drop message based on message bytes size', function() {
-            batcher = new client.Batcher(5, 5, 1);
+            batcher = new client.Batcher(fakeContext(), 5, 5, 1);
             logs = [{ hi: 'bye' }, 'bleh'];
             actual = batcher.batch(logs);
             expected = [['bleh']];
@@ -599,7 +599,7 @@ describe('Batching', function() {
     });
     describe('#getSizeInBytes', function() {
         it('should return 5 for string', function() {
-            batcher = new client.Batcher(15, 15, 1);
+            batcher = new client.Batcher(fakeContext(), 15, 15, 1);
             log = 'aaaaa';
             actual = batcher.getSizeInBytes(log);
             expected = 5;
@@ -607,7 +607,7 @@ describe('Batching', function() {
         });
 
         it('should return 7 for object', function() {
-            batcher = new client.Batcher(15, 15, 1);
+            batcher = new client.Batcher(fakeContext(), 15, 15, 1);
             log = { a: 2 };
             actual = batcher.getSizeInBytes(log);
             expected = 7;

--- a/azure/test/blobs_logs_monitoring.test.js
+++ b/azure/test/blobs_logs_monitoring.test.js
@@ -586,7 +586,7 @@ describe('Batching', function() {
             assert.deepEqual(actual, expected);
         });
         it('should return two batches because of batch size bytes', function() {
-            batcher = new client.Batcher(fakeContext(), 5, 12, 10);
+            batcher = new client.Batcher(fakeContext(), 15, 12, 10);
             logs = [{ hi: 'bye' }, 'bleh'];
             actual = batcher.batch(logs);
             expected = [[{ hi: 'bye' }], ['bleh']];

--- a/azure/test/blobs_logs_monitoring.test.js
+++ b/azure/test/blobs_logs_monitoring.test.js
@@ -9,6 +9,8 @@ function fakeContext() {
     contextSpy.log = sinon.spy();
     contextSpy.log.error = function(x) {}; // do nothing
     contextSpy.log.warn = function(x) {}; // do nothing
+    
+    contextSpy.bindingData = sinon.spy();
     contextSpy.bindingData.blobTrigger = "test/file.log"
 
     return contextSpy;

--- a/azure/test/blobs_logs_monitoring.test.js
+++ b/azure/test/blobs_logs_monitoring.test.js
@@ -9,6 +9,7 @@ function fakeContext() {
     contextSpy.log = sinon.spy();
     contextSpy.log.error = function(x) {}; // do nothing
     contextSpy.log.warn = function(x) {}; // do nothing
+    contextSpy.bindingData.blobTrigger = "test/file.log"
 
     return contextSpy;
 }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Fixes the batches submitted and batches retried log.

When uploading multiple log files to blob storage, the logs were sometimes wrong. The logs would look like this:
```
Num batches sent: 413. Num batches retried: 104
180 batches of logs were sent for file blobnew/1_2.log 
```
```
Num batches sent: 0. Num batches retried: 0
179 batches of logs were sent for file blobnew/1_8.log
All log lines have been sent successfully.
```

I suspect this is due to the variables being at the top level of the function. A similar issue to this: https://stackoverflow.com/questions/70520614/share-variables-between-functions-in-azure-function-app-python

### Motivation

<!--- What inspired you to submit this pull request? --->

Improve logging

### Testing Guidelines

<!--- How did you test this pull request? --->

Manually tested by uploading many blobs, didn't see the weird logs again
<img width="430" alt="Screenshot 2024-02-14 at 3 06 11 PM" src="https://github.com/DataDog/datadog-serverless-functions/assets/43612608/0fa32959-da7e-47e3-9c80-4fdd161f6319">

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
