### PR TITLE
refactor(logs): Avoid compiling regex many times

### DIFF
--- a/aws/logs_monitoring/logs/helpers.py
+++ b/aws/logs_monitoring/logs/helpers.py
@@ -10,8 +10,9 @@ import logging
 import os
 import re
 
-from logs.exceptions import ScrubbingException
 from settings import DD_CUSTOM_TAGS, DD_RETRY_KEYWORD
+
+from logs.exceptions import ScrubbingException
 
 logger = logging.getLogger()
 logger.setLevel(logging.getLevelName(os.environ.get("DD_LOG_LEVEL", "INFO").upper()))
@@ -36,8 +37,6 @@ def filter_logs(logs, include_pattern=None, exclude_pattern=None):
 
     for log in logs:
         try:
-            logger.debug(log)
-
             if exclude_regex is not None and re.search(exclude_regex, log):
                 logger.debug("Exclude pattern matched, excluding log event")
                 continue


### PR DESCRIPTION
### What does this PR do?

Optimize CPU consumption by compiling the regex only once.

### Motivation

Save CPU and cost

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
