### PR TITLE
refactor(s3): Move all cache files to the `cache/` folder

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -1,4 +1,17 @@
+---
 name: Integration tests
+
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  issues: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
 
 on: [pull_request]
 
@@ -9,10 +22,13 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.10', '3.11']
+        python-version: ["3.10", "3.11"]
     steps:
-      - name: Checkout source
-        uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
 
       - name: Run integration tests
         run: |

--- a/aws/logs_monitoring/caching/cloudwatch_log_group_cache.py
+++ b/aws/logs_monitoring/caching/cloudwatch_log_group_cache.py
@@ -6,9 +6,11 @@ from time import time
 
 import boto3
 from botocore.config import Config
+
 from caching.common import sanitize_aws_tag_string
 from settings import (
     DD_S3_BUCKET_NAME,
+    DD_S3_CACHE_DIRNAME,
     DD_S3_LOG_GROUP_CACHE_DIRNAME,
     DD_TAGS_CACHE_TTL_SECONDS,
 )
@@ -20,7 +22,7 @@ class CloudwatchLogGroupTagsCache:
         self,
         prefix,
     ):
-        self.cache_dirname = DD_S3_LOG_GROUP_CACHE_DIRNAME
+        self.cache_dirname = f"{DD_S3_CACHE_DIRNAME}/{DD_S3_LOG_GROUP_CACHE_DIRNAME}"
         self.cache_ttl_seconds = DD_TAGS_CACHE_TTL_SECONDS
         self.bucket_name = DD_S3_BUCKET_NAME
         self.cache_prefix = prefix

--- a/aws/logs_monitoring/caching/lambda_cache.py
+++ b/aws/logs_monitoring/caching/lambda_cache.py
@@ -1,18 +1,22 @@
 import os
+
 from botocore.exceptions import ClientError
+
 from caching.base_tags_cache import BaseTagsCache
 from caching.common import parse_get_resources_response_for_tags_by_arn
-from telemetry import send_forwarder_internal_metrics
 from settings import (
-    DD_S3_CACHE_FILENAME,
-    DD_S3_CACHE_LOCK_FILENAME,
+    DD_S3_LAMBDA_CACHE_FILENAME,
+    DD_S3_LAMBDA_CACHE_LOCK_FILENAME,
     GET_RESOURCES_LAMBDA_FILTER,
 )
+from telemetry import send_forwarder_internal_metrics
 
 
 class LambdaTagsCache(BaseTagsCache):
     def __init__(self, prefix):
-        super().__init__(prefix, DD_S3_CACHE_FILENAME, DD_S3_CACHE_LOCK_FILENAME)
+        super().__init__(
+            prefix, DD_S3_LAMBDA_CACHE_FILENAME, DD_S3_LAMBDA_CACHE_LOCK_FILENAME
+        )
 
     def should_fetch_tags(self):
         return os.environ.get("DD_FETCH_LAMBDA_TAGS", "false").lower() == "true"

--- a/aws/logs_monitoring/retry/storage.py
+++ b/aws/logs_monitoring/retry/storage.py
@@ -1,10 +1,12 @@
-import os
-import logging
-from time import time
 import json
+import logging
+import os
+from time import time
+
 import boto3
 from botocore.exceptions import ClientError
-from settings import DD_RETRY_PATH, DD_S3_BUCKET_NAME
+
+from settings import DD_S3_BUCKET_NAME, DD_S3_RETRY_DIRNAME
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.getLevelName(os.environ.get("DD_LOG_LEVEL", "INFO").upper()))
@@ -76,7 +78,7 @@ class Storage(object):
             return None
 
     def _get_key_prefix(self, retry_prefix):
-        return f"{DD_RETRY_PATH}/{self.function_prefix}/{str(retry_prefix)}/"
+        return f"{DD_S3_RETRY_DIRNAME}/{self.function_prefix}/{str(retry_prefix)}/"
 
     def _serialize(self, data):
         return bytes(json.dumps(data).encode("UTF-8"))

--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -4,11 +4,11 @@
 # Copyright 2021 Datadog, Inc.
 
 import base64
+import logging
 import os
 
 import boto3
 import botocore.config
-import logging
 
 logger = logging.getLogger()
 logger.setLevel(logging.getLevelName(os.environ.get("DD_LOG_LEVEL", "INFO").upper()))
@@ -255,15 +255,20 @@ CN_STRING = "cn"
 DD_ADDITIONAL_TARGET_LAMBDAS = get_env_var("DD_ADDITIONAL_TARGET_LAMBDAS", default=None)
 
 DD_S3_BUCKET_NAME = get_env_var("DD_S3_BUCKET_NAME", default=None)
+
 # These default cache names remain unchanged so we can get existing cache data for these
