### PR TITLE
[AWSX][logs forwarder] Run cfn-lint as a pip package instead of an action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,3 +28,10 @@ jobs:
           pip install black
           black --check --diff --exclude pb2.py ./aws/logs_monitoring
           black --check --diff ./aws/rds_enhanced_monitoring
+
+      - name: Install cfn-lint print version and check formatting
+        run: |
+          pip install cfn-lint==1.11.1
+          cfn-lint --version
+          cfn-lint -t aws/logs_monitoring/template.yaml -i W1030
+          cfn-lint -t aws/rds_enhanced_monitoring/rds-enhanced-sam-template.yaml


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

install run cfn-lint using pip which allows to control the used version. 
I've currently set the working version to `1.11.1` as the linter is broken starting version `1.12`  see screenshot below
<img width="647" alt="Screenshot 2024-09-04 at 14 56 37" src="https://github.com/user-attachments/assets/79a6165a-3a76-494e-b193-e23904730ef7">


<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
