### PR TITLE
fix(enrichment): search for service as key, not as value in extracted ddtags

### DIFF
--- a/aws/logs_monitoring/steps/enrichment.py
+++ b/aws/logs_monitoring/steps/enrichment.py
@@ -154,7 +154,7 @@ def extract_ddtags_from_message(event):
                 return
 
         # Extract service tag from message.ddtags if exists
-        if "service" in extracted_ddtags:
+        if "service:" in extracted_ddtags:
             event[DD_SERVICE] = next(
                 tag[8:]
                 for tag in extracted_ddtags.split(",")

--- a/aws/logs_monitoring/tests/test_enrichment.py
+++ b/aws/logs_monitoring/tests/test_enrichment.py
@@ -107,6 +107,21 @@ class TestMergeMessageTags(unittest.TestCase):
             "my_application_service",
         )
 
+    def test_extract_ddtags_from_message_service_only_in_extracted_ddtags_values(self):
+        loaded_message_tags = {"ddtags": "key:my-service-repo"}
+        event = {"message": loaded_message_tags, "ddtags": self.custom_tags}
+
+        extract_ddtags_from_message(event)
+
+        self.assertEqual(
+            event["ddtags"],
+            "custom_tag_2:value2,service:my_custom_service,key:my-service-repo",
+        )
+        self.assertNotIn(
+            "service",
+            event,
+        )
+
 
 class TestExtractHostFromLogEvents(unittest.TestCase):
     def test_parse_source_cloudtrail(self):


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
When your `ddtags` in log message look like this: 
```
{
  ...,
  "ddtags": "custom_key:contains-the-word-service",
  ...
}
```
meaning that there is no `service:` tag, but instead the word `service` is in a tag value, then it causes a `StopIteration` error which leads to function fail, and no logs are forwarded.
![image](https://github.com/user-attachments/assets/a4a777cb-e667-4dbc-acf7-620f7a635756)

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->
Without this PR, users are required to exclude this specific word, or find other ways to mitigate the problem. 
### Testing Guidelines

<!--- How did you test this pull request? --->
- [x] unit tests
- [x] manual test with uploaded function to AWS

### Additional Notes

<!--- Anything else we should know when reviewing? --->
The reason this causes a `StopIteration` error is that the `next()` function that is used, raises this error when an empty iterator is passed as an argument. So, if there is just the word `service` (without the colon symbol) in the `ddtags` string, returns an empty iterator.

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
