### PR TITLE
[AWS Log Forwarder] Eliminate AllowedPattern on DdApiKeySecretArn

### DIFF
--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -13,9 +13,8 @@ Parameters:
     Description: The Datadog API key, which can be found from the APIs page (/account/settings#api). It will be stored in AWS Secrets Manager securely. If DdApiKeySecretArn is also set, this value is ignored.
   DdApiKeySecretArn:
     Type: String
-    AllowedPattern: "arn:.*:secretsmanager:.*"
     Default: "arn:aws:secretsmanager:DEFAULT"
-    Description: The ARN of the secret storing the Datadog API key, if you already have it stored in Secrets Manager. You must store the secret as a plaintext, rather than a key-value pair.
+    Description: The ARN or name of the secret storing the Datadog API key, if you already have it stored in Secrets Manager. You must store the secret as a plaintext, rather than a key-value pair.
   DdSite:
     Type: String
     Default: datadoghq.com


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Eliminates the need to enter a secretsmanager arn as the value of DdApiKeySecretArn. My PR allows any string, as the value of DdApiKeySecretArn is passed as the SecretId value of the get_secret_value method of the Boto3 SDK, which allows for either the ARN **or the name** of the secret.

### Motivation

My organization deploys this via a Terraform `aws_cloudformation_stack_set` resource that then deploys the log forwarder lambda function and associated resources in the CloudFormation template to accounts in specific organization units (OUs) managed from our AWS Organizations account via `aws_cloudformation_stack_set_instance` resources.

This allows us to use a single Terraform workspace to centralize management of this stack while also using a similar deployment method to first create a secret in Secrets Manager to store the Datadog API key.

However, the ARN of a secret in SecretsManager will always include a random suffix that cannot be unified across AWS accounts, like this: `arn:aws:secretsmanager:<region>:<account-id>:secret:datadog-api-pxdLu8`

Therefore, the value of the `DdApiKeySecretArn` input parameter will always vary for every account to which this stack set is deployed. While I can retrieve the unique ARN of this secret for each account via a Terraform data source, this would require a unique AWS provider alias for every destination account followed by a data source using `for_each` that loops through a set of each provider alias.

All of that adds an extreme level of unnecessary complexity because the value of DdApiKeySecretArn is inputted into the [get_secret_value](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/secretsmanager/client/get_secret_value.html) method of the Boto3 SDK, which accepts a SecretId value of the "ARN **or name** of the secret to retrieve"

Because my secret is named "datadog-api" in every child OU, I can simply pass in this value _instead of the ARN_ into the `DdApiKeySecretArn` input parameter, vastly simplifying my Terraform.

**In summary, there is no need to restrict the AllowedPattern to an ARN, and doing so increases the complexity of infrastructure as code.**

As it stands right now, without this PR being merged, if I want to use the remote template, I have to replace the AllowedPattern as follows:

```hcl
# Get the Datadog Forwarder template from the Datadog S3 bucket
data "http" "datadog_forwarder_template" {
  url = "https://datadog-cloudformation-template.s3.amazonaws.com/aws/forwarder/${local.datadog_forwarder_version}.yaml"
}

# Create a local file with the CloudFormation template content
# Replacing the AllowedPattern for the DdApiKeySecretArn parameter so we can pass in the name of the secret
resource "local_file" "datadog_forwarder_template" {
  content = replace(
    data.http.datadog_forwarder_template.response_body,
    "AllowedPattern: \"arn:.*:secretsmanager:.*\"",
    "AllowedPattern: \".+\""
  )
  filename = "${path.module}/datadog_forwarder_${local.datadog_forwarder_version}.yaml"
}

# Upload the modified Datadog Forwarder template to S3 so we can use use TemplateURL in the stack set.
# We can't use TemplateBody because it has a 4096 byte limit
resource "aws_s3_object" "datadog_forwarder_template" {
  bucket = local.lambdas_bucket
  source = local_file.datadog_forwarder_template.filename
  key    = "datadog-forwarder/datadog_forwarder_${local.datadog_forwarder_version}.yaml"
  etag   = md5(local_file.datadog_forwarder_template.content)
  acl    = "bucket-owner-full-control"
}
```

Finally, in our stack set, I must use our customized YAML by referencing the URL of the S3 object instead of the remote URL provided by datadog (which I initially retrieve in the http data source before modifying and uploading to S3):

```
template_url            = "s3://${local.lambdas_bucket}/${aws_s3_object.datadog_forwarder_template.key}"
```

If this PR is merged, then anyone else using AWS Organizations to manage their stacks can eliminate the following items that I had to add to support this:

- data.http.datadog_forwarder.template
- local_file.datadog_forwarder_template
- aws_s3_object.datadog_forwarder_template
- local provider
- http provider

### Testing Guidelines

I tested this by using the Terraform code outlined in the "Motivation" section of this PR to allow any value in AllowedPattern. Eliminating AllowedPattern has the same effect.

### Additional Notes

There are no breaking changes, as users already inputting the secret ARN may continue to do so.

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
