### PR TITLE
fix missing cache_layer error for cloudwatch log from kinesis

### DIFF
--- a/aws/logs_monitoring/steps/parsing.py
+++ b/aws/logs_monitoring/steps/parsing.py
@@ -54,7 +54,7 @@ def parse(event, context, cache_layer):
             case AwsEventType.SNS:
                 events = sns_handler(event, metadata)
             case AwsEventType.KINESIS:
-                events = kinesis_awslogs_handler(event, context, metadata)
+                events = kinesis_awslogs_handler(event, context, metadata, cache_layer)
             case _:
                 events = ["Parsing: Unsupported event type"]
     except Exception as e:
@@ -154,12 +154,12 @@ def sns_handler(event, metadata):
 
 
 # Handle CloudWatch logs from Kinesis
-def kinesis_awslogs_handler(event, context, metadata):
+def kinesis_awslogs_handler(event, context, metadata, cache_layer):
     def reformat_record(record):
         return {"awslogs": {"data": record["kinesis"]["data"]}}
 
     return itertools.chain.from_iterable(
-        awslogs_handler(reformat_record(r), context, metadata) for r in event["Records"]
+        awslogs_handler(reformat_record(r), context, metadata, cache_layer) for r in event["Records"]
     )
 
 

--- a/aws/logs_monitoring/steps/parsing.py
+++ b/aws/logs_monitoring/steps/parsing.py
@@ -159,8 +159,7 @@ def kinesis_awslogs_handler(event, context, metadata, cache_layer):
         return {"awslogs": {"data": record["kinesis"]["data"]}}
 
     return itertools.chain.from_iterable(
-        awslogs_handler(reformat_record(r), context, metadata, cache_layer) 
-        for r in event["Records"]
+        awslogs_handler(reformat_record(r), context, metadata, cache_layer) for r in event["Records"]
     )
 
 

--- a/aws/logs_monitoring/steps/parsing.py
+++ b/aws/logs_monitoring/steps/parsing.py
@@ -159,7 +159,8 @@ def kinesis_awslogs_handler(event, context, metadata, cache_layer):
         return {"awslogs": {"data": record["kinesis"]["data"]}}
 
     return itertools.chain.from_iterable(
-        awslogs_handler(reformat_record(r), context, metadata, cache_layer) for r in event["Records"]
+        awslogs_handler(reformat_record(r), context, metadata, cache_layer) 
+        for r in event["Records"]
     )
 
 


### PR DESCRIPTION
### What does this PR do?

When sending cloudwatch logs from kinesis, the following error occurred in the latest version.
```
[ERROR] TypeError: awslogs_handler() missing 1 required positional argument: 'cache_layer'
Traceback (most recent call last):
  File "/var/task/datadog_lambda/wrapper.py", line 232, in __call__
    self.response = self.func(event, context, **kwargs)
  File "/var/task/lambda_function.py", line 75, in datadog_forwarder
    parsed = parse(event, context, cache_layer)
  File "/var/task/steps/parsing.py", line 69, in parse
    return normalize_events(events, metadata)
  File "/var/task/steps/parsing.py", line 170, in normalize_events
    for event in events:
  File "/var/task/steps/parsing.py", line 162, in <genexpr>
    awslogs_handler(reformat_record(r), context, metadata) for r in event["Records"]
```

It seems that function `awslogs_handler(event, context, metadata, cache_layer)` requires argument `cache_layer`; however, we don't pass in `cache_layer` when calling this function.
https://github.com/DataDog/datadog-serverless-functions/blob/master/aws/logs_monitoring/steps/handlers/awslogs_handler.py#L33

### Motivation
CLOUDS-4786


### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
