### PR TITLE
[Logs Forwarder] Use ListTagsForResource instead of deprecated ListTagsLogGroup call

### DIFF
--- a/aws/logs_monitoring/steps/handlers/aws_attributes.py
+++ b/aws/logs_monitoring/steps/handlers/aws_attributes.py
@@ -8,6 +8,8 @@ class AwsAttributes:
         self.log_events = log_events
         self.owner = owner
         self.lambda_arn = None
+        self.account = None
+        self.region = None
 
     def to_dict(self):
         awslogs = {
@@ -27,6 +29,9 @@ class AwsAttributes:
     def get_log_group(self):
         return self.log_group
 
+    def get_log_group_arn(self):
+        return f"arn:aws:logs:{self.region}:{self.account}:log-group:{self.log_group}"
+
     def get_log_stream(self):
         return self.log_stream
 
@@ -38,3 +43,11 @@ class AwsAttributes:
 
     def set_lambda_arn(self, arn):
         self.lambda_arn = arn
+
+    def set_account_region(self, arn):
+        try:
+            parts = arn.split(":")
+            self.account = parts[4]
+            self.region = parts[3]
+        except Exception:
+            raise Exception("Failed to parse account and region from ARN")

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -778,7 +778,7 @@ Resources:
               - Fn::If:
                   - SetDdFetchLogGroupTags
                   - Action:
-                      - logs:ListTagsLogGroup
+                      - logs:ListTagsForResource
                     Resource: "*"
                     Effect: Allow
                   - Ref: AWS::NoValue


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
