### PR TITLE
Use API endpoint for series submission

### DIFF
--- a/aws/rds_enhanced_monitoring/lambda_function.py
+++ b/aws/rds_enhanced_monitoring/lambda_function.py
@@ -342,7 +342,7 @@ class Stats(object):
         creds = urlencode(datadog_keys)
         data = json.dumps(metrics_dict).encode("ascii")
         url = "%s?%s" % (
-            datadog_keys.get("api_host", "https://app.%s/api/v1/series" % DD_SITE),
+            datadog_keys.get("api_host", "https://api.%s/api/v1/series" % DD_SITE),
             creds,
         )
         req = Request(url, data, {"Content-Type": "application/json"})

--- a/aws/vpc_flow_log_monitoring/lambda_function.py
+++ b/aws/vpc_flow_log_monitoring/lambda_function.py
@@ -417,7 +417,7 @@ class Stats(object):
         creds = urlencode(datadog_keys)
         data = json.dumps(metrics_dict).encode("utf-8")
         url = "%s?%s" % (
-            datadog_keys.get("api_host", "https://app.%s/api/v1/series" % DD_SITE),
+            datadog_keys.get("api_host", "https://api.%s/api/v1/series" % DD_SITE),
             creds,
         )
         req = Request(url, data, {"Content-Type": "application/json"})


### PR DESCRIPTION


### What does this PR do?

[Use API endpoint for series submission](https://github.com/DataDog/datadog-serverless-functions/pull/782/commits/bdd013fb4e6e5faa62034066cf0ab5cfbfa2631b) 

* Use the API endpoint for timeseries submission of RDS enhanced metrics instead of the web endpoint
* same for VPC Flow Logs metrics

We in #fabric are trying to keep timeseries traffic out of the web endpoint, for better isolation and perforance tunning. This change aligns with our best practices, see https://docs.datadoghq.com/api/latest/metrics/#submit-metrics.

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
