### PR TITLE
Fix the error of "Cannot export output ForwarderBucketName" or "Invalid policy" when deploying lambda forwarder using cloudformation template

### DIFF
--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -433,6 +433,13 @@ Conditions:
       - Fn::Equals:
           - Ref: ReservedConcurrency
           - ""
+  SetForwarderBucket:
+    Fn::Or:
+      - Condition: CreateS3Bucket
+      - Fn::Not:
+          - Fn::Equals:
+              - Ref: DdForwarderExistingBucketName
+              - ""
 Rules:
   MustSetDdApiKey:
     Assertions:
@@ -561,7 +568,10 @@ Resources:
               - Ref: DdPort
               - Ref: AWS::NoValue
           DD_STORE_FAILED_EVENTS:
-            Ref: DdStoreFailedEvents
+            Fn::If:
+              - SetForwarderBucket
+              - Ref: DdStoreFailedEvents
+              - Ref: AWS::NoValue
           REDACT_IP:
             Fn::If:
               - SetRedactIp
@@ -702,33 +712,39 @@ Resources:
             Version: "2012-10-17"
             Statement:
               # Access the s3 bucket that is used by the forwarder as a datastore
-              - Action:
-                  - s3:GetObject
-                  - s3:PutObject
-                  - s3:DeleteObject
-                  - s3:ListBucket
-                Resource:
-                  - Fn::If:
-                    - CreateS3Bucket
-                    - Fn::Join:
-                        - "/"
-                        - - Fn::GetAtt: ForwarderBucket.Arn
-                          - "*"
-                    - Fn::Sub: "arn:aws:s3:::${DdForwarderExistingBucketName}/*"
-                Effect: Allow
+              - Fn::If:
+                  - SetForwarderBucket
+                  - Action:
+                      - s3:GetObject
+                      - s3:PutObject
+                      - s3:DeleteObject
+                      - s3:ListBucket
+                    Resource:
+                      - Fn::If:
+                        - CreateS3Bucket
+                        - Fn::Join:
+                            - "/"
+                            - - Fn::GetAtt: ForwarderBucket.Arn
+                              - "*"
+                        - Fn::Sub: "arn:aws:s3:::${DdForwarderExistingBucketName}/*"
+                    Effect: Allow
+                  - Ref: AWS::NoValue
               # Get the actual log content from the s3 bucket based on the received s3 event.
               # Use PermissionsBoundaryArn to limit (allow/deny) access if needed.
-              - Action:
-                  - s3:ListBucket
-                Resource:
-                  - Fn::If:
-                    - CreateS3Bucket
-                    - Fn::GetAtt: ForwarderBucket.Arn
-                    - Fn::Sub: "arn:aws:s3:::${DdForwarderExistingBucketName}"
-                Condition:
-                  StringLike:
-                    s3:prefix: "retry/*"
-                Effect: Allow
+              - Fn::If:
+                  - SetForwarderBucket            
+                  - Action:
+                      - s3:ListBucket
+                    Resource:
+                      - Fn::If:
+                        - CreateS3Bucket
+                        - Fn::GetAtt: ForwarderBucket.Arn
+                        - Fn::Sub: "arn:aws:s3:::${DdForwarderExistingBucketName}"
+                    Condition:
+                      StringLike:
+                        s3:prefix: "retry/*"
+                    Effect: Allow
+                  - Ref: AWS::NoValue
               - Action:
                   - s3:GetObject
                 Resource: "*"
@@ -1074,6 +1090,7 @@ Outputs:
         Fn::Sub: ${AWS::StackName}-ApiKeySecretArn
     Condition: CreateDdApiKeySecret
   ForwarderBucketName:
+    Condition: SetForwarderBucket
     Description: Name of the S3 bucket used by the Forwarder
     Value:
       Fn::If:


### PR DESCRIPTION
### What does this PR do?
When creating lambda forwarder with the following parameters, the stack would fail with errors `Cannot export output ForwarderBucketName` or `Invalid policy `.

- DdFetchLambdaTags: false
- DdFetchLogGroupTags: false
- DdForwarderBucketName: (empty)
- DdForwarderExistingBucketName: (empty)

### Motivation
CLOUDS-4708
This issue could be replicated in my sandbox.

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
