### PR TITLE
[AWSX][Logs Forwarder] Enable Email and IP redaction based on user config only

### DIFF
--- a/aws/logs_monitoring/logs/datadog_scrubber.py
+++ b/aws/logs_monitoring/logs/datadog_scrubber.py
@@ -16,13 +16,17 @@ class DatadogScrubber(object):
             if config.name in os.environ:
                 rules.append(
                     ScrubbingRule(
-                        compileRegex(config.name, config.pattern), config.placeholder
+                        compileRegex(config.name, config.pattern),
+                        config.placeholder,
+                        config.enabled,
                     )
                 )
         self._rules = rules
 
     def scrub(self, payload):
         for rule in self._rules:
+            if rule.enabled is False:
+                continue
             try:
                 payload = rule.regex.sub(rule.placeholder, payload)
             except Exception:
@@ -31,6 +35,7 @@ class DatadogScrubber(object):
 
 
 class ScrubbingRule(object):
-    def __init__(self, regex, placeholder):
+    def __init__(self, regex, placeholder, enabled):
         self.regex = regex
         self.placeholder = placeholder
+        self.enabled = enabled

--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -156,22 +156,27 @@ if DD_USE_PRIVATE_LINK:
 
 
 class ScrubbingRuleConfig(object):
-    def __init__(self, name, pattern, placeholder):
+    def __init__(self, name, pattern, placeholder, enabled=True):
         self.name = name
         self.pattern = pattern
         self.placeholder = placeholder
+        self.enabled = enabled
 
 
 # Scrubbing sensitive data
 # Option to redact all pattern that looks like an ip address / email address / custom pattern
 SCRUBBING_RULE_CONFIGS = [
     ScrubbingRuleConfig(
-        "REDACT_IP", r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}", "xxx.xxx.xxx.xxx"
+        "REDACT_IP",
+        r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}",
+        "xxx.xxx.xxx.xxx",
+        get_env_var("REDACT_IP", "false", boolean=True),
     ),
     ScrubbingRuleConfig(
         "REDACT_EMAIL",
         r"[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+",
         "xxxxx@xxxxx.com",
+        get_env_var("REDACT_EMAIL", "false", boolean=True),
     ),
     ScrubbingRuleConfig(
         "DD_SCRUBBING_RULE",


### PR DESCRIPTION

<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

This PR enables email and IP redaction in the scrubber taking into account user configuration. It will be disabled by default if the env vars were not set.

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
