### PR TITLE
[Logs forwarder] update AWS CF template for AWS China

### DIFF
--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -552,8 +552,8 @@ Resources:
               Service:
                 - lambda.amazonaws.com
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
       PermissionsBoundary: !If
         - SetPermissionsBoundary
         - !Ref PermissionsBoundaryArn
@@ -574,7 +574,7 @@ Resources:
                     - !If
                       - CreateS3Bucket
                       - !Sub "${ForwarderBucket.Arn}/*"
-                      - !Sub "arn:aws:s3:::${DdForwarderExistingBucketName}/*"
+                      - !Sub "arn:${AWS::Partition}:s3:::${DdForwarderExistingBucketName}/*"
                   Effect: Allow
                 - !Ref AWS::NoValue
               - !If
@@ -587,7 +587,7 @@ Resources:
                     - !If
                       - CreateS3Bucket
                       - !GetAtt ForwarderBucket.Arn
-                      - !Sub "arn:aws:s3:::${DdForwarderExistingBucketName}"
+                      - !Sub "arn:${AWS::Partition}:s3:::${DdForwarderExistingBucketName}"
                   Condition:
                     StringLike:
                       s3:prefix:
@@ -661,7 +661,7 @@ Resources:
         - "logs.amazonaws.com.cn"
         - "logs.amazonaws.com"
       SourceAccount: !Ref "AWS::AccountId"
-      SourceArn: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:*"
+      SourceArn: !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:*"
   S3Permission:
     Type: AWS::Lambda::Permission
     Properties:
@@ -772,7 +772,7 @@ Resources:
       Description: Copies Datadog Forwarder zip to the destination S3 bucket
       Handler: index.handler
       Runtime: python3.11
-      Timeout: 300
+      Timeout: 600
       Code:
         ZipFile: |
           import json
@@ -859,8 +859,8 @@ Resources:
               Service:
                 - lambda.amazonaws.com
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
       PermissionsBoundary: !If
         - SetPermissionsBoundary
         - !Ref PermissionsBoundaryArn
@@ -878,7 +878,7 @@ Resources:
                   - !If
                     - CreateS3Bucket
                     - !Sub "${ForwarderBucket.Arn}/*"
-                    - !Sub "arn:aws:s3:::${DdForwarderExistingBucketName}/*"
+                    - !Sub "arn:${AWS::Partition}:s3:::${DdForwarderExistingBucketName}/*"
               - Effect: Allow
                 Action:
                   - s3:ListBucket
@@ -886,7 +886,7 @@ Resources:
                   - !If
                     - CreateS3Bucket
                     - !GetAtt "ForwarderBucket.Arn"
-                    - !Sub "arn:aws:s3:::${DdForwarderExistingBucketName}"
+                    - !Sub "arn:${AWS::Partition}:s3:::${DdForwarderExistingBucketName}"
               - !If
                 - SetS3SourceZip
                 - Effect: Allow


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

The AWS CloudFormation template for logs forwarder is not working in AWS China. The PR makes the CF stack work in AWS China (tested and validated sucessfully) and possibly AWS Gov Cloud (not tested)

### Motivation

The provided AWS CloudFormation template for logs forwarder did not work properly.

### Testing Guidelines

Tested by deploying the CF stack in AWS China successfully.

### Additional Notes

In ARNs, the fixed "aws" partition has been replaced by AWS::Partition to make it work in other AWS partitions.
The ForwarderZipCopier lambda timeout has also been increased from 300 to 600 because of latencies and unstable Internet in China.

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
