### PR TITLE
Adding cloudtrail insight to the cloudtrail regex pattern

### DIFF
--- a/aws/logs_monitoring/steps/common.py
+++ b/aws/logs_monitoring/steps/common.py
@@ -9,7 +9,7 @@ from steps.enums import (
 from settings import DD_CUSTOM_TAGS, DD_SERVICE, DD_SOURCE
 
 CLOUDTRAIL_REGEX = re.compile(
-    "\d+_CloudTrail(|-Digest)_\w{2}(|-gov|-cn)-\w{4,9}-\d_(|.+)\d{8}T\d{4,6}Z(|.+).json.gz$",
+    "\d+_CloudTrail(|-Digest|-Insight)_\w{2}(|-gov|-cn)-\w{4,9}-\d_(|.+)\d{8}T\d{4,6}Z(|.+).json.gz$",
     re.I,
 )
 


### PR DESCRIPTION
Adding Cloudtrail-Insight to the regex pattern so that Cloudtrail-Insight logs are marked with source of cloudtrail instead of default s3.

<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adds Insight to the cloudtrail regex.

### Motivation

Customer issue

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
