### PR TITLE
Disable enhanced metric by setting an environment variable `DD_SUBMIT_ENHANCED_METRICS` to `false`

### DIFF
--- a/aws/logs_monitoring/enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/enhanced_lambda_metrics.py
@@ -147,7 +147,7 @@ def parse_and_submit_enhanced_metrics(logs, cache_layer):
     # If the Lambda layer is not present we can't submit enhanced metrics
     if not DD_SUBMIT_ENHANCED_METRICS:
         return
-    
+
     # force disable submit enhanced metrics by setting envionment varaible DD_SUBMIT_ENHANCED_METRICS
     if not DD_SUBMIT_ENHANCED_METRICS_ENV:
         return

--- a/aws/logs_monitoring/enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/enhanced_lambda_metrics.py
@@ -148,7 +148,7 @@ def parse_and_submit_enhanced_metrics(logs, cache_layer):
     if not DD_SUBMIT_ENHANCED_METRICS:
         return
     
-    # force disable submit enhanced metrics from envionment varaible DD_SUBMIT_ENHANCED_METRICS
+    # force disable submit enhanced metrics by setting envionment varaible DD_SUBMIT_ENHANCED_METRICS
     if not DD_SUBMIT_ENHANCED_METRICS_ENV:
         return
 

--- a/aws/logs_monitoring/enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/enhanced_lambda_metrics.py
@@ -7,6 +7,7 @@ import logging
 import re
 import datetime
 from time import time
+from settings import DD_SUBMIT_ENHANCED_METRICS_ENV
 
 ENHANCED_METRICS_NAMESPACE_PREFIX = "aws.lambda.enhanced"
 
@@ -145,6 +146,10 @@ def parse_and_submit_enhanced_metrics(logs, cache_layer):
     """
     # If the Lambda layer is not present we can't submit enhanced metrics
     if not DD_SUBMIT_ENHANCED_METRICS:
+        return
+    
+    # force disable submit enhanced metrics from envionment varaible DD_SUBMIT_ENHANCED_METRICS
+    if not DD_SUBMIT_ENHANCED_METRICS_ENV:
         return
 
     for log in logs:

--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -156,7 +156,9 @@ if DD_USE_PRIVATE_LINK:
 ## @param DD_SUBMIT_ENHANCED_METRICS - boolean - optional - default: true
 ## Set this variable to `False` to disable enhanced metrics for other lambda functions.
 #
-DD_SUBMIT_ENHANCED_METRICS_ENV = get_env_var("DD_SUBMIT_ENHANCED_METRICS", "true", boolean=True)
+DD_SUBMIT_ENHANCED_METRICS_ENV = get_env_var(
+    "DD_SUBMIT_ENHANCED_METRICS", "true", boolean=True
+)
 
 class ScrubbingRuleConfig(object):
     def __init__(self, name, pattern, placeholder):

--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -153,6 +153,10 @@ if DD_USE_PRIVATE_LINK:
     DD_API_URL = "https://pvtlink.api.datadoghq.com"
     DD_TRACE_INTAKE_URL = "https://trace-pvtlink.agent.datadoghq.com"
 
+## @param DD_SUBMIT_ENHANCED_METRICS - boolean - optional - default: true
+## Set this variable to `False` to disable enhanced metrics for other lambda functions.
+#
+DD_SUBMIT_ENHANCED_METRICS_ENV = get_env_var("DD_SUBMIT_ENHANCED_METRICS", "true", boolean=True)
 
 class ScrubbingRuleConfig(object):
     def __init__(self, name, pattern, placeholder):

--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -160,6 +160,7 @@ DD_SUBMIT_ENHANCED_METRICS_ENV = get_env_var(
     "DD_SUBMIT_ENHANCED_METRICS", "true", boolean=True
 )
 
+
 class ScrubbingRuleConfig(object):
     def __init__(self, name, pattern, placeholder):
         self.name = name


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->
If the forwarder has another function log group as a trigger, enhanced lambda metric of another function would be generated, which is confusing because this will cause the other function to appear in the Serverless page.

### What does this PR do?
This PR would allow customer to disable enhanced metric by simply setting an environment variable `DD_SUBMIT_ENHANCED_METRICS` to `false`

<!--- A brief description of the change being made with this pull request. --->

### Motivation
Jira issues CLOUDS-4535/CLOUDS-4529

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
