### PR TITLE
AWSX-1182 Override DD_LOG_LEVEL env var to WARN in the forwarder template

### DIFF
--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -249,6 +249,16 @@ Parameters:
     Type: String
     Default: ""
     Description: The name of an existing s3 bucket to use. If not provided, a new bucket will be created.
+  DdLogLevel:
+    Type: String
+    Default: "WARN"
+    Description: Set the log level for the forwarder. Valid values are DEBUG, INFO, WARN, ERROR, CRITICAL. If not set, default is WARN.
+    AllowedValues:
+      - DEBUG
+      - INFO
+      - WARN
+      - ERROR
+      - CRITICAL
 Conditions:
   IsAWSChina: !Equals [!Ref 'AWS::Partition', aws-cn]
   IsGovCloud: !Equals [!Ref 'AWS::Partition', aws-us-gov]
@@ -336,6 +346,8 @@ Conditions:
     - !Equals [!Join ["", !Ref VPCSecurityGroupIds], ""]
   SetVpcSubnetIds: !Not
     - !Equals [!Join ["", !Ref VPCSubnetIds], ""]
+  SetDdLogLevel: !Not
+    - !Equals [!Ref DdLogLevel, ""]
 Rules:
   MustSetDdApiKey:
     Assertions:
@@ -523,6 +535,10 @@ Resources:
           DD_TRACE_INTAKE_URL: !If
             - SetDdTraceIntakeUrl
             - !Ref DdTraceIntakeUrl
+            - !Ref AWS::NoValue
+          DD_LOG_LEVEL: !If
+            - SetDdLogLevel
+            - !Ref DdLogLevel
             - !Ref AWS::NoValue
       ReservedConcurrentExecutions: !If
         - SetReservedConcurrentExecutions
@@ -988,6 +1004,7 @@ Metadata:
           - DdForwarderExistingBucketName
           - DdForwarderBucketName
           - DdStoreFailedEvents
+          - DdLogLevel
     ParameterLabels:
       DdApiKey:
         default: "DdApiKey *"


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Overrides the log level to WARN to avoid having the forwarder info logs by default.  

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
