### PR TITLE
Add optional S3 AccessLogsTarget

### DIFF
--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -229,6 +229,10 @@ Parameters:
     Type: String
     Default: ""
     Description: The name of the forwarder bucket to create. If not provided, AWS will generate a unique name.
+  DdForwarderBucketsAccessLogsTarget:
+    Type: String
+    Default: ""
+    Description: (Optional) The name of the S3 bucket to store access logs. Leave empty if access logging is not needed.
 Conditions:
   IsAWSChina:
     Fn::Equals:
@@ -418,6 +422,7 @@ Conditions:
       - Fn::Equals:
           - Ref: ReservedConcurrency
           - ""
+  ShouldUseAccessLogBucket: !Not [!Equals [!Ref DdForwarderBucketsAccessLogsTarget, ""]]
 Rules:
   MustSetDdApiKey:
     Assertions:
@@ -832,6 +837,13 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
+      LoggingConfiguration:
+        !If
+          - ShouldUseAccessLogBucket
+          -
+            DestinationBucketName: !Ref DdForwarderBucketsAccessLogsTarget
+            LogFilePrefix: "datadog-forwarder/"
+          - !Ref "AWS::NoValue"
   ForwarderBucketPolicy:
     Type: "AWS::S3::BucketPolicy"
     Properties:


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Allows user to configure an access-logs target bucket, were access-logs of the forwarder bucket will be stored. This helps resolving AWS Security HUB S3.9 finding (more info in the issue related)
Resolves https://github.com/DataDog/datadog-serverless-functions/issues/764

### Motivation

Allow users to decide if they want a target access log bucket.

### Testing Guidelines

executed the cloudformation template.yml with the addition made.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
