### PR TITLE
[AZINTS] fix forwarder v4 model upgrade

### DIFF
--- a/azure/eventhub_log_forwarder/function_template.json
+++ b/azure/eventhub_log_forwarder/function_template.json
@@ -64,8 +64,7 @@
   },
   "variables": {
     "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'storageacct')]",
-    "eventHubAuthRule": "[resourceId('Microsoft.EventHub/namespaces/authorizationRules', parameters('eventhubNamespace'),'RootManageSharedAccessKey')]",
-    "storageAccountConnectionString": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2018-11-01').keys[0].value,';','EndpointSuffix=',parameters('endpointSuffix'),';')]"
+    "eventHubAuthRule": "[resourceId('Microsoft.EventHub/namespaces/authorizationRules', parameters('eventhubNamespace'),'RootManageSharedAccessKey')]"
   },
   "resources": [
     {
@@ -118,7 +117,7 @@
             },
             {
               "name": "AzureWebJobsStorage",
-              "value": "[variables('storageAccountConnectionString')]"
+              "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2018-11-01').keys[0].value,';','EndpointSuffix=',parameters('endpointSuffix'),';')]"
             },
             {
               "name": "FUNCTIONS_WORKER_RUNTIME",
@@ -134,7 +133,7 @@
             },
             {
               "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
-              "value": "[variables('storageAccountConnectionString')]"
+              "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2018-11-01').keys[0].value,';','EndpointSuffix=',parameters('endpointSuffix'),';')]"
             },
             {
               "name": "WEBSITE_CONTENTSHARE",
@@ -177,7 +176,7 @@
         "retentionInterval": "P1D",
         "storageAccountSettings": {
           "storageAccountName": "[variables('storageAccountName')]",
-          "storageAccountKey": "[variables('storageAccountConnectionString')]"
+          "storageAccountKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2019-06-01').keys[0].value]"
         }
       },
       "dependsOn": [

--- a/azure/eventhub_log_forwarder/function_template.json
+++ b/azure/eventhub_log_forwarder/function_template.json
@@ -163,11 +163,36 @@
       ]
     },
     {
+      "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+      "apiVersion": "2023-01-31",
+      "name": "[concat('syncFunctionTriggers-', parameters('functionAppName'), '-identity')]",
+      "location": "[parameters('location')]"
+    },
+    {
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2022-04-01",
+      "name": "[guid('syncFunctionTriggers-', parameters('functionAppName'))]",
+      "properties": {
+        "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772')]",
+        "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', concat('syncFunctionTriggers-', parameters('functionAppName'), '-identity')), '2023-01-31').principalId]",
+        "principalType": "ServicePrincipal"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', concat('syncFunctionTriggers-', parameters('functionAppName'), '-identity'))]"
+      ]
+    },
+    {
       "type": "Microsoft.Resources/deploymentScripts",
       "apiVersion": "2023-08-01",
       "name": "[concat('syncFunctionTriggers-', parameters('functionAppName'))]",
       "location": "[parameters('location')]",
       "kind": "AzureCLI",
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "[concat('syncFunctionTriggers-', parameters('functionAppName'), '-identity')]": {}
+        }
+      },
       "properties": {
         "azCliVersion": "2.67.0",
         "scriptContent": "[format('az rest --url ''https://management.azure.com{0}/syncfunctiontriggers?api-version=2024-04-01'' --method post', resourceId('Microsoft.Web/sites', parameters('functionAppName')))]",

--- a/azure/eventhub_log_forwarder/function_template.json
+++ b/azure/eventhub_log_forwarder/function_template.json
@@ -164,13 +164,13 @@
     },
     {
       "type": "Microsoft.Resources/deploymentScripts",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2023-08-01",
       "name": "[concat('syncFunctionTriggers-', parameters('functionAppName'))]",
       "location": "[parameters('location')]",
       "kind": "AzureCLI",
       "properties": {
         "azCliVersion": "2.67.0",
-        "scriptContent": "[format('az rest --method post --url ''https://management.azure.com{0}/syncfunctiontriggers?api-version=2024-04-01''', resourceId('Microsoft.Web/sites', parameters('functionAppName')))]",
+        "scriptContent": "[format('az rest --url ''https://management.azure.com{0}/syncfunctiontriggers?api-version=2024-04-01'' --method post', resourceId('Microsoft.Web/sites', parameters('functionAppName')))]",
         "timeout": "PT30M",
         "cleanupPreference": "OnSuccess",
         "retentionInterval": "P1D",

--- a/azure/eventhub_log_forwarder/function_template.json
+++ b/azure/eventhub_log_forwarder/function_template.json
@@ -167,10 +167,6 @@
               "value": "~20"
             },
             {
-              "name": "WEBSITE_RUN_FROM_PACKAGE",
-              "value": "1"
-            },
-            {
               "name": "SCM_DO_BUILD_DURING_DEPLOYMENT",
               "value": "true"
             }

--- a/azure/eventhub_log_forwarder/function_template.json
+++ b/azure/eventhub_log_forwarder/function_template.json
@@ -181,7 +181,7 @@
         }
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Web/sites/extensions', concat(parameters('functionAppName'), '/zipdeploy'))]"
+        "[resourceId('Microsoft.Web/sites/extensions', parameters('functionAppName'), 'zipdeploy')]"
       ]
     }
   ]

