### PR TITLE
Add s3 multipart upload lifecycle rule resolves #762

### DIFF
--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -868,6 +868,13 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
+      LifecycleConfiguration:
+       Rules:
+       - Id: delete-incomplete-mpu-7days
+         Prefix: ''
+         AbortIncompleteMultipartUpload:
+           DaysAfterInitiation: 7
+         Status: Enabled        
   ForwarderBucketPolicy:
     Type: "AWS::S3::BucketPolicy"
     Condition: CreateS3Bucket


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adds a s3 bucket lifecycle rule which deletes incomplete multiparts after 7 days.

### Motivation

Reduce noise in AWS Trusted advisor, flagging this as a warning.

### Testing Guidelines

Test if s3 bucket builds correctly (it worked for me manually)

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] New feature

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
