### PR TITLE
[AZINTS-3246] deprecate old blob forwarder

### DIFF
--- a/azure/blobs_logs_monitoring/README.md
+++ b/azure/blobs_logs_monitoring/README.md
@@ -47,4 +47,3 @@ You have two options to add custom tags to your logs:
 - Automatically with the `DD_TAGS` environment variable
 
 Learn more about Datadog tagging in our main [Tagging documentation](https://docs.datadoghq.com/tagging/).
- -->

--- a/azure/blobs_logs_monitoring/README.md
+++ b/azure/blobs_logs_monitoring/README.md
@@ -1,4 +1,50 @@
-# Note: Deprecated in favor of the new blob storage based forwarder
+> [!WARNING]
+> Deprecated in favor of the [new Blob Storage-based forwarder](https://docs.datadoghq.com/logs/guide/azure-logging-guide/?tab=blobstorage)
 
-See [the docs](https://docs.datadoghq.com/logs/guide/azure-logging-guide/?tab=blobstorage) to get started.
+# Datadog-Azure function
 
+The Datadog-Azure function is used to forward Azure logs to Datadog from new blob files added in
+a storage account. The function reads the file, splits lines on \n and sends each line as
+a log entry to Datadog.
+
+## Quick Start
+
+The provided Node.js script must be deployed into your Azure Functions service. Follow the tutorial below to learn how to do so:
+
+### 1. Create a new Blob triggered function
+
+- Expand your function application and click the `+` button next to `Functions`. If this is the first function in your function application, select `Custom function`. This displays the complete set of function templates.
+- In the search field type `Blob` and choose `Blob Trigger`.
+- Select the `Javascript` language in the right menu.
+- Enter a name for the function.
+- Select the path in the storage account where you want to read file from you want to pull logs from.
+- Add the wanted `Storage account connection` or create a new one if you haven't have one already.
+
+### 2. Provide the code
+
+- Copy paste the code of the [Datadog-Azure function](./index.js).
+
+## 3. (optional) Send logs to EU or to a proxy
+
+### Send logs to EU
+
+Set the environment variable `DD_SITE` to `datadoghq.eu` and logs are automatically forwarded to your EU platform.
+
+## Parameters
+
+- **API KEY**:
+
+There are 2 possibilities to set your [Datadog's API key](https://app.datadoghq.com/organization-settings/api-keys):
+
+1. Replace `<DATADOG_API_KEY>` in the code with your API Key value.
+2. Set the value through the `DD_API_KEY` environment variable
+
+- **Custom Tags**:
+
+You have two options to add custom tags to your logs:
+
+- Manually by editing the function code: Replace the `''` placeholder for the `DD_TAGS` variable by a comma separated list of tags
+- Automatically with the `DD_TAGS` environment variable
+
+Learn more about Datadog tagging in our main [Tagging documentation](https://docs.datadoghq.com/tagging/).
+ -->

--- a/azure/blobs_logs_monitoring/README.md
+++ b/azure/blobs_logs_monitoring/README.md
@@ -1,46 +1,4 @@
-# Datadog-Azure function
+# Note: Deprecated in favor of the new blob storage based forwarder
 
-The Datadog-Azure function is used to forward Azure logs to Datadog from new blob files added in
-a storage account. The function reads the file, splits lines on \n and sends each line as
-a log entry to Datadog.
+See [the docs](https://docs.datadoghq.com/logs/guide/azure-logging-guide/?tab=blobstorage) to get started.
 
-## Quick Start
-
-The provided Node.js script must be deployed into your Azure Functions service. Follow the tutorial below to learn how to do so:
-
-### 1. Create a new Blob triggered function
-
-- Expand your function application and click the `+` button next to `Functions`. If this is the first function in your function application, select `Custom function`. This displays the complete set of function templates.
-- In the search field type `Blob` and choose `Blob Trigger`.
-- Select the `Javascript` language in the right menu.
-- Enter a name for the function.
-- Select the path in the storage account where you want to read file from you want to pull logs from.
-- Add the wanted `Storage account connection` or create a new one if you haven't have one already.
-
-### 2. Provide the code
-
-- Copy paste the code of the [Datadog-Azure function](./index.js).
-
-## 3. (optional) Send logs to EU or to a proxy
-
-### Send logs to EU
-
-Set the environment variable `DD_SITE` to `datadoghq.eu` and logs are automatically forwarded to your EU platform.
-
-## Parameters
-
-- **API KEY**:
-
-There are 2 possibilities to set your [Datadog's API key](https://app.datadoghq.com/organization-settings/api-keys):
-
-1. Replace `<DATADOG_API_KEY>` in the code with your API Key value.
-2. Set the value through the `DD_API_KEY` environment variable
-
-- **Custom Tags**:
-
-You have two options to add custom tags to your logs:
-
-- Manually by editing the function code: Replace the `''` placeholder for the `DD_TAGS` variable by a comma separated list of tags
-- Automatically with the `DD_TAGS` environment variable
-
-Learn more about Datadog tagging in our main [Tagging documentation](https://docs.datadoghq.com/tagging/).


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

Updates the readme to point to the updated docs for the new blob forwarder: https://github.com/DataDog/documentation/pull/28536

Not removing the code yet in case customers are relying on it.

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