--- a/azure/eventhub_log_forwarder/function_template.json
+++ b/azure/eventhub_log_forwarder/function_template.json
@@ -161,6 +161,14 @@
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites', parameters('functionAppName'))]"
       ]
+    },
+    {
+      "type": "Microsoft.Web/sites/syncfunctiontriggers",
+      "apiVersion": "2016-08-01",
+      "name": "[concat(parameters('functionAppName'), '/syncfunctiontriggers')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/sites/extensions', concat(parameters('functionAppName'), '/zipdeploy'))]"
+      ]
     }
   ]
 }

--- a/azure/eventhub_log_forwarder/function_template.json
+++ b/azure/eventhub_log_forwarder/function_template.json
@@ -15,6 +15,13 @@
         "description": "The name of the function app."
       }
     },
+    "appServicePlanName": {
+      "type": "string",
+      "defaultValue": "[concat('datadog-asp-', newGuid())]",
+      "metadata": {
+        "description": "The name of the app service plan."
+      }
+    },
     "eventhubName": {
       "type": "string",
       "defaultValue": "datadog-eventhub",
@@ -81,16 +88,32 @@
       }
     },
     {
+      "type": "Microsoft.Web/serverfarms",
+      "apiVersion": "2024-04-01",
+      "name": "[parameters('appServicePlanName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Y1",
+        "tier": "Dynamic"
+      },
+      "kind": "functionapp",
+      "properties": {
+        "zoneRedundant": false
+      }
+    },
+    {
       "apiVersion": "2024-04-01",
       "type": "Microsoft.Web/sites",
       "name": "[parameters('functionAppName')]",
       "location": "[parameters('location')]",
       "kind": "functionapp",
       "dependsOn": [
+        "[resourceId('Microsoft.Web/serverfarms', parameters('appServicePlanName'))]",
         "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
       ],
       "properties": {
         "name": "[parameters('functionAppName')]",
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', parameters('appServicePlanName'))]",
         "clientAffinityEnabled": false,
         "siteConfig": {
           "cors": {

--- a/azure/eventhub_log_forwarder/function_template.json
+++ b/azure/eventhub_log_forwarder/function_template.json
@@ -163,9 +163,23 @@
       ]
     },
     {
-      "type": "Microsoft.Web/sites/syncfunctiontriggers",
-      "apiVersion": "2016-08-01",
-      "name": "[concat(parameters('functionAppName'), '/syncfunctiontriggers')]",
+      "type": "Microsoft.Resources/deploymentScripts",
+      "apiVersion": "2020-10-01",
+      "name": "[concat('syncFunctionTriggers-', parameters('functionAppName'))]",
+      "location": "[parameters('location')]",
+      "kind": "AzureCLI",
+      "properties": {
+        "azCliVersion": "2.67.0",
+        "scriptContent": "[format('az rest --method post --url ''https://management.azure.com{0}/syncfunctiontriggers?api-version=2024-04-01''', resourceId('Microsoft.Web/sites', parameters('functionAppName')))]",
+        "timeout": "PT30M",
+        "cleanupPreference": "OnSuccess",
+        "retentionInterval": "P1D",
+        "storageAccountSettings": {
+          "storageAccountName": "[variables('storageAccountName')]",
+          "storageAccountContainerName": "[concat('scripts-', parameters('functionAppName'))]",
+          "storageAccountAccessKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2021-04-01').keys[0].value]"
+        }
+      },
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites/extensions', concat(parameters('functionAppName'), '/zipdeploy'))]"
       ]

--- a/azure/eventhub_log_forwarder/function_template.json
+++ b/azure/eventhub_log_forwarder/function_template.json
@@ -15,13 +15,6 @@
         "description": "The name of the function app."
       }
     },
