### PR TITLE
fix(aws): Remove none extracted value by regex

### DIFF
--- a/aws/logs_monitoring/steps/handlers/s3_handler.py
+++ b/aws/logs_monitoring/steps/handlers/s3_handler.py
@@ -294,11 +294,11 @@ class S3EventHandler:
             self.data_store.data = self.data_store.data.decode("utf-8", errors="ignore")
 
             if self.multiline_regex_start_pattern.match(self.data_store.data):
-                self.data_store.data = [
-                    item
-                    for item in self.multiline_regex_pattern.split(self.data_store.data)
-                    if item is not None
-                ]
+                self.data_store.data = list(
+                    filter(
+                        None, self.multiline_regex_pattern.split(self.data_store.data)
+                    )
+                )
             else:
                 self.logger.debug(
                     "DD_MULTILINE_LOG_REGEX_PATTERN %s did not match start of file, splitting by line",

--- a/aws/logs_monitoring/steps/handlers/s3_handler.py
+++ b/aws/logs_monitoring/steps/handlers/s3_handler.py
@@ -8,6 +8,7 @@ from io import BufferedReader, BytesIO
 
 import boto3
 import botocore
+
 from settings import (
     CN_STRING,
     DD_CUSTOM_TAGS,
@@ -293,9 +294,11 @@ class S3EventHandler:
             self.data_store.data = self.data_store.data.decode("utf-8", errors="ignore")
 
             if self.multiline_regex_start_pattern.match(self.data_store.data):
-                self.data_store.data = self.multiline_regex_pattern.split(
-                    self.data_store.data
-                )
+                self.data_store.data = [
+                    item
+                    for item in self.multiline_regex_pattern.split(self.data_store.data)
+                    if item is not None
+                ]
             else:
                 self.logger.debug(
                     "DD_MULTILINE_LOG_REGEX_PATTERN %s did not match start of file, splitting by line",


### PR DESCRIPTION
### What does this PR do?

Fix an issue when the multiline regex extract `None`.

### Motivation

This `None` value lead to an error further in the logs process.

### Testing Guidelines

I've set up a lambda with the `DD_MULTILINE_LOG_REGEX_PATTERN: (Build:\s)|(Process:\s)|(Timestamp)` and send some tricky formatted log to reproduce and fix.

### Additional Notes


### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
