### PR TITLE
Fix a bug in splitting line on S3 file with DD_MULTILINE_LOG_REGEX_PATTERN

### DIFF
--- a/aws/logs_monitoring/steps/handlers/s3_handler.py
+++ b/aws/logs_monitoring/steps/handlers/s3_handler.py
@@ -296,6 +296,7 @@ class S3EventHandler:
                     "DD_MULTILINE_LOG_REGEX_PATTERN %s did not match start of file, splitting by line",
                     DD_MULTILINE_LOG_REGEX_PATTERN,
                 )
+                self.data_store.data = self.data_store.data.splitlines()
 
             for line in self.data_store.data:
                 yield self._format_event(line)


### PR DESCRIPTION
### What does this PR do?

Fix a parsing issue for a S3 file with `DD_MULTILINE_LOG_REGEX_PATTERN` environment variable, which is introduced by the refactoring at https://github.com/DataDog/datadog-serverless-functions/commit/196c6331506beba4f1649fce84c052958aff2333

### Motivation

My log files in S3 bucket was parsed wrongly and ingested to Datadog Log when I upgraded the version from 3.108.0 to 3.116.0. Strictly speaking, the issue was introduced from 3.113.0 [[diff](https://github.com/DataDog/datadog-serverless-functions/compare/aws-dd-forwarder-3.112.0...aws-dd-forwarder-3.113.0)].

### Testing Guidelines

Since this is a very small change, I didn't wrote any test code. Instead, I paste the sample code here for easier understanding  
```python
In [1]: data = 'hello\r\nnext line\nbye'

# expected
In [2]: for line in data.splitlines():
    ...:     print(line)
    ...:
hello
next line
bye

# Now. My parsed log in Datadog Log is like this now.
In [3]: for line in data:
    ...:     print(line)
    ...:
h
e
l
l
o



n
e
x
t

l
i
n
e


b
y
e
```

### Additional Notes

This problem happens only when `DD_MULTILINE_LOG_REGEX_PATTERN` is given but the content of file doesn't match it.

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
