### PR TITLE
[Logs forwarder] Parse enhanced metrics from Lambda telemetry JSON logs.

### DIFF
--- a/aws/logs_monitoring/tests/approved_files/TestEnhancedLambdaMetrics.test_generate_enhanced_lambda_metrics_json.approved.json
+++ b/aws/logs_monitoring/tests/approved_files/TestEnhancedLambdaMetrics.test_generate_enhanced_lambda_metrics_json.approved.json
@@ -1,0 +1,54 @@
+[
+    {
+        "name": "aws.lambda.enhanced.duration",
+        "tags": [
+            "memorysize:128",
+            "cold_start:false",
+            "region:us-east-1",
+            "account_id:172597598159",
+            "aws_account:172597598159",
+            "functionname:post-coupon-prod-us"
+        ],
+        "timestamp": 10000,
+        "value": 3.47065
+    },
+    {
+        "name": "aws.lambda.enhanced.billed_duration",
+        "tags": [
+            "memorysize:128",
+            "cold_start:false",
+            "region:us-east-1",
+            "account_id:172597598159",
+            "aws_account:172597598159",
+            "functionname:post-coupon-prod-us"
+        ],
+        "timestamp": 10000,
+        "value": 3.5
+    },
+    {
+        "name": "aws.lambda.enhanced.max_memory_used",
+        "tags": [
+            "memorysize:128",
+            "cold_start:false",
+            "region:us-east-1",
+            "account_id:172597598159",
+            "aws_account:172597598159",
+            "functionname:post-coupon-prod-us"
+        ],
+        "timestamp": 10000,
+        "value": 89
+    },
+    {
+        "name": "aws.lambda.enhanced.estimated_cost",
+        "tags": [
+            "memorysize:128",
+            "cold_start:false",
+            "region:us-east-1",
+            "account_id:172597598159",
+            "aws_account:172597598159",
+            "functionname:post-coupon-prod-us"
+        ],
+        "timestamp": 10000,
+        "value": 7.49168125e-06
+    }
+]

--- a/aws/logs_monitoring/tests/approved_files/TestEnhancedLambdaMetrics.test_parse_metrics_from_cold_start_json_report_log.approved.json
+++ b/aws/logs_monitoring/tests/approved_files/TestEnhancedLambdaMetrics.test_parse_metrics_from_cold_start_json_report_log.approved.json
@@ -1,0 +1,47 @@
+[
+    {
+        "name": "aws.lambda.enhanced.duration",
+        "tags": [
+            "memorysize:128",
+            "cold_start:true"
+        ],
+        "timestamp": null,
+        "value": 0.0008100000000000001
+    },
+    {
+        "name": "aws.lambda.enhanced.billed_duration",
+        "tags": [
+            "memorysize:128",
+            "cold_start:true"
+        ],
+        "timestamp": null,
+        "value": 0.1
+    },
+    {
+        "name": "aws.lambda.enhanced.max_memory_used",
+        "tags": [
+            "memorysize:128",
+            "cold_start:true"
+        ],
+        "timestamp": null,
+        "value": 90
+    },
+    {
+        "name": "aws.lambda.enhanced.init_duration",
+        "tags": [
+            "memorysize:128",
+            "cold_start:true"
+        ],
+        "timestamp": null,
+        "value": 1.234
+    },
+    {
+        "name": "aws.lambda.enhanced.estimated_cost",
+        "tags": [
+            "memorysize:128",
+            "cold_start:true"
+        ],
+        "timestamp": null,
+        "value": 4.0833375e-07
+    }
+]

--- a/aws/logs_monitoring/tests/approved_files/TestEnhancedLambdaMetrics.test_parse_metrics_from_json_report_log.approved.json
+++ b/aws/logs_monitoring/tests/approved_files/TestEnhancedLambdaMetrics.test_parse_metrics_from_json_report_log.approved.json
@@ -1,0 +1,38 @@
+[
+    {
+        "name": "aws.lambda.enhanced.duration",
+        "tags": [
+            "memorysize:128",
+            "cold_start:false"
+        ],
+        "timestamp": null,
+        "value": 0.00062
+    },
+    {
+        "name": "aws.lambda.enhanced.billed_duration",
+        "tags": [
+            "memorysize:128",
+            "cold_start:false"
+        ],
+        "timestamp": null,
+        "value": 0.1
+    },
+    {
+        "name": "aws.lambda.enhanced.max_memory_used",
+        "tags": [
+            "memorysize:128",
+            "cold_start:false"
+        ],
+        "timestamp": null,
+        "value": 51
+    },
+    {
+        "name": "aws.lambda.enhanced.estimated_cost",
+        "tags": [
+            "memorysize:128",
+            "cold_start:false"
+        ],
+        "timestamp": null,
+        "value": 4.0833375e-07
+    }
+]

--- a/aws/logs_monitoring/tests/approved_files/TestEnhancedLambdaMetrics.test_parse_metrics_from_timeout_json_report_log.approved.json
+++ b/aws/logs_monitoring/tests/approved_files/TestEnhancedLambdaMetrics.test_parse_metrics_from_timeout_json_report_log.approved.json
@@ -1,0 +1,56 @@
+[
+    {
+        "name": "aws.lambda.enhanced.duration",
+        "tags": [
+            "memorysize:128",
+            "cold_start:true"
+        ],
+        "timestamp": null,
+        "value": 30.0
+    },
+    {
+        "name": "aws.lambda.enhanced.billed_duration",
+        "tags": [
+            "memorysize:128",
+            "cold_start:true"
+        ],
+        "timestamp": null,
+        "value": 30.0
+    },
+    {
+        "name": "aws.lambda.enhanced.max_memory_used",
+        "tags": [
+            "memorysize:128",
+            "cold_start:true"
+        ],
+        "timestamp": null,
+        "value": 74
+    },
+    {
+        "name": "aws.lambda.enhanced.init_duration",
+        "tags": [
+            "memorysize:128",
+            "cold_start:true"
+        ],
+        "timestamp": null,
+        "value": 0.985413
+    },
+    {
+        "name": "aws.lambda.enhanced.estimated_cost",
+        "tags": [
+            "memorysize:128",
+            "cold_start:true"
+        ],
+        "timestamp": null,
+        "value": 6.270012500000001e-05
+    },
+    {
+        "name": "aws.lambda.enhanced.timeouts",
+        "tags": [
+            "memorysize:128",
+            "cold_start:true"
+        ],
+        "timestamp": null,
+        "value": 1.0
+    }
+]


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

This change makes forwarder parse enhanced metrics from Lambda telemetry logs which get emitted instead of regular REPORT ones when JSON format is enabled. For schema, see https://docs.aws.amazon.com/lambda/latest/dg/telemetry-schema-reference.html#platform-report

### Motivation

I would like to see same basic enhanced metrics I see when Lambda uses plain text logging when I enable JSON logging option.

### Testing Guidelines
1. `tests/run_unit_tests.sh`
2. Build forwarder zip, uploaded to sandbox AWS account w/ DD integration, ran lambda w/ `LOG_FORMAT=JSON` envar set and confirmed enhanced telemetry is showing up

### Additional Notes

1. I wanted to add integration tests but they're current seem to be broken (see https://github.com/DataDog/datadog-serverless-functions/issues/858)
2. I replicated how `cold_start` tag is set for REPORT logs but for some reason neither show up in our DD instance

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
