### PR TITLE
[Logs forwarder] Scrub log's inner messages

### DIFF
--- a/aws/logs_monitoring/forwarder.py
+++ b/aws/logs_monitoring/forwarder.py
@@ -90,7 +90,12 @@ class Forwarder(object):
 
             # apply scrubbing rules to inner log message if exists
             if isinstance(log, dict) and log.get("message"):
-                log["message"] = scrubber.scrub(log["message"])
+                try:
+                    log["message"] = scrubber.scrub(log["message"])
+                except Exception as e:
+                    logger.exception(
+                        f"Exception while scrubbing log message {log['message']}: {e}"
+                    )
 
             logs_to_forward.append(json.dumps(log, ensure_ascii=False))
 

--- a/aws/logs_monitoring/forwarder.py
+++ b/aws/logs_monitoring/forwarder.py
@@ -82,17 +82,22 @@ class Forwarder(object):
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(f"Forwarding {len(logs)} logs")
 
+        scrubber = DatadogScrubber(SCRUBBING_RULE_CONFIGS)
         logs_to_forward = []
         for log in logs:
             if key:
                 log = add_retry_tag(log)
+
+            # apply scrubbing rules to inner log message if exists
+            if isinstance(log, dict) and log.get("message"):
+                log["message"] = scrubber.scrub(log["message"])
+
             logs_to_forward.append(json.dumps(log, ensure_ascii=False))
 
         logs_to_forward = filter_logs(
             logs_to_forward, INCLUDE_AT_MATCH, EXCLUDE_AT_MATCH
         )
 
-        scrubber = DatadogScrubber(SCRUBBING_RULE_CONFIGS)
         if DD_USE_TCP:
             batcher = DatadogBatcher(256 * 1000, 256 * 1000, 1)
             cli = DatadogTCPClient(DD_URL, DD_PORT, DD_NO_SSL, DD_API_KEY, scrubber)

--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -176,7 +176,7 @@ SCRUBBING_RULE_CONFIGS = [
     ScrubbingRuleConfig(
         "DD_SCRUBBING_RULE",
         get_env_var("DD_SCRUBBING_RULE", default=None),
-        get_env_var("DD_SCRUBBING_RULE_REPLACEMENT", default="xxxxx"),
+        get_env_var("DD_SCRUBBING_RULE_REPLACEMENT", default=""),
     ),
 ]
 

--- a/aws/logs_monitoring/tests/events/cloudwatch_logs_ddtags.json
+++ b/aws/logs_monitoring/tests/events/cloudwatch_logs_ddtags.json
@@ -1,0 +1,16 @@
+{
+	"messageType": "DATA_MESSAGE",
+	"owner": "601427279990",
+	"logGroup": "/aws/lambda/testing-datadog",
+	"logStream": "2024/10/10/[$LATEST]20bddfd5a2dc4c6b97ac02800eae90d0",
+	"subscriptionFilters": [
+		"testing-datadog"
+	],
+	"logEvents": [
+		{
+			"id": "35311576111948622874033876462979853992919938886093242368",
+			"timestamp": 1583425836114,
+			"message": "{\"status\":\"debug\",\"message\":\"datadog:Patched console output with trace context\",\"ddtags\":\"env:test,service:test-inner-message\"}\n"
+		}
+	]
+}


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
We're encoding cloud watch event message twice when finding a `ddtags` entry. 
Override the message entry after poping the ddtags section with a dict instead of encoding the message again.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
