### PR TITLE
[AWSX][logs forwarder] Properly handle Transit gateway log source

### DIFF
--- a/aws/logs_monitoring/steps/enums.py
+++ b/aws/logs_monitoring/steps/enums.py
@@ -93,7 +93,7 @@ class AwsS3EventSourceKeyword(Enum):
     REDSHIFT = ("_redshift_", AwsEventSource.REDSHIFT)
     # e.g. AWSLogs/123456779121/vpcdnsquerylogs/vpc-********/2021/05/11/vpc-********_vpcdnsquerylogs_********_20210511T0910Z_71584702.log.gz
     ROUTE53 = ("vpcdnsquerylogs", AwsEventSource.ROUTE53)
-    TRANSITAGATEWAY = ("transit-gateway", AwsEventSource.TRANSITGATEWAY)
+    TRANSITGATEWAY = ("transit-gateway", AwsEventSource.TRANSITGATEWAY)
     VERIFIED_ACCESS = ("verified-access", AwsEventSource.VERIFIED_ACCESS)
     # e.g. AWSLogs/123456779121/vpcflowlogs/us-east-1/2020/10/02/123456779121_vpcflowlogs_us-east-1_fl-xxxxx.log.gz
     VPC = ("vpcflowlogs", AwsEventSource.VPC)

--- a/aws/logs_monitoring/steps/handlers/s3_handler.py
+++ b/aws/logs_monitoring/steps/handlers/s3_handler.py
@@ -73,8 +73,8 @@ class S3EventHandler:
 
     def _set_source(self, event):
         self.data_store.source = parse_event_source(event, self.data_store.key)
-        if str(AwsS3EventSourceKeyword.TRANSITAGATEWAY) in self.data_store.bucket:
-            self.data_store.source = AwsEventSource.TRANSITGATEWAY
+        if str(AwsS3EventSourceKeyword.TRANSITGATEWAY) in self.data_store.bucket:
+            self.data_store.source = str(AwsEventSource.TRANSITGATEWAY)
         self.metadata[DD_SOURCE] = self.data_store.source
 
     def _set_host(self):

--- a/aws/logs_monitoring/tests/test_s3_handler.py
+++ b/aws/logs_monitoring/tests/test_s3_handler.py
@@ -267,6 +267,26 @@ class TestS3EventsHandler(unittest.TestCase):
             "cloudfront",
         )
 
+    def test_set_source_transit_gateway(self):
+        self.s3_handler.data_store.key = "AWSLogs/1234566312/vpcflowlogs/us-east-1/2024/08/09/11/123455660991_vpcflowlogs_us-east-1_fl-01fb37"
+        self.s3_handler.data_store.bucket = "my-bucket-transit-gateway"
+        self.s3_handler._set_source(
+            {
+                "Records": [
+                    {
+                        "s3": {
+                            "bucket": {"name": "my-bucket-transit-gateway"},
+                            "object": {"key": self.s3_handler.data_store.key},
+                        }
+                    }
+                ]
+            }
+        )
+        self.assertEqual(
+            self.s3_handler.data_store.source,
+            "transitgateway",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Cast enum value to string when setting transit gateway as a log source.
Add utests

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
