### PR TITLE
Set service tag after adding S3 bucket tags to metadata dict

### DIFF
--- a/aws/logs_monitoring/steps/handlers/s3_handler.py
+++ b/aws/logs_monitoring/steps/handlers/s3_handler.py
@@ -50,9 +50,9 @@ class S3EventHandler:
     def handle(self, event):
         event = self._extract_event(event)
         self._set_source(event)
-        add_service_tag(self.metadata)
         self._set_host()
         self._add_s3_tags_from_cache()
+        add_service_tag(self.metadata)
         self._extract_data()
         yield from self._get_structured_lines_for_s3_handler()
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Currently the service tag is added before the S3 bucket tags have been added to the metadata dict. This means the `add_service_tag` function doesn't know about potential `service` tags that are set on the bucket.

This PR makes sure the S3 bucket tags are added to the metadata dict, before the `service` tag is being set.

### Motivation

Currently, the `service` tag that is set on a bucket is not used to set the `service` attribute on the logs sent to DD. Instead it will fall back to setting `service` to the value of `ddsource`.

### Testing Guidelines

Built the handler locally and updated our DD Forwarder. After the changes, the `service` attribute of the logs coming from a S3 bucket are now correctly set to the `service` tag set on the S3 bucket.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
