### PR TITLE
Fix typo of `lAMBDA` -> `LAMBDA` within `AwsS3EventSourceKeyword()` class

### DIFF
--- a/aws/logs_monitoring/steps/enums.py
+++ b/aws/logs_monitoring/steps/enums.py
@@ -128,7 +128,7 @@ class AwsCwEventSourcePrefix(Enum):
     # e.g. /aws/kinesisfirehose/dev
     KINESIS = ("/aws/kinesis", AwsEventSource.KINESIS)
     # e.g. /aws/lambda/helloDatadog
-    lAMBDA = ("/aws/lambda", AwsEventSource.LAMBDA)
+    LAMBDA = ("/aws/lambda", AwsEventSource.LAMBDA)
     # e.g. sns/us-east-1/123456779121/SnsTopicX
     SNS = ("sns/", AwsEventSource.SNS)
     SSM = ("/aws/ssm/", AwsEventSource.SSM)


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Fixes a class property typo.

### Motivation

Noted the typo in another PR when reviewing changes.

### Testing Guidelines

N/A

### Additional Notes

Noe

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
