### PR TITLE
[AWSX] Fix waf events duplication

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,5 +38,5 @@ jobs:
           # cfn-lint was updated in July 2024 to add this check which fails on the template.
           # TODO: We might be able to update the template to fix this error; it seems likely that 
           # SecurityGroupIds in VpcConfig are not generated properly
-          cfn-lint -t aws/logs_monitoring/template.yaml -i W1030  
+          cfn-lint -t aws/logs_monitoring/template.yaml
           cfn-lint -t aws/rds_enhanced_monitoring/rds-enhanced-sam-template.yaml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,15 +28,3 @@ jobs:
           pip install black
           black --check --diff --exclude pb2.py ./aws/logs_monitoring
           black --check --diff ./aws/rds_enhanced_monitoring
-
-      - name: Setup CloudFormation Linter with Latest Version
-        uses: scottbrenner/cfn-lint-action@v2
-
-      - name: Print the CloudFormation Linter Version & run Linter
-        run: |
-          cfn-lint --version
-          # cfn-lint was updated in July 2024 to add this check which fails on the template.
-          # TODO: We might be able to update the template to fix this error; it seems likely that 
-          # SecurityGroupIds in VpcConfig are not generated properly
-          cfn-lint -t aws/logs_monitoring/template.yaml
-          cfn-lint -t aws/rds_enhanced_monitoring/rds-enhanced-sam-template.yaml

--- a/aws/logs_monitoring/steps/transformation.py
+++ b/aws/logs_monitoring/steps/transformation.py
@@ -18,18 +18,17 @@ def transform(events):
     Args:
         events (dict[]): the list of event dicts we want to transform
     """
-    for index, event in enumerate(reversed(events)):
+    for index, event in enumerate(events):
+        waf = parse_aws_waf_logs(event)
+        if waf != event:
+            events[index] = waf
+
+    for event in reversed(events):
         findings = separate_security_hub_findings(event)
 
         if findings:
             events.remove(event)
             events.extend(findings)
-
-            continue
-
-        waf = parse_aws_waf_logs(event)
-        if waf != event:
-            events[index] = waf
 
     return events
 

--- a/aws/logs_monitoring/tests/approved_files/TestTransform.test_transform_mixed.approved.json
+++ b/aws/logs_monitoring/tests/approved_files/TestTransform.test_transform_mixed.approved.json
@@ -1,0 +1,42 @@
+[
+    {
+        "ddsource": "waf",
+        "message": {
+            "httpRequest": {
+                "headers": {
+                    "header2": "value2"
+                }
+            },
+            "request_id": "1"
+        }
+    },
+    {
+        "ddsource": "waf",
+        "message": {
+            "httpRequest": {
+                "headers": {
+                    "header1": "value1"
+                }
+            },
+            "request_id": "2"
+        }
+    },
+    {
+        "ddsource": "securityhub",
+        "detail": {
+            "finding": {
+                "finding": "1",
+                "resources": {}
+            }
+        }
+    },
+    {
+        "ddsource": "securityhub",
+        "detail": {
+            "finding": {
+                "finding": "2",
+                "resources": {}
+            }
+        }
+    }
+]

--- a/aws/logs_monitoring/tests/approved_files/TestTransform.test_transform_security_hub.approved.json
+++ b/aws/logs_monitoring/tests/approved_files/TestTransform.test_transform_security_hub.approved.json
@@ -1,0 +1,38 @@
+[
+    {
+        "ddsource": "securityhub",
+        "detail": {
+            "finding": {
+                "finding": "3",
+                "resources": {}
+            }
+        }
+    },
+    {
+        "ddsource": "securityhub",
+        "detail": {
+            "finding": {
+                "finding": "4",
+                "resources": {}
+            }
+        }
+    },
+    {
+        "ddsource": "securityhub",
+        "detail": {
+            "finding": {
+                "finding": "1",
+                "resources": {}
+            }
+        }
+    },
+    {
+        "ddsource": "securityhub",
+        "detail": {
+            "finding": {
+                "finding": "2",
+                "resources": {}
+            }
+        }
+    }
+]

--- a/aws/logs_monitoring/tests/approved_files/TestTransform.test_transform_waf.approved.json
+++ b/aws/logs_monitoring/tests/approved_files/TestTransform.test_transform_waf.approved.json
@@ -1,0 +1,36 @@
+[
+    {
+        "ddsource": "waf",
+        "message": {
+            "httpRequest": {
+                "headers": {
+                    "header1": "value1",
+                    "header2": "value2"
+                }
+            },
+            "request_id": "1"
+        }
+    },
+    {
+        "ddsource": "waf",
+        "message": {
+            "httpRequest": {
+                "headers": {
+                    "header1": "value1"
+                }
+            },
+            "request_id": "2"
+        }
+    },
+    {
+        "ddsource": "waf",
+        "message": {
+            "httpRequest": {
+                "headers": {
+                    "header3": "value3"
+                }
+            },
+            "request_id": "3"
+        }
+    }
+]

--- a/oci/datadog-oci-orm/metrics-setup/metrics-function/func.py
+++ b/oci/datadog-oci-orm/metrics-setup/metrics-function/func.py
@@ -147,4 +147,3 @@ def handler(ctx: context.InvokeContext, data: io.BytesIO = None) -> response.Res
         response_data=json.dumps({"result": result}),
         headers={"Content-Type": "application/json"},
     )
-


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Fix WAF events  processing which resulted in duplicating events due to iteration over a reversed list. 
Iterate separately over WAF events list in the transformation step before iterating over the same list to process securityhub findings


/!\ Removed cfn-lint action in this PR to allow the CI to pass. The action seems to be broken 
<img width="647" alt="Screenshot 2024-09-04 at 14 56 37" src="https://github.com/user-attachments/assets/c0cb3bf6-986b-4420-872d-05b9bd73d612">

 

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
