### PR TITLE
Update forwarder README.md for `DdFetchStepFunctionsTags`

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -395,6 +395,9 @@ SSL encrypted TCP connection, set this parameter to true.
 `DdFetchLogGroupTags`
 : Let the forwarder fetch Log Group tags using ListTagsLogGroup and apply them to logs, metrics, and traces. If set to true, permission `logs:ListTagsLogGroup` will be automatically added to the Lambda execution IAM role.
 
+`DdFetchStepFunctionsTags`
+: Let the Forwarder fetch Step Functions tags using GetResources API calls and apply them to traces (if Step Functions tracing is enabled). If set to true, permission `tag:GetResources` will be automatically added to the Lambda execution IAM role.
+
 ### Log scrubbing (optional)
 
 `RedactIp`


### PR DESCRIPTION
We have added the `DdFetchStepFunctionsTags` back in 2022 but didn't update the doc to reflect that until now.

https://github.com/DataDog/datadog-serverless-functions/blob/93c228160c6faffaf3482037aac5a2a10f6704fb/aws/logs_monitoring/template.yaml#L89-L94