### PR TITLE
Update AWS permission for the parameter DdFetchLogGroupTags

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -428,7 +428,7 @@ To test different patterns against your logs, turn on [debug logs](#troubleshoot
 : Let the Forwarder fetch Lambda tags using GetResources API calls and apply them to logs, metrics, and traces. If set to true, permission `tag:GetResources` will be automatically added to the Lambda execution IAM role.
 
 `DdFetchLogGroupTags`
-: Let the forwarder fetch Log Group tags using ListTagsLogGroup and apply them to logs, metrics, and traces. If set to true, permission `logs:ListTagsLogGroup` will be automatically added to the Lambda execution IAM role.
+: Let the forwarder fetch Log Group tags using ListTagsLogGroup and apply them to logs, metrics, and traces. If set to true, permission `logs:ListTagsForResource` will be automatically added to the Lambda execution IAM role.
 
 `DdFetchStepFunctionsTags`
 : Let the Forwarder fetch Step Functions tags using GetResources API calls and apply them to logs and traces (if Step Functions tracing is enabled). If set to true, permission `tag:GetResources` will be automatically added to the Lambda execution IAM role.


### PR DESCRIPTION
### What does this PR do?

Updates the AWS permission in the README for the `DdFetchLogGroupTags` to `logs:ListTagsForResource` since AWS has deprecated the `logs:ListTagsLogGroup` permission.

### Motivation

Customer had submitted feedback that this parameter should be updated in the documentation. 
https://datadog.zendesk.com/agent/tickets/1977402
https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_ListTagsLogGroup.html
The update to this permission can be found [here](https://github.com/DataDog/datadog-serverless-functions/releases/tag/aws-dd-forwarder-3.115.0) but the documentation had not been updated

### Testing Guidelines

- Verified the release from Forwarder version 3.115.0 where the change was made
- Reached out in `support-aws-integrations` to further confirm this permission should be updated in the documentation as well

### Additional Notes



### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
