### PR TITLE
[Logs forwarder] Rework Cloudwatch log group tags cache

### DIFF
--- a/aws/logs_monitoring/caching/cloudwatch_log_group_cache.py
+++ b/aws/logs_monitoring/caching/cloudwatch_log_group_cache.py
@@ -1,45 +1,41 @@
+import json
+import logging
 import os
+from random import randint
+from time import time
+
 import boto3
-from caching.base_tags_cache import BaseTagsCache
+from botocore.config import Config
 from caching.common import sanitize_aws_tag_string
-from telemetry import send_forwarder_internal_metrics
 from settings import (
-    DD_S3_LOG_GROUP_CACHE_FILENAME,
-    DD_S3_LOG_GROUP_CACHE_LOCK_FILENAME,
+    DD_S3_BUCKET_NAME,
+    DD_S3_LOG_GROUP_CACHE_DIRNAME,
+    DD_TAGS_CACHE_TTL_SECONDS,
 )
+from telemetry import send_forwarder_internal_metrics
 
 
-class CloudwatchLogGroupTagsCache(BaseTagsCache):
+class CloudwatchLogGroupTagsCache:
     def __init__(self, prefix):
-        super().__init__(
-            prefix, DD_S3_LOG_GROUP_CACHE_FILENAME, DD_S3_LOG_GROUP_CACHE_LOCK_FILENAME
+        self.cache_dirname = DD_S3_LOG_GROUP_CACHE_DIRNAME
+        self.cache_ttl_seconds = DD_TAGS_CACHE_TTL_SECONDS
+        self.bucket_name = DD_S3_BUCKET_NAME
+        self.cache_prefix = prefix
+        self.tags_by_log_group = {}
+        # We need to use the standard retry mode for the Cloudwatch Logs client that defaults to 3 retries
+        self.cloudwatch_logs_client = boto3.client(
+            "logs", config=Config(retries={"mode": "standard"})
         )
-        self.cloudwatch_logs_client = boto3.client("logs")
+        self.s3_client = boto3.client("s3")
 
-    def should_fetch_tags(self):
-        return os.environ.get("DD_FETCH_LOG_GROUP_TAGS", "false").lower() == "true"
-
-    def build_tags_cache(self):
-        """Makes API calls to GetResources to get the live tags of the account's Lambda functions
-
-        Returns an empty dict instead of fetching custom tags if the tag fetch env variable is not set to true
-
-        Returns:
-            tags_by_arn_cache (dict<str, str[]>): each Lambda's tags in a dict keyed by ARN
-        """
-        new_tags = {}
-        for log_group in self.tags_by_id.keys():
-            log_group_tags = self._get_log_group_tags(log_group)
-            # If we didn't get back log group tags we'll use the locally cached ones if they exist
-            # This avoids losing tags on a failed api call
-            if log_group_tags is None:
-                log_group_tags = self.tags_by_id.get(log_group, [])
-            new_tags[log_group] = log_group_tags
-
-        self.logger.debug(
-            "All tags in Cloudwatch Log Groups refresh: {}".format(new_tags)
+        self.logger = logging.getLogger()
+        self.logger.setLevel(
+            logging.getLevelName(os.environ.get("DD_LOG_LEVEL", "INFO").upper())
         )
-        return True, new_tags
+
+        # Initialize the cache
+        if self._should_fetch_tags():
+            self._build_tags_cache()
 
     def get(self, log_group):
         """Get the tags for the Cloudwatch Log Group from the cache
@@ -53,24 +49,118 @@ class CloudwatchLogGroupTagsCache(BaseTagsCache):
         Returns:
             log_group_tags (str[]): the list of "key:value" Datadog tag strings
         """
-        if self._is_expired():
-            send_forwarder_internal_metrics("cw_log_group_tags_cache_expired")
-            self.logger.debug("Local cache expired, fetching cache from S3")
-            self._refresh()
+        # If the custom tag fetch env var is not set to true do not fetch tags
+        if not self._should_fetch_tags():
+            self.logger.debug(
+                "Not fetching custom tags because the env variable DD_FETCH_LOG_GROUP_TAGS is "
+                "not set to true"
+            )
+            return []
 
-        log_group_tags = self.tags_by_id.get(log_group, None)
-        if log_group_tags is None:
-            # If the custom tag fetch env var is not set to true do not fetch
-            if not self.should_fetch_tags():
-                self.logger.debug(
-                    "Not fetching custom tags because the env variable DD_FETCH_LOG_GROUP_TAGS is "
-                    "not set to true"
+        return self._fetch_log_group_tags(log_group)
+
+    def _should_fetch_tags(self):
+        return os.environ.get("DD_FETCH_LOG_GROUP_TAGS", "false").lower() == "true"
+
+    def _build_tags_cache(self):
+        try:
+            prefix = self._get_cache_file_prefix()
+            response = self.s3_client.list_objects_v2(
+                Bucket=DD_S3_BUCKET_NAME, Prefix=prefix
+            )
+            cache_files = [content["Key"] for content in response.get("Contents", [])]
+            for cache_file in cache_files:
+                log_group_tags, last_modified = self._get_log_group_tags_from_cache(
+                    cache_file
                 )
-                return []
-            log_group_tags = self._get_log_group_tags(log_group) or []
-            self.tags_by_id[log_group] = log_group_tags
+                if log_group_tags and not self._is_expired(last_modified):
+                    log_group = cache_file.split("/")[-1].split(".")[0]
+                    self.tags_by_log_group[log_group] = {
+                        "tags": log_group_tags,
+                        "last_modified": last_modified,
+                    }
+            self.logger.debug(
+                f"loggroup_tags_cache initialized successfully {self.tags_by_log_group}"
+            )
+        except Exception:
+            self.logger.exception("failed to build log group tags cache", exc_info=True)
+
+    def _fetch_log_group_tags(self, log_group):
+        # first, check in-memory cache
+        log_group_tags_struct = self.tags_by_log_group.get(log_group, None)
+        if log_group_tags_struct and not self._is_expired(
+            log_group_tags_struct.get("last_modified", None)
+        ):
+            return log_group_tags_struct.get("tags", [])
+
+        # then, check cache file, update and return
+        cache_file_name = self._get_cache_file_name(log_group)
+        log_group_tags, last_modified = self._get_log_group_tags_from_cache(
+            cache_file_name
+        )
+        if log_group_tags and not self._is_expired(last_modified):
+            self.tags_by_log_group[log_group] = {
+                "tags": log_group_tags,
+                "last_modified": time(),
+            }
+            return log_group_tags
+
+        # finally, make an api call, update and return
+        log_group_tags = self._get_log_group_tags(log_group) or []
+        self._update_log_group_tags_cache(log_group, log_group_tags)
+        self.tags_by_log_group[log_group] = {
+            "tags": log_group_tags,
+            "last_modified": time(),
+        }
 
         return log_group_tags
+
+    def _get_log_group_tags_from_cache(self, cache_file_name):
+        try:
+            response = self.s3_client.get_object(
+                Bucket=self.bucket_name, Key=cache_file_name
+            )
+            tags_cache = json.loads(response.get("Body").read().decode("utf-8"))
+            last_modified_unix_time = int(response.get("LastModified").timestamp())
+        except Exception:
+            send_forwarder_internal_metrics("s3_cache_fetch_failure")
+            self.logger.exception(
+                "Failed to get log group tags from cache", exc_info=True
+            )
+            return None, -1
+
+        return tags_cache, last_modified_unix_time
+
+    def _update_log_group_tags_cache(self, log_group, tags):
+        cache_file_name = self._get_cache_file_name(log_group)
+        try:
+            self.s3_client.put_object(
+                Bucket=self.bucket_name,
+                Key=cache_file_name,
+                Body=(bytes(json.dumps(tags).encode("UTF-8"))),
+            )
+        except Exception:
+            send_forwarder_internal_metrics("s3_cache_write_failure")
+            self.logger.exception(
+                "Failed to update log group tags cache", exc_info=True
+            )
+
+    def _is_expired(self, last_modified):
+        if not last_modified:
+            return True
+
+        # add a random number of seconds to avoid having all tags refetched at the same time
+        earliest_time_to_refetch_tags = (
+            last_modified + self.cache_ttl_seconds + randint(1, 100)
+        )
+        return time() > earliest_time_to_refetch_tags
+
+    def _get_cache_file_name(self, log_group):
+        log_group_name = log_group.replace("/", "_")
+        return f"{self._get_cache_file_prefix()}/{log_group_name}.json"
+
+    def _get_cache_file_prefix(self):
+        return f"{self.cache_dirname}/{self.cache_prefix}"
 
     def _get_log_group_tags(self, log_group):
         response = None
@@ -79,8 +169,8 @@ class CloudwatchLogGroupTagsCache(BaseTagsCache):
             response = self.cloudwatch_logs_client.list_tags_log_group(
                 logGroupName=log_group
             )
-        except Exception as e:
-            self.logger.exception(f"Failed to get log group tags due to {e}")
+        except Exception:
+            self.logger.exception("Failed to get log group tags", exc_info=True)
         formatted_tags = None
         if response is not None:
             formatted_tags = [

--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -258,12 +258,12 @@ DD_S3_BUCKET_NAME = get_env_var("DD_S3_BUCKET_NAME", default=None)
 # These default cache names remain unchanged so we can get existing cache data for these
 DD_S3_CACHE_FILENAME = "cache.json"
 DD_S3_CACHE_LOCK_FILENAME = "cache.lock"
-DD_S3_LOG_GROUP_CACHE_FILENAME = "log-group-cache.json"
-DD_S3_LOG_GROUP_CACHE_LOCK_FILENAME = "log-group-cache.lock"
 DD_S3_STEP_FUNCTIONS_CACHE_FILENAME = "step-functions-cache.json"
 DD_S3_STEP_FUNCTIONS_CACHE_LOCK_FILENAME = "step-functions-cache.lock"
 DD_S3_TAGS_CACHE_FILENAME = "s3-cache.json"
 DD_S3_TAGS_CACHE_LOCK_FILENAME = "s3-cache.lock"
+
+DD_S3_LOG_GROUP_CACHE_DIRNAME = "log-group-cache"
 
 DD_TAGS_CACHE_TTL_SECONDS = int(get_env_var("DD_TAGS_CACHE_TTL_SECONDS", default=300))
 DD_S3_CACHE_LOCK_TTL_SECONDS = 60

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -742,7 +742,9 @@ Resources:
                         - Fn::Sub: "arn:aws:s3:::${DdForwarderExistingBucketName}"
                     Condition:
                       StringLike:
-                        s3:prefix: "retry/*"
+                        s3:prefix:
+                          - "retry/*"
+                          - "log-group-cache/*"
                     Effect: Allow
                   - Ref: AWS::NoValue
               - Action:

--- a/aws/logs_monitoring/tests/run_unit_tests.sh
+++ b/aws/logs_monitoring/tests/run_unit_tests.sh
@@ -2,4 +2,5 @@
 
 export DD_API_KEY=11111111111111111111111111111111
 export DD_ADDITIONAL_TARGET_LAMBDAS=ironmaiden,megadeth
+export DD_S3_BUCKET_NAME=dd-s3-bucket
 python3 -m unittest discover .

--- a/aws/logs_monitoring/tests/test_cloudtrail_s3.py
+++ b/aws/logs_monitoring/tests/test_cloudtrail_s3.py
@@ -97,11 +97,12 @@ class TestS3CloudwatchParsing(unittest.TestCase):
             gzip.compress(json.dumps(copy.deepcopy(test_data)).encode("utf-8"))
         )
 
+    @patch("caching.cloudwatch_log_group_cache.CloudwatchLogGroupTagsCache.__init__")
     @patch("caching.base_tags_cache.boto3")
     @patch("steps.handlers.s3_handler.boto3")
     @patch("lambda_function.boto3")
     def test_s3_cloudtrail_pasing_and_enrichment(
-        self, lambda_boto3, parsing_boto3, cache_boto3
+        self, lambda_boto3, parsing_boto3, cache_boto3, mock_cache_init
     ):
         context = Context()
         boto3 = parsing_boto3.client()
@@ -117,6 +118,7 @@ class TestS3CloudwatchParsing(unittest.TestCase):
                 },
             }
         }