-    "appServicePlanName": {
-      "type": "string",
-      "defaultValue": "[concat('datadog-asp-', newGuid())]",
-      "metadata": {
-        "description": "The name of the app service plan."
-      }
-    },
     "eventhubName": {
       "type": "string",
       "defaultValue": "datadog-eventhub",
@@ -88,32 +81,16 @@
       }
     },
     {
-      "type": "Microsoft.Web/serverfarms",
-      "apiVersion": "2024-04-01",
-      "name": "[parameters('appServicePlanName')]",
-      "location": "[parameters('location')]",
-      "sku": {
-        "name": "Y1",
-        "tier": "Dynamic"
-      },
-      "kind": "functionapp",
-      "properties": {
-        "zoneRedundant": false
-      }
-    },
-    {
       "apiVersion": "2024-04-01",
       "type": "Microsoft.Web/sites",
       "name": "[parameters('functionAppName')]",
       "location": "[parameters('location')]",
       "kind": "functionapp",
       "dependsOn": [
-        "[resourceId('Microsoft.Web/serverfarms', parameters('appServicePlanName'))]",
         "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
       ],
       "properties": {
         "name": "[parameters('functionAppName')]",
-        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', parameters('appServicePlanName'))]",
         "clientAffinityEnabled": false,
         "siteConfig": {
           "cors": {

--- a/azure/eventhub_log_forwarder/function_template.json
+++ b/azure/eventhub_log_forwarder/function_template.json
@@ -190,7 +190,7 @@
       "identity": {
         "type": "UserAssigned",
         "userAssignedIdentities": {
-          "[concat('syncFunctionTriggers-', parameters('functionAppName'), '-identity')]": {}
+          "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', concat('syncFunctionTriggers-', parameters('functionAppName'), '-identity'))]": {}
         }
       },
       "properties": {
@@ -205,6 +205,7 @@
         }
       },
       "dependsOn": [
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', concat('syncFunctionTriggers-', parameters('functionAppName'), '-identity'))]",
         "[resourceId('Microsoft.Web/sites/extensions', parameters('functionAppName'), 'zipdeploy')]"
       ]
     }

--- a/azure/eventhub_log_forwarder/function_template.json
+++ b/azure/eventhub_log_forwarder/function_template.json
@@ -195,7 +195,7 @@
       },
       "properties": {
         "azCliVersion": "2.67.0",
-        "scriptContent": "[format('az rest --url ''https://management.azure.com{0}/syncfunctiontriggers?api-version=2024-04-01'' --method post', resourceId('Microsoft.Web/sites', parameters('functionAppName')))]",
+        "scriptContent": "[format('az rest --url ''{0}{1}/syncfunctiontriggers?api-version=2024-04-01'' --method post', environment().resourceManager, resourceId('Microsoft.Web/sites', parameters('functionAppName')))]",
         "timeout": "PT30M",
         "cleanupPreference": "OnSuccess",
         "retentionInterval": "P1D",

--- a/azure/eventhub_log_forwarder/function_template.json
+++ b/azure/eventhub_log_forwarder/function_template.json
@@ -64,7 +64,8 @@
   },
   "variables": {
     "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'storageacct')]",
-    "authRule": "[resourceId('Microsoft.EventHub/namespaces/authorizationRules', parameters('eventhubNamespace'),'RootManageSharedAccessKey')]"
+    "eventHubAuthRule": "[resourceId('Microsoft.EventHub/namespaces/authorizationRules', parameters('eventhubNamespace'),'RootManageSharedAccessKey')]",
+    "storageAccountConnectionString": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2018-11-01').keys[0].value,';','EndpointSuffix=',parameters('endpointSuffix'),';')]"
   },
   "resources": [
     {
@@ -117,7 +118,7 @@
             },
             {
               "name": "AzureWebJobsStorage",
-              "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2018-11-01').keys[0].value,';','EndpointSuffix=',parameters('endpointSuffix'),';')]"
+              "value": "[variables('storageAccountConnectionString')]"
             },
             {
               "name": "FUNCTIONS_WORKER_RUNTIME",
@@ -129,11 +130,11 @@
             },
             {
               "name": "EVENTHUB_CONNECTION_STRING",
-              "value": "[listKeys(variables('authRule'),'2017-04-01').primaryConnectionString]"
+              "value": "[listKeys(variables('eventHubAuthRule'),'2017-04-01').primaryConnectionString]"
             },
             {
               "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
-              "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2018-11-01').keys[0].value,';','EndpointSuffix=',parameters('endpointSuffix'),';')]"
+              "value": "[variables('storageAccountConnectionString')]"
             },
             {
               "name": "WEBSITE_CONTENTSHARE",
@@ -176,8 +177,7 @@
         "retentionInterval": "P1D",
         "storageAccountSettings": {
           "storageAccountName": "[variables('storageAccountName')]",
-          "storageAccountContainerName": "[concat('scripts-', parameters('functionAppName'))]",
-          "storageAccountAccessKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2021-04-01').keys[0].value]"
+          "storageAccountKey": "[variables('storageAccountConnectionString')]"
         }
       },
       "dependsOn": [

--- a/azure/eventhub_log_forwarder/parent_template.json
+++ b/azure/eventhub_log_forwarder/parent_template.json
@@ -51,6 +51,13 @@
         "description": "The name of the function app."
       }
     },
+    "appServicePlanName": {
+      "type": "string",
+      "defaultValue": "[concat('datadog-asp-', newGuid())]",
+      "metadata": {
+        "description": "The name of the app service plan."
+      }
+    },
     "eventhubName": {
       "type": "string",
       "defaultValue": "datadog-eventhub",
@@ -145,6 +152,9 @@
           },
           "eventHubName": {
             "value": "[parameters('eventHubName')]"
+          },
+          "appServicePlanName": {
+            "value": "[parameters('appServicePlanName')]"
           },
           "functionAppName": {
             "value": "[parameters('functionAppName')]"

--- a/azure/eventhub_log_forwarder/parent_template.json
+++ b/azure/eventhub_log_forwarder/parent_template.json
@@ -51,13 +51,6 @@
         "description": "The name of the function app."
       }
     },
