### PR TITLE
[AWSX][Logs forwarder] Remove RDS source identification

### DIFF
--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -267,7 +267,7 @@ DD_SOURCE = "ddsource"
 DD_CUSTOM_TAGS = "ddtags"
 DD_SERVICE = "service"
 DD_HOST = "host"
-DD_FORWARDER_VERSION = "3.133.0"
+DD_FORWARDER_VERSION = "4.0.0"
 
 # CONST STRINGS
 AWS_STRING = "aws"

--- a/aws/logs_monitoring/steps/common.py
+++ b/aws/logs_monitoring/steps/common.py
@@ -45,9 +45,6 @@ def is_cloudtrail(key):
 def find_cloudwatch_source(log_group):
     for prefix in AwsCwEventSourcePrefix:
         if log_group.startswith(str(prefix)):
-            if prefix == AwsCwEventSourcePrefix.RDS:
-                return find_rds_source(log_group)
-
             return str(prefix.event_source)
 
     # directly look for the source in the log group
@@ -56,14 +53,6 @@ def find_cloudwatch_source(log_group):
             return str(source)
 
     return str(AwsEventSource.CLOUDWATCH)
-
-
-def find_rds_source(log_group):
-    for engine in AwsEventSource.rds_sources():
-        if str(engine) in log_group:
-            return str(engine)
-
-    return str(AwsEventSource.RDS)
 
 
 def find_s3_source(key):

--- a/aws/logs_monitoring/steps/enums.py
+++ b/aws/logs_monitoring/steps/enums.py
@@ -31,7 +31,6 @@ class AwsEventSource(Enum):
     MYSQL = "mysql"
     NETWORKFIREWALL = "network-firewall"
     POSTGRESQL = "postgresql"
-    RDS = "rds"
     REDSHIFT = "redshift"
     ROUTE53 = "route53"
     S3 = "s3"
@@ -61,10 +60,6 @@ class AwsEventSource(Enum):
             AwsEventSource.BEDROCK,
             AwsEventSource.CLOUDFRONT,
         ]
-
-    @staticmethod
-    def rds_sources():
-        return [AwsEventSource.MARIADB, AwsEventSource.MYSQL, AwsEventSource.POSTGRESQL]
 
 
 class AwsS3EventSourceKeyword(Enum):
@@ -134,7 +129,6 @@ class AwsCwEventSourcePrefix(Enum):
     KINESIS = ("/aws/kinesis", AwsEventSource.KINESIS)
     # e.g. /aws/lambda/helloDatadog
     lAMBDA = ("/aws/lambda", AwsEventSource.LAMBDA)
-    RDS = ("/aws/rds", AwsEventSource.RDS)
     # e.g. sns/us-east-1/123456779121/SnsTopicX
     SNS = ("sns/", AwsEventSource.SNS)
     SSM = ("/aws/ssm/", AwsEventSource.SSM)

--- a/aws/logs_monitoring/tests/approved_files/TestAWSLogsHandler.test_awslogs_handler_rds_postgresql.metadata.approved.json
+++ b/aws/logs_monitoring/tests/approved_files/TestAWSLogsHandler.test_awslogs_handler_rds_postgresql.metadata.approved.json
@@ -1,6 +1,6 @@
 {
-    "ddsource": "postgresql",
-    "ddtags": "env:dev,test_tag_key:test_tag_value,logname:postgresql",
-    "host": "datadog",
-    "service": "postgresql"
+    "ddsource": "cloudwatch",
+    "ddtags": "env:dev,test_tag_key:test_tag_value",
+    "host": "/aws/rds/instance/datadog/postgresql",
+    "service": "cloudwatch"
 }

--- a/aws/logs_monitoring/tests/test_awslogs_handler.py
+++ b/aws/logs_monitoring/tests/test_awslogs_handler.py
@@ -8,7 +8,7 @@ from unittest.mock import patch, MagicMock
 from approvaltests.approvals import verify_as_json
 from approvaltests.namer import NamerFactory
 
-from aws.logs_monitoring.steps.enums import AwsEventSource
+from steps.enums import AwsEventSource
 
 sys.modules["trace_forwarder.connection"] = MagicMock()
 sys.modules["datadog_lambda.wrapper"] = MagicMock()
@@ -24,7 +24,7 @@ env_patch = patch.dict(
     },
 )
 env_patch.start()
-from aws.logs_monitoring.settings import DD_HOST, DD_SOURCE
+from settings import DD_HOST, DD_SOURCE
 from steps.handlers.awslogs_handler import AwsLogsHandler
 from steps.handlers.aws_attributes import AwsAttributes
 from caching.cache_layer import CacheLayer
@@ -61,7 +61,7 @@ class TestAWSLogsHandler(unittest.TestCase):
             }
         }
         context = None
-        metadata = {"ddsource": "postgresql", "ddtags": "env:dev"}
+        metadata = {"ddsource": "cloudwatch", "ddtags": "env:dev"}
         mock_cache_init.return_value = None
         cache_layer = CacheLayer("")
         cache_layer._cloudwatch_log_group_cache.get = MagicMock(

--- a/aws/logs_monitoring/tests/test_parsing.py
+++ b/aws/logs_monitoring/tests/test_parsing.py
@@ -55,19 +55,19 @@ class TestParseEventSource(unittest.TestCase):
     def test_rds_event(self):
         self.assertEqual(
             parse_event_source({"awslogs": "logs"}, "/aws/rds/my-rds-resource"),
-            str(AwsEventSource.RDS),
+            str(AwsEventSource.CLOUDWATCH),
         )
 
     def test_mariadb_event(self):
         self.assertEqual(
             parse_event_source({"awslogs": "logs"}, "/aws/rds/mariaDB-instance/error"),
-            str(AwsEventSource.MARIADB),
+            str(AwsEventSource.CLOUDWATCH),
         )
 
     def test_mysql_event(self):
         self.assertEqual(
             parse_event_source({"awslogs": "logs"}, "/aws/rds/mySQL-instance/error"),
-            str(AwsEventSource.MYSQL),
+            str(AwsEventSource.CLOUDWATCH),
         )
 
     def test_postgresql_event(self):
@@ -75,7 +75,7 @@ class TestParseEventSource(unittest.TestCase):
             parse_event_source(
                 {"awslogs": "logs"}, "/aws/rds/instance/datadog/postgresql"
             ),
-            str(AwsEventSource.POSTGRESQL),
+            str(AwsEventSource.CLOUDWATCH),
         )
 
     def test_lambda_event(self):


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Pulling off RDS source, service and host identification from the logs forwarder as we start migrating code towards Datadog backend.

This should be released with version >= 4.0.0

This should not have any effects on the outcome of the log processing as we'll still be setting these in Datadog's backend.

<!--- A brief description of the change being made with this pull request. --->

### Motivation
We've started working on a project to gradually remove complex logic from Lambda forwarder towards Datadog backend. We're starting with migrating the logic around defining source, service and host info for a log. 
RDS is the first source we're migrating.

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