-DD_S3_CACHE_FILENAME = "cache.json"
-DD_S3_CACHE_LOCK_FILENAME = "cache.lock"
+DD_S3_CACHE_DIRNAME = "cache"
+
+DD_S3_LAMBDA_CACHE_FILENAME = "lambda.json"
+DD_S3_LAMBDA_CACHE_LOCK_FILENAME = "lambda.lock"
+
 DD_S3_STEP_FUNCTIONS_CACHE_FILENAME = "step-functions-cache.json"
 DD_S3_STEP_FUNCTIONS_CACHE_LOCK_FILENAME = "step-functions-cache.lock"
-DD_S3_TAGS_CACHE_FILENAME = "s3-cache.json"
-DD_S3_TAGS_CACHE_LOCK_FILENAME = "s3-cache.lock"
 
-DD_S3_LOG_GROUP_CACHE_DIRNAME = "log-group-cache"
+DD_S3_TAGS_CACHE_FILENAME = "s3.json"
+DD_S3_TAGS_CACHE_LOCK_FILENAME = "s3.lock"
+
+DD_S3_LOG_GROUP_CACHE_DIRNAME = "log-group"
 
 DD_TAGS_CACHE_TTL_SECONDS = int(get_env_var("DD_TAGS_CACHE_TTL_SECONDS", default=300))
 DD_S3_CACHE_LOCK_TTL_SECONDS = 60

--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -277,7 +277,7 @@ GET_RESOURCES_STEP_FUNCTIONS_FILTER = "states"
 GET_RESOURCES_S3_FILTER = "s3:bucket"
 
 
-# Retyer
-DD_RETRY_PATH = "failed_events"
+# Retryer
+DD_S3_RETRY_DIRNAME = "failed_events"
 DD_RETRY_KEYWORD = "retry"
 DD_STORE_FAILED_EVENTS = get_env_var("DD_STORE_FAILED_EVENTS", "false", boolean=True)

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -586,7 +586,7 @@ Resources:
                   Condition:
                     StringLike:
                       s3:prefix:
-                        - "retry/*"
+                        - "failed_events/*"
                         - "cache/*"
                   Effect: Allow
                 - !Ref AWS::NoValue

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -587,7 +587,7 @@ Resources:
                     StringLike:
                       s3:prefix:
                         - "retry/*"
-                        - "log-group-cache/*"
+                        - "cache/*"
                   Effect: Allow
                 - !Ref AWS::NoValue
               - Action:

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -327,6 +327,9 @@ Conditions:
     - !Equals [!Ref ReservedConcurrency, ""]
   ShouldUseAccessLogBucket: !Not
     - !Equals [!Ref DdForwarderBucketsAccessLogsTarget, ""]
+  ShouldDdFetchTags: !Or
+    - !Equals [!Ref DdFetchLambdaTags, true]
+    - !Equals [!Ref DdFetchStepFunctionsTags, true]
   SetForwarderBucket: !Or
     - !Condition CreateS3Bucket
     - !Not
@@ -606,8 +609,9 @@ Resources:
                   - !Sub "${DdApiKeySecretArn}*"
                 Effect: Allow
               # Fetch Lambda resource tags for data enrichment
+              # Fetch Step Functions resource tags for data enrichment
               - !If
-                - SetDdFetchLambdaTags
+                - ShouldDdFetchTags
                 - Action:
                     - tag:GetResources
                   Resource: "*"
@@ -618,14 +622,6 @@ Resources:
                 - SetDdFetchLogGroupTags
                 - Action:
                     - logs:ListTagsForResource
-                  Resource: "*"
-                  Effect: Allow
-                - !Ref AWS::NoValue
-              # Fetch Step Functions resource tags for data enrichment
-              - !If
-                - SetDdFetchStepFunctionsTags
-                - Action:
-                    - tag:GetResources
                   Resource: "*"
                   Effect: Allow
                 - !Ref AWS::NoValue

--- a/aws/logs_monitoring/tools/build_bundle.sh
+++ b/aws/logs_monitoring/tools/build_bundle.sh
@@ -34,7 +34,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 cd $DIR
 
 # Read the desired version
-if [ -z "$1" ]; then
+if [[ -z ${1:-} ]]; then
     log_error "Must specify a desired version number"
 elif [[ ! $1 =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
     log_error "Must use a semantic version, e.g., 3.1.4"


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Change the location of caches files under a `cache/` folder prefix. So that it's allowed by the Policy and will result in a NotFoundException instead of AccessDeniedException, as explained [here](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html).

### Motivation

avoid CloudTrail pollution for AccessDeniedException

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [x] This PR passes the installation tests (ask a Datadog member to run the tests)