-    "appServicePlanName": {
-      "type": "string",
-      "defaultValue": "[concat('datadog-asp-', newGuid())]",
-      "metadata": {
-        "description": "The name of the app service plan."
-      }
-    },
     "eventhubName": {
       "type": "string",
       "defaultValue": "datadog-eventhub",
@@ -152,9 +145,6 @@
           },
           "eventHubName": {
             "value": "[parameters('eventHubName')]"
-          },
-          "appServicePlanName": {
-            "value": "[parameters('appServicePlanName')]"
           },
           "functionAppName": {
             "value": "[parameters('functionAppName')]"


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

In the upgrade, I added this setting which the docs said should improve performance (while disallowing portal editing, which was already not working since using v4 breaks this). Instead, it seems to have broken the initial deployment, which slipped through the cracks when testing. This reverts that change to restore the ARM template functionality.

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

Replace the variable in the parent template with:
```
    "functionAppTemplateLink": "https://raw.githubusercontent.com/DataDog/datadog-serverless-functions/refs/heads/ava.silver/azints/fix-v4-upgrade/azure/eventhub_log_forwarder/function_template.json",
```

And run
```bash
az deployment group create --resource-group your-resource-group --template-file azure/eventhub_log_forwarder/parent_template.json --parameters apiKey=$DD_API_KEY
```

validated from a fresh deploy:
```bash
az deployment group create --resource-group ava-test-3 --template-file azure/eventhub_log_forwarder/parent_template.json --parameters apiKey=$DD_API_KEY datadogTags=ava:true
```

Added a diagnostic setting on a loggy instance to point to the eventhub, spammed logs, and observed logs coming in:
<img width="699" alt="image" src="https://github.com/user-attachments/assets/ba8ec591-9b4a-4da8-86c7-73b6d960eaab" />


### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
