### PR TITLE
support nested DD_API_KEY secret in lambda forwarder

### DIFF
--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -211,10 +211,10 @@ if "DD_API_KEY_SECRET_ARN" in os.environ:
         if "DD_API_KEY" in secret_json:
             DD_API_KEY = secret_json["DD_API_KEY"]
             logger.debug(
-                "Successfully retrieved the Datadog API key from 'datadogKey'."
+                "Successfully retrieved the Datadog API key from 'DD_API_KEY'."
             )
         else:
-            raise ValueError("The secret does not contain the 'datadogKey' field.")
+            raise ValueError("The secret does not contain the 'DD_API_KEY' field.")
 
     except json.JSONDecodeError:
         # If parsing as JSON fails, treat the secret as a plain string

--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -207,13 +207,13 @@ if "DD_API_KEY_SECRET_ARN" in os.environ:
         # Try to parse the secret as JSON
         secret_json = json.loads(secret_string)
 
-        # If it's a JSON object, look for the 'datadogKey' field
+        # If it's a JSON object, look for the 'DD_API_KEY' field
         if "DD_API_KEY" in secret_json:
-            DD_API_KEY = secret_json["datadogKey"]
+            DD_API_KEY = secret_json["DD_API_KEY"]
             logger.debug("Successfully retrieved the Datadog API key from 'datadogKey'.")
         else:
             raise ValueError("The secret does not contain the 'datadogKey' field.")
-    
+
     except json.JSONDecodeError:
         # If parsing as JSON fails, treat the secret as a plain string
         logger.debug("Secret is not JSON, using it directly as the Datadog API key.")

--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -196,9 +196,9 @@ if "DD_API_KEY_SECRET_ARN" in os.environ:
     logger.debug(f"Fetching the Datadog API key from SecretsManager: {SECRET_ARN}")
 
     # Fetch the secret from Secrets Manager
-    secret_response = boto3.client("secretsmanager", config=boto3_config).get_secret_value(
-        SecretId=SECRET_ARN
-    )
+    secret_response = boto3.client(
+        "secretsmanager", config=boto3_config
+    ).get_secret_value(SecretId=SECRET_ARN)
 
     # The secret could be either a plain string or a JSON object
     secret_string = secret_response.get("SecretString")
@@ -210,7 +210,9 @@ if "DD_API_KEY_SECRET_ARN" in os.environ:
         # If it's a JSON object, look for the 'DD_API_KEY' field
         if "DD_API_KEY" in secret_json:
             DD_API_KEY = secret_json["DD_API_KEY"]
-            logger.debug("Successfully retrieved the Datadog API key from 'datadogKey'.")
+            logger.debug(
+                "Successfully retrieved the Datadog API key from 'datadogKey'."
+            )
         else:
             raise ValueError("The secret does not contain the 'datadogKey' field.")
 

--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -214,7 +214,11 @@ if "DD_API_KEY_SECRET_ARN" in os.environ:
                 "Successfully retrieved the Datadog API key from 'DD_API_KEY'."
             )
         else:
-            raise ValueError("The secret does not contain the 'DD_API_KEY' field.")
+            logger.error(
+                "The secret does not contain the 'DD_API_KEY' field. "
+                "Please ensure the secret is in the correct format. "
+                "Not setting the Datadog API key."
+            )
 
     except json.JSONDecodeError:
         # If parsing as JSON fails, treat the secret as a plain string


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adds support for nested `DD_API_KEY` in AWS SecretsManager.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

It is common for organizations and individuals to store this in a shared dictionary with other secrets in AWS, which is not currently supported.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] New feature

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
