### PR TITLE
Drop unrequired `s3:ListBucket` permission

### DIFF
--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -46,7 +46,7 @@ Parameters:
     ConstraintDescription: ReservedConcurrency must be an integer number
     Default: ""
     Description: >-
-      Reserved concurrency for the Datadog Forwarder Lambda function. If empty, use unreserved account concurrency. 
+      Reserved concurrency for the Datadog Forwarder Lambda function. If empty, use unreserved account concurrency.
       We recommend using at least 10 reserved concurrency, but default to 0 as you may need to increase your limits for this.
       If using unreserved account concurrency you may limit other lambda functions in your environment.
   LogRetentionInDays:
@@ -731,7 +731,7 @@ Resources:
               # Get the actual log content from the s3 bucket based on the received s3 event.
               # Use PermissionsBoundaryArn to limit (allow/deny) access if needed.
               - Fn::If:
-                  - SetForwarderBucket            
+                  - SetForwarderBucket
                   - Action:
                       - s3:ListBucket
                     Resource:
@@ -869,7 +869,7 @@ Resources:
   # A s3 bucket used by the Forwarder as a datastore
   ForwarderBucket:
     Type: AWS::S3::Bucket
-    Condition: CreateS3Bucket 
+    Condition: CreateS3Bucket
     Properties:
       BucketName:
         Fn::If:
@@ -891,7 +891,7 @@ Resources:
          Prefix: ''
          AbortIncompleteMultipartUpload:
            DaysAfterInitiation: 7
-         Status: Enabled        
+         Status: Enabled
   ForwarderBucketPolicy:
     Type: "AWS::S3::BucketPolicy"
     Condition: CreateS3Bucket

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -718,7 +718,6 @@ Resources:
                       - s3:GetObject
                       - s3:PutObject
                       - s3:DeleteObject
-                      - s3:ListBucket
                     Resource:
                       - Fn::If:
                         - CreateS3Bucket


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Removal of the current IAM permission `s3:ListBucket` against the `ForwarderRolePolicy0` inline policy for the Lambda forwarder function - which is tied to the resource ARN of `arn:aws:s3:::MY_BUCKET_NAME/*`.

The action `s3:ListBucket` has no use here, as this action only applies to a _bucket_ (e.g. `arn:aws:s3:::MY_BUCKET_NAME`), not an S3 bucket object (e.g. `arn:aws:s3:::MY_BUCKET_NAME/*`).

This is outlined in the [AWS S3 actions guide](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html#:~:text=amz%2Dcontent%2Dsha256-,ListBucket,-Grants%20permission%20to).

### Motivation

Just a little cleanup of the generated IAM role policy.

### Testing Guidelines

N/A

### Additional Notes

None

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
