### PR TITLE
Adding GuardDuty to S3 source parser

### DIFF
--- a/aws/logs_monitoring/steps/enums.py
+++ b/aws/logs_monitoring/steps/enums.py
@@ -94,6 +94,8 @@ class AwsS3EventSourceKeyword(Enum):
     # e.g. 2020/10/02/21/aws-waf-logs-testing-1-2020-10-02-21-25-30-x123x-x456x or AWSLogs/123456779121/WAFLogs/us-east-1/xxxxxx-waf/2022/10/11/14/10/123456779121_waflogs_us-east-1_xxxxx-waf_20221011T1410Z_12756524.log.gz
     WAF_0 = ("aws-waf-logs", AwsEventSource.WAF)
     WAF_1 = ("waflogs", AwsEventSource.WAF)
+    # e.q AWSLogs/123456779121/GuardDuty/eu-west-1/2024/03/21/ed8bb84e-a534-3a98-9da9-16c4784eaf8a.jsonl.gz
+    GUARDDUTY = ("guardduty",  AwsEventSource.GUARDDUTY)
 
     def __str__(self):
         return f"{self.string}"


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adding GuardDuty to possible `source` on S3 event.

### Motivation

We are using S3 as our GuardDuty findings storage. Then, we trigger Lambda with a bucket notification.
Unfortunately, `source` was not parsed correctly and was left as `source:s3`

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
