### PR TITLE
DOCS-7244 - Add details to CloudWatch docs

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -252,7 +252,11 @@ We love pull requests. Here's a quick guide.
 
 ### Shipping logs to multiple destinations
 
-If you need to ship logs to multiple Datadog organizations or other destinations, configure the `AdditionalTargetLambdaArns` Cloudformation parameter to let the Datadog Forwarder copy the incoming logs to the specified Lambda functions. These additional Lambda functions will be called asynchronously with the exact same `event` the Datadog Forwarder receives.
+If you need to ship logs to multiple Datadog organizations or other destinations, configure the `AdditionalTargetLambdaArns` CloudFormation parameter to let the Datadog Forwarder copy the incoming logs to the specified Lambda functions. These additional Lambda functions are called asynchronously with the exact same `event` the Datadog Forwarder receives.
+
+<div class="alert alert-warning">
+Shipping logs to two or more destinations involves using two or more Lambda functions that may start logging each other in an infinite loop. Use <code>ExcludeAtMatch</code> to filter Lambda logs and avoid this infinite loop. See the <a href="#log-filtering-optional">Log filtering</a> section for more details.
+</div>
 
 ### AWS PrivateLink support
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adds an alert to remind users to use filtering when shipping logs to multiple destinations.
<!--- A brief description of the change being made with this pull request. --->

### Motivation
Raised by sales, DOCS-7244

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
