### PR TITLE
AttributeError: 'function' object has no attribute 'paginate' error when sending step function logs

### DIFF
--- a/aws/logs_monitoring/caching/step_functions_cache.py
+++ b/aws/logs_monitoring/caching/step_functions_cache.py
@@ -33,7 +33,7 @@ class StepFunctionsTagsCache(BaseTagsCache):
         """
         tags_fetch_success = False
         tags_by_arn_cache = {}
-        get_resources_paginator = self.get_resources_paginator
+        get_resources_paginator = self.get_resources_paginator()
 
         try:
             for page in get_resources_paginator.paginate(


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Fix a bug of **AttributeError: 'function' object has no attribute 'paginate'** error when sending step function logs.
It seems that currently `get_resources_paginator` is mistakenly set to a **function** object rather than **paginator**. 

Please see how we are using **paginator** for lambda and s3.
https://github.com/DataDog/datadog-serverless-functions/blob/master/aws/logs_monitoring/caching/lambda_cache.py#L30
https://github.com/DataDog/datadog-serverless-functions/blob/master/aws/logs_monitoring/caching/s3_tags_cache.py#L29



<!--- A brief description of the change being made with this pull request. --->

### Motivation
When sending step function logs, the following error occurred. 

```
[ERROR] AttributeError: 'function' object has no attribute 'paginate'
Traceback (most recent call last):
  File "/opt/python/datadog_lambda/wrapper.py", line 232, in __call__
    self.response = self.func(event, context, **kwargs)
  File "/opt/python/lambda_function.py", line 75, in datadog_forwarder
    parsed = parse(event, context, cache_layer)
  File "/opt/python/steps/parsing.py", line 68, in parse
    return normalize_events(events, metadata)
  File "/opt/python/steps/parsing.py", line 169, in normalize_events
    for event in events:
  File "/opt/python/steps/handlers/awslogs_handler.py", line 51, in awslogs_handler
    set_host(metadata, aws_attributes, cache_layer)
  File "/opt/python/steps/handlers/awslogs_handler.py", line 130, in set_host
    handle_step_function_source(metadata, log_events, log_stream, cache_layer)
  File "/opt/python/steps/handlers/awslogs_handler.py", line 165, in handle_step_function_source
    formatted_stepfunctions_tags = cache_layer.get_step_functions_tags_cache().get(
  File "/opt/python/caching/step_functions_cache.py", line 85, in get
    self._refresh()
  File "/opt/python/caching/base_tags_cache.py", line 141, in _refresh
    success, new_tags_fetched = self.build_tags_cache()
  File "/opt/python/caching/step_functions_cache.py", line 39, in build_tags_cache
    for page in get_resources_paginator.paginate(
```

<!--- What inspired you to submit this pull request? --->
Issue in CLOUDS-4643
This could be replicated in my environment

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
