### PR TITLE
AWSX-1006 fix s3 listobject issue visible in CloudTrail

### DIFF
--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -583,7 +583,7 @@ Resources:
                   Condition:
                     StringLike:
                       s3:prefix:
-                        - "retry/*"
+                        - "failed_events/*"
                         - "log-group-cache/*"
                   Effect: Allow
                 - !Ref AWS::NoValue


### PR DESCRIPTION
### What does this PR do?

Fix the wrong path declared in the CFT so the retry mechanism has access to the proper s3 prefix

### Motivation

Issues reported by a few customers

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

I think the intent was to give `ListBucket` permission [here](https://github.com/DataDog/datadog-serverless-functions/blob/master/aws/logs_monitoring/template.yaml#L749) but I'm a bit confused why we have 2 similar blocks
with different actions an resource id [here](https://github.com/DataDog/datadog-serverless-functions/blob/master/aws/logs_monitoring/template.yaml#L730) and [here](https://github.com/DataDog/datadog-serverless-functions/blob/master/aws/logs_monitoring/template.yaml#L748).

Also I see in [this commit](https://github.com/DataDog/datadog-serverless-functions/commit/aa9bfc4fc4490d9f751680635fd5cbae5a0e1f24) that the `ListBucket` was removed from the first block by an external contributor.

In the change which was introduced 3 months ago to store and retry, there might be a mistake. IIUC, the [call to list_objects](https://github.com/DataDog/datadog-serverless-functions/commit/23886fb627762ce26fee5a51cee5142b920f58f6#diff-de98a1ddacb4cbb68467412efca7ac54954c18ca9923a6bb5668dad25bf9f102R53) uses the prefix `failed_events` while the [template](https://github.com/DataDog/datadog-serverless-functions/commit/23886fb627762ce26fee5a51cee5142b920f58f6#diff-7c5bda646bf6435d9285913888d0473f0ac98ed0fdd025ae5d9ea357ad9b3ffaR730) gives permission to the s3 prefix `retry`

The other prefix `log-group-cache`  seems to be used properly from the other file you pointed out.

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