+        mock_cache_init.return_value = None
         cache_layer = CacheLayer("")
         cache_layer._s3_tags_cache.get = MagicMock(return_value=[])
         cache_layer._lambda_cache.get = MagicMock(return_value=[])

--- a/aws/logs_monitoring/tests/test_lambda_function.py
+++ b/aws/logs_monitoring/tests/test_lambda_function.py
@@ -71,7 +71,9 @@ class TestInvokeAdditionalTargetLambdas(unittest.TestCase):
 
 
 class TestLambdaFunctionEndToEnd(unittest.TestCase):
-    def test_datadog_forwarder(self):
+    @patch("caching.cloudwatch_log_group_cache.CloudwatchLogGroupTagsCache.__init__")
+    def test_datadog_forwarder(self, mock_cache_init):
+        mock_cache_init.return_value = None
         cache_layer = CacheLayer("")
         cache_layer._cloudwatch_log_group_cache.get = MagicMock(return_value=[])
         cache_layer._lambda_cache.get = MagicMock(
@@ -135,9 +137,11 @@ class TestLambdaFunctionEndToEnd(unittest.TestCase):
         assert "creator" not in inferred_span["meta"]
         assert "service" not in inferred_span["meta"]
 
-    def test_setting_service_tag_from_log_group_cache(self):
+    @patch("caching.cloudwatch_log_group_cache.CloudwatchLogGroupTagsCache.__init__")
+    def test_setting_service_tag_from_log_group_cache(self, mock_cache_init):
         reload(sys.modules["settings"])
         reload(sys.modules["steps.parsing"])
+        mock_cache_init.return_value = None
         cache_layer = CacheLayer("")
         cache_layer._cloudwatch_log_group_cache.get = MagicMock(
             return_value=["service:log_group_service"]
@@ -158,9 +162,11 @@ class TestLambdaFunctionEndToEnd(unittest.TestCase):
             self.assertEqual(log["service"], "log_group_service")
 
     @patch.dict(os.environ, {"DD_TAGS": "service:dd_tag_service"})
-    def test_service_override_from_dd_tags(self):
+    @patch("caching.cloudwatch_log_group_cache.CloudwatchLogGroupTagsCache.__init__")
+    def test_service_override_from_dd_tags(self, mock_cache_init):
         reload(sys.modules["settings"])
         reload(sys.modules["steps.parsing"])
+        mock_cache_init.return_value = None
         cache_layer = CacheLayer("")
         cache_layer._cloudwatch_log_group_cache.get = MagicMock(
             return_value=["service:log_group_service"]
@@ -180,16 +186,23 @@ class TestLambdaFunctionEndToEnd(unittest.TestCase):
         for log in logs:
             self.assertEqual(log["service"], "dd_tag_service")
 
+    @patch("caching.cloudwatch_log_group_cache.CloudwatchLogGroupTagsCache.__init__")
     @patch("caching.base_tags_cache.send_forwarder_internal_metrics")
     @patch("caching.cloudwatch_log_group_cache.send_forwarder_internal_metrics")
     @patch("caching.lambda_cache.send_forwarder_internal_metrics")
     def test_overrding_service_tag_from_lambda_cache(
-        self, mock_lambda_send_metrics, mock_cw_send_metrics, mock_base_send_metrics
+        self,
+        mock_lambda_send_metrics,
+        mock_cw_send_metrics,
+        mock_base_send_metrics,
+        mock_cache_init,
     ):
+        mock_cache_init.return_value = None
         cache_layer = CacheLayer("")
         cache_layer._lambda_cache.get = MagicMock(
             return_value=["service:lambda_service"]
         )
+        cache_layer._cloudwatch_log_group_cache = MagicMock()
         context = Context()
         input_data = self._get_input_data()
         event = {
@@ -205,7 +218,11 @@ class TestLambdaFunctionEndToEnd(unittest.TestCase):
         for log in logs:
             self.assertEqual(log["service"], "lambda_service")
 
-    def test_overrding_service_tag_from_lambda_cache_when_dd_tags_is_set(self):
+    @patch("caching.cloudwatch_log_group_cache.CloudwatchLogGroupTagsCache.__init__")
+    def test_overrding_service_tag_from_lambda_cache_when_dd_tags_is_set(
+        self, mock_cache_init
+    ):
+        mock_cache_init.return_value = None
         cache_layer = CacheLayer("")
         cache_layer._lambda_cache.get = MagicMock(
             return_value=["service:lambda_service"]
@@ -225,10 +242,14 @@ class TestLambdaFunctionEndToEnd(unittest.TestCase):
         for log in logs:
             self.assertEqual(log["service"], "lambda_service")
 
+    @patch("caching.cloudwatch_log_group_cache.CloudwatchLogGroupTagsCache.__init__")
     @patch("steps.handlers.s3_handler.get_s3_client")
     @patch("steps.handlers.s3_handler.extract_data")
-    def test_s3_tags_not_added_to_metadata(self, mock_extract_data, mock_get_s3_client):
+    def test_s3_tags_not_added_to_metadata(
+        self, mock_extract_data, mock_get_s3_client, mock_cache_init
+    ):
         mock_get_s3_client.side_effect = MagicMock()
+        mock_cache_init.return_value = None
         cache_layer = CacheLayer("")
         cache_layer._s3_tags_cache.get = MagicMock(return_value=["s3_tag:tag_value"])
         context = Context()
@@ -248,6 +269,7 @@ class TestLambdaFunctionEndToEnd(unittest.TestCase):
 
         assert "s3_tag:tag_value" not in normalized_events[0]["ddtags"]
 
+    @patch("caching.cloudwatch_log_group_cache.CloudwatchLogGroupTagsCache.__init__")
     @patch("steps.handlers.s3_handler.parse_service_arn")
     @patch("steps.handlers.s3_handler.get_s3_client")
     @patch("steps.handlers.s3_handler.extract_data")
@@ -256,8 +278,10 @@ class TestLambdaFunctionEndToEnd(unittest.TestCase):
         mock_extract_data,
         mock_get_s3_client,
         mock_parse_service_arn,
+        mock_cache_init,
     ):
         mock_get_s3_client.side_effect = MagicMock()
+        mock_cache_init.return_value = None
         cache_layer = CacheLayer("")
         cache_layer._s3_tags_cache.get = MagicMock(return_value=["s3_tag:tag_value"])
         context = Context()

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_customized_log_group_lambda_invocation.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_customized_log_group_lambda_invocation.json~snapshot
@@ -96,7 +96,35 @@
             "device": null,
             "host": null,
             "interval": 10,
+            "metric": "aws.dd_forwarder.s3_cache_fetch_failure",
+            "points": "<redacted from snapshot>",
+            "tags": [
+              "forwardername:test",
+              "forwarder_memorysize:1536",
+              "forwarder_version:<redacted from snapshot>",
+              "event_type:awslogs"
+            ],
+            "type": "distribution"
+          },
+          {
+            "device": null,
+            "host": null,
+            "interval": 10,
             "metric": "aws.dd_forwarder.list_tags_log_group_api_call",
+            "points": "<redacted from snapshot>",
+            "tags": [
+              "forwardername:test",
+              "forwarder_memorysize:1536",
+              "forwarder_version:<redacted from snapshot>",
+              "event_type:awslogs"
+            ],
+            "type": "distribution"
+          },
+          {
+            "device": null,
+            "host": null,
+            "interval": 10,
+            "metric": "aws.dd_forwarder.s3_cache_write_failure",
             "points": "<redacted from snapshot>",
             "tags": [
               "forwardername:test",

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log.json~snapshot
@@ -68,7 +68,35 @@
             "device": null,
             "host": null,
             "interval": 10,
+            "metric": "aws.dd_forwarder.s3_cache_fetch_failure",
+            "points": "<redacted from snapshot>",
+            "tags": [
+              "forwardername:test",
+              "forwarder_memorysize:1536",
+              "forwarder_version:<redacted from snapshot>",
+              "event_type:awslogs"
+            ],
+            "type": "distribution"
+          },
+          {
+            "device": null,
+            "host": null,
+            "interval": 10,
             "metric": "aws.dd_forwarder.list_tags_log_group_api_call",
+            "points": "<redacted from snapshot>",
+            "tags": [
+              "forwardername:test",
+              "forwarder_memorysize:1536",
+              "forwarder_version:<redacted from snapshot>",
+              "event_type:awslogs"
+            ],
+            "type": "distribution"
+          },
+          {
+            "device": null,
+            "host": null,
+            "interval": 10,
+            "metric": "aws.dd_forwarder.s3_cache_write_failure",
             "points": "<redacted from snapshot>",
             "tags": [
               "forwardername:test",

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_apigateway.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_apigateway.json~snapshot
@@ -1,22 +1,94 @@
 {
   "events": [
     {
+      "data": [
+        {
+          "aws": {
+            "awslogs": {
+              "logGroup": "API-Gateway-Execution-Logs_xxxxxxxxxx/production",
+              "logStream": "123456789123_API-Gateway_us-east-1",
+              "owner": "123456789123"
+            },
+            "function_version": "$LATEST",
+            "invoked_function_arn": "arn:aws:lambda:us-east-1:0000000000:function:test"
+          },
+          "ddsource": "apigateway",
+          "ddsourcecategory": "aws",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>",
+          "eventId": "11111111111111111111111111111111",
+          "host": "API-Gateway-Execution-Logs_xxxxxxxxxx/production",
+          "ingestionTime": 1607444452966,
+          "logStreamName": "11111111111111111111111111111111",
+          "message": "(aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa) Extended Request Id: XXXXXX-XXXXXXXX=",
+          "service": "apigateway",
+          "timestamp": 1607444432899
+        },
+        {
+          "aws": {
+            "awslogs": {
+              "logGroup": "API-Gateway-Execution-Logs_xxxxxxxxxx/production",
+              "logStream": "123456789123_API-Gateway_us-east-1",
+              "owner": "123456789123"
+            },
+            "function_version": "$LATEST",
+            "invoked_function_arn": "arn:aws:lambda:us-east-1:0000000000:function:test"
+          },
+          "ddsource": "apigateway",
+          "ddsourcecategory": "aws",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>",
+          "eventId": "11111111111111111111111111111111",
+          "host": "API-Gateway-Execution-Logs_xxxxxxxxxx/production",
+          "ingestionTime": 1607444452966,
+          "logStreamName": "11111111111111111111111111111111",
+          "message": "(aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa) Verifying Usage Plan for request: <redacted from snapshot>. API Key:  API Stage: xxxxxxxxxx/production",
+          "service": "apigateway",
+          "timestamp": 1607444432899
+        },
+        {
+          "aws": {
+            "awslogs": {
+              "logGroup": "API-Gateway-Execution-Logs_xxxxxxxxxx/production",
+              "logStream": "123456789123_API-Gateway_us-east-1",
+              "owner": "123456789123"
+            },
+            "function_version": "$LATEST",
+            "invoked_function_arn": "arn:aws:lambda:us-east-1:0000000000:function:test"
+          },
+          "ddsource": "apigateway",
+          "ddsourcecategory": "aws",
+          "ddtags": "forwardername:test,forwarder_memorysize:1536,forwarder_version:<redacted from snapshot>",
+          "eventId": "11111111111111111111111111111111",
+          "host": "API-Gateway-Execution-Logs_xxxxxxxxxx/production",
+          "ingestionTime": 1607444452966,
+          "logStreamName": "11111111111111111111111111111111",
+          "message": "(aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa) API Key  authorized because method 'POST /event' does not require API Key. Request will not contribute to throttle or quota limits",
+          "service": "apigateway",
+          "timestamp": 1607444432900
+        }
+      ],
+      "headers": {
+        "Accept": "*/*",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "<redacted from snapshot>",
+        "Content-type": "application/json",
+        "DD-API-KEY": "abcdefghijklmnopqrstuvwxyz012345",
+        "DD-EVP-ORIGIN": "aws_forwarder",
+        "DD-EVP-ORIGIN-VERSION": "<redacted from snapshot>",
+        "Host": "recorder:8080",
+        "User-Agent": "<redacted from snapshot>",
+        "traceparent": "00-0000000000000000433534434534ef0d-91ed514f1e5c03b2-01",
+        "tracestate": "dd=s:2",
+        "x-datadog-parent-id": "<redacted from snapshot>",
+        "x-datadog-sampling-priority": "2",
+        "x-datadog-trace-id": "4842834437835386637"
+      },
+      "path": "/api/v2/logs",
+      "verb": "POST"
+    },
+    {
       "data": {
         "series": [
-          {
-            "device": null,
-            "host": null,
-            "interval": 10,
-            "metric": "aws.dd_forwarder.cw_log_group_tags_cache_expired",
-            "points": "<redacted from snapshot>",
-            "tags": [
-              "forwardername:test",
-              "forwarder_memorysize:1536",
-              "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
-            ],
-            "type": "distribution"
-          },
           {
             "device": null,
             "host": null,
@@ -35,7 +107,63 @@
             "device": null,
             "host": null,
             "interval": 10,
-            "metric": "aws.dd_forwarder.s3_cache_expired",
+            "metric": "aws.dd_forwarder.list_tags_log_group_api_call",
+            "points": "<redacted from snapshot>",
+            "tags": [
+              "forwardername:test",
+              "forwarder_memorysize:1536",
+              "forwarder_version:<redacted from snapshot>",
+              "event_type:awslogs"
+            ],
+            "type": "distribution"
+          },
+          {
+            "device": null,
+            "host": null,
+            "interval": 10,
+            "metric": "aws.dd_forwarder.s3_cache_write_failure",
+            "points": "<redacted from snapshot>",
+            "tags": [
+              "forwardername:test",
+              "forwarder_memorysize:1536",
+              "forwarder_version:<redacted from snapshot>",
+              "event_type:awslogs"
+            ],
+            "type": "distribution"
+          },
+          {
+            "device": null,
+            "host": null,
+            "interval": 10,
+            "metric": "aws.dd_forwarder.incoming_events",
+            "points": "<redacted from snapshot>",
+            "tags": [
+              "forwardername:test",
+              "forwarder_memorysize:1536",
+              "forwarder_version:<redacted from snapshot>",
+              "event_type:awslogs"
+            ],
+            "type": "distribution"
+          },
+          {
+            "device": null,
+            "host": null,
+            "interval": 10,
+            "metric": "aws.dd_forwarder.logs_forwarded",
+            "points": "<redacted from snapshot>",
+            "tags": [
+              "forwardername:test",
+              "forwarder_memorysize:1536",
+              "forwarder_version:<redacted from snapshot>",
+              "event_type:awslogs"
+            ],
+            "type": "distribution"
+          },
+          {
+            "device": null,
+            "host": null,
+            "interval": 10,
+            "metric": "aws.dd_forwarder.metrics_forwarded",
             "points": "<redacted from snapshot>",
             "tags": [
               "forwardername:test",

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_cloudtrail.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_cloudtrail.json~snapshot
@@ -106,7 +106,35 @@
             "device": null,
             "host": null,
             "interval": 10,
+            "metric": "aws.dd_forwarder.s3_cache_fetch_failure",
+            "points": "<redacted from snapshot>",
+            "tags": [
+              "forwardername:test",
+              "forwarder_memorysize:1536",
+              "forwarder_version:<redacted from snapshot>",
+              "event_type:awslogs"
+            ],
+            "type": "distribution"
+          },
+          {
+            "device": null,
+            "host": null,
+            "interval": 10,
             "metric": "aws.dd_forwarder.list_tags_log_group_api_call",
+            "points": "<redacted from snapshot>",
+            "tags": [
+              "forwardername:test",
+              "forwarder_memorysize:1536",
+              "forwarder_version:<redacted from snapshot>",
+              "event_type:awslogs"
+            ],
+            "type": "distribution"
+          },
+          {
+            "device": null,
+            "host": null,
+            "interval": 10,
+            "metric": "aws.dd_forwarder.s3_cache_write_failure",
             "points": "<redacted from snapshot>",
             "tags": [
               "forwardername:test",

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_coldstart.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_coldstart.json~snapshot
@@ -7,7 +7,35 @@
             "device": null,
             "host": null,
             "interval": 10,
+            "metric": "aws.dd_forwarder.s3_cache_fetch_failure",
+            "points": "<redacted from snapshot>",
+            "tags": [
+              "forwardername:test",
+              "forwarder_memorysize:1536",
+              "forwarder_version:<redacted from snapshot>",
+              "event_type:awslogs"
+            ],
+            "type": "distribution"
+          },
+          {
+            "device": null,
+            "host": null,
+            "interval": 10,
             "metric": "aws.dd_forwarder.list_tags_log_group_api_call",
+            "points": "<redacted from snapshot>",
+            "tags": [
+              "forwardername:test",
+              "forwarder_memorysize:1536",
+              "forwarder_version:<redacted from snapshot>",
+              "event_type:awslogs"
+            ],
+            "type": "distribution"
+          },
+          {
+            "device": null,
+            "host": null,
+            "interval": 10,
+            "metric": "aws.dd_forwarder.s3_cache_write_failure",
             "points": "<redacted from snapshot>",
             "tags": [
               "forwardername:test",
@@ -36,20 +64,6 @@
             "host": null,
             "interval": 10,
             "metric": "aws.dd_forwarder.local_lambda_cache_expired",
-            "points": "<redacted from snapshot>",
-            "tags": [
-              "forwardername:test",
-              "forwarder_memorysize:1536",
-              "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
-            ],
-            "type": "distribution"
-          },
-          {
-            "device": null,
-            "host": null,
-            "interval": 10,
-            "metric": "aws.dd_forwarder.s3_cache_fetch_failure",
             "points": "<redacted from snapshot>",
             "tags": [
               "forwardername:test",

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_fsx_windows.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_fsx_windows.json~snapshot
@@ -49,7 +49,35 @@
             "device": null,
             "host": null,
             "interval": 10,
+            "metric": "aws.dd_forwarder.s3_cache_fetch_failure",
+            "points": "<redacted from snapshot>",
+            "tags": [
+              "forwardername:test",
+              "forwarder_memorysize:1536",
+              "forwarder_version:<redacted from snapshot>",
+              "event_type:awslogs"
+            ],
+            "type": "distribution"
+          },
+          {
+            "device": null,
+            "host": null,
+            "interval": 10,
             "metric": "aws.dd_forwarder.list_tags_log_group_api_call",
+            "points": "<redacted from snapshot>",
+            "tags": [
+              "forwardername:test",
+              "forwarder_memorysize:1536",
+              "forwarder_version:<redacted from snapshot>",
+              "event_type:awslogs"
+            ],
+            "type": "distribution"
+          },
+          {
+            "device": null,
+            "host": null,
+            "interval": 10,
+            "metric": "aws.dd_forwarder.s3_cache_write_failure",
             "points": "<redacted from snapshot>",
             "tags": [
               "forwardername:test",

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_lambda_invocation.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_lambda_invocation.json~snapshot
@@ -760,7 +760,35 @@
             "device": null,
             "host": null,
             "interval": 10,
+            "metric": "aws.dd_forwarder.s3_cache_fetch_failure",
+            "points": "<redacted from snapshot>",
+            "tags": [
+              "forwardername:test",
+              "forwarder_memorysize:1536",
+              "forwarder_version:<redacted from snapshot>",
+              "event_type:awslogs"
+            ],
+            "type": "distribution"
+          },
+          {
+            "device": null,
+            "host": null,
+            "interval": 10,
             "metric": "aws.dd_forwarder.list_tags_log_group_api_call",
+            "points": "<redacted from snapshot>",
+            "tags": [
+              "forwardername:test",
+              "forwarder_memorysize:1536",
+              "forwarder_version:<redacted from snapshot>",
+              "event_type:awslogs"
+            ],
+            "type": "distribution"
+          },
+          {
+            "device": null,
+            "host": null,
+            "interval": 10,
+            "metric": "aws.dd_forwarder.s3_cache_write_failure",
             "points": "<redacted from snapshot>",
             "tags": [
               "forwardername:test",

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_route53.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_route53.json~snapshot
@@ -49,7 +49,35 @@
             "device": null,
             "host": null,
             "interval": 10,
+            "metric": "aws.dd_forwarder.s3_cache_fetch_failure",
+            "points": "<redacted from snapshot>",
+            "tags": [
+              "forwardername:test",
+              "forwarder_memorysize:1536",
+              "forwarder_version:<redacted from snapshot>",
+              "event_type:awslogs"
+            ],
+            "type": "distribution"
+          },
+          {
+            "device": null,
+            "host": null,
+            "interval": 10,
             "metric": "aws.dd_forwarder.list_tags_log_group_api_call",
+            "points": "<redacted from snapshot>",
+            "tags": [
+              "forwardername:test",
+              "forwarder_memorysize:1536",
+              "forwarder_version:<redacted from snapshot>",
+              "event_type:awslogs"
+            ],
+            "type": "distribution"
+          },
+          {
+            "device": null,
+            "host": null,
+            "interval": 10,
+            "metric": "aws.dd_forwarder.s3_cache_write_failure",
             "points": "<redacted from snapshot>",
             "tags": [
               "forwardername:test",

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/step_functions_log.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/step_functions_log.json~snapshot
@@ -49,7 +49,35 @@
             "device": null,
             "host": null,
             "interval": 10,
+            "metric": "aws.dd_forwarder.s3_cache_fetch_failure",
+            "points": "<redacted from snapshot>",
+            "tags": [
+              "forwardername:test",
+              "forwarder_memorysize:1536",
+              "forwarder_version:<redacted from snapshot>",
+              "event_type:awslogs"
+            ],
+            "type": "distribution"
+          },
+          {
+            "device": null,
+            "host": null,
+            "interval": 10,
             "metric": "aws.dd_forwarder.list_tags_log_group_api_call",
+            "points": "<redacted from snapshot>",
+            "tags": [
+              "forwardername:test",
+              "forwarder_memorysize:1536",
+              "forwarder_version:<redacted from snapshot>",
+              "event_type:awslogs"
+            ],
+            "type": "distribution"
+          },
+          {
+            "device": null,
+            "host": null,
+            "interval": 10,
+            "metric": "aws.dd_forwarder.s3_cache_write_failure",
             "points": "<redacted from snapshot>",
             "tags": [
               "forwardername:test",


### PR DESCRIPTION

<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
- Add client config for limiting max retries
- Add a separate tags cache file per log group
- Init the cache at startup from existing files
- Allow individual cache file updates w/o having a lock file
- Add a random number of seconds (jitter) on verifying tags expiry
- Update cloudformation template to allow listing objects in the cache dir

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
