### PR TITLE
chore: Polish the language to recommend Lambda Extension over forwarder

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -12,10 +12,10 @@ aliases:
 
 The Datadog Forwarder is an AWS Lambda function that ships logs from AWS to Datadog, specifically:
 
--   Forward CloudWatch and S3 logs.
--   Forward logs from SNS, and Kinesis events to Datadog.
--   Kinesis data stream events support CloudWatch logs only.
--   Forward metrics, traces, and logs from AWS Lambda functions to Datadog. Datadog recommends to use [Datadog Lambda Extension][1] to monitor Lambda functions.
+- Forward CloudWatch and S3 logs.
+- Forward logs from SNS, and Kinesis events to Datadog.
+- Kinesis data stream events support CloudWatch logs only.
+- Forward metrics, traces, and logs from AWS Lambda functions to Datadog. However, instead of using a forwarder, Datadog recommends to use [Datadog Lambda Extension][1] to monitor Lambda functions.
 
 For Serverless customers using the Forwarder to forward metrics, traces, and logs from AWS Lambda logs to Datadog, you should [migrate to the Datadog Lambda Extension][3] to collect telemetry directly from the Lambda execution environments. The Forwarder is still available for use in Serverless Monitoring, but will not be updated to support the latest features.
 

--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -12,10 +12,10 @@ aliases:
 
 The Datadog Forwarder is an AWS Lambda function that ships logs from AWS to Datadog, specifically:
 
-- Forward CloudWatch and S3 logs.
-- Forward logs from SNS, and Kinesis events to Datadog.
-- Kinesis data stream events support CloudWatch logs only.
-- Forward metrics, traces, and logs from AWS Lambda functions to Datadog. However, instead of using a forwarder, Datadog recommends to use [Datadog Lambda Extension][1] to monitor Lambda functions.
+-   Forward CloudWatch and S3 logs.
+-   Forward logs from SNS, and Kinesis events to Datadog.
+-   Kinesis data stream events support CloudWatch logs only.
+-   Forward metrics, traces, and logs from AWS Lambda functions to Datadog. However, instead of using a forwarder, Datadog recommends to use [Datadog Lambda Extension][1] to monitor Lambda functions.
 
 For Serverless customers using the Forwarder to forward metrics, traces, and logs from AWS Lambda logs to Datadog, you should [migrate to the Datadog Lambda Extension][3] to collect telemetry directly from the Lambda execution environments. The Forwarder is still available for use in Serverless Monitoring, but will not be updated to support the latest features.
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Polishes the language to make it clear that Datadog Lambda Extension is perferred over Forwarder to monitor Lambda functions.

Open to changes if you have a better way to clarify this.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
