### PR TITLE
feat(logs): AWSX-1389 Moving s3 access logs identification to backend

### DIFF
--- a/aws/logs_monitoring/steps/handlers/s3_handler.py
+++ b/aws/logs_monitoring/steps/handlers/s3_handler.py
@@ -57,7 +57,6 @@ class S3EventHandler:
         event = self._extract_event(event)
         self._set_source(event)
         add_service_tag(self.metadata)
-        self._set_host()
         self._add_s3_tags_from_cache()
         self._extract_data()
         yield from self._get_structured_lines_for_s3_handler()
@@ -82,18 +81,6 @@ class S3EventHandler:
         if str(AwsS3EventSourceKeyword.TRANSITGATEWAY) in self.data_store.bucket:
             self.data_store.source = str(AwsEventSource.TRANSITGATEWAY)
         self.metadata[DD_SOURCE] = self.data_store.source
-
-    def _set_host(self):
-        hostname = self._parse_service_arn()
-        if hostname:
-            self.metadata[DD_HOST] = hostname
-
-    def _parse_service_arn(self):
-        src = AwsEventSource._value2member_map_.get(self.data_store.source)
-        match src:
-            case AwsEventSource.S3:
-                # For S3 access logs we use the bucket name to rebuild the arn
-                return self._get_s3_arn()
 
     def _get_s3_arn(self):
         if not self.data_store.bucket:

--- a/aws/logs_monitoring/tests/test_cloudtrail_s3.py
+++ b/aws/logs_monitoring/tests/test_cloudtrail_s3.py
@@ -1,11 +1,15 @@
-from unittest.mock import MagicMock, patch
+import copy
+import gzip
+import io
+import json
 import os
 import sys
 import unittest
-import json
-import copy
-import io
-import gzip
+from unittest.mock import MagicMock, patch
+
+import lambda_function
+from caching.cache_layer import CacheLayer
+from steps.parsing import parse
 
 sys.modules["trace_forwarder.connection"] = MagicMock()
 sys.modules["datadog_lambda.wrapper"] = MagicMock()
@@ -22,10 +26,6 @@ env_patch = patch.dict(
     },
 )
 env_patch.start()
-import lambda_function
-from steps.parsing import parse
-from caching.cache_layer import CacheLayer
-
 env_patch.stop()
 
 

--- a/aws/logs_monitoring/tests/test_customized_log_group.py
+++ b/aws/logs_monitoring/tests/test_customized_log_group.py
@@ -1,7 +1,8 @@
 import unittest
+
 from customized_log_group import (
-    is_lambda_customized_log_group,
     get_lambda_function_name_from_logstream_name,
+    is_lambda_customized_log_group,
     is_step_functions_log_group,
 )
 


### PR DESCRIPTION
### What does this PR do?

Remove the S3 ARN identification for S3 Access Logs, moved to backend.

### Motivation

Remove business logic from the forwarder to have it centralized in the backend.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
