### PR TITLE
[AWS] fix(logs-forwarder): properly set AWS partition for log groups tags cache

### DIFF
--- a/aws/logs_monitoring/steps/handlers/aws_attributes.py
+++ b/aws/logs_monitoring/steps/handlers/aws_attributes.py
@@ -2,14 +2,25 @@ from steps.common import merge_dicts
 
 
 class AwsAttributes:
-    def __init__(self, log_group=None, log_stream=None, log_events=None, owner=None):
+    def __init__(
+        self, context, log_group=None, log_stream=None, log_events=None, owner=None
+    ):
         self.log_group = log_group
         self.log_stream = log_stream
         self.log_events = log_events
         self.owner = owner
+        self.partition = self._get_aws_partition(context)
         self.lambda_arn = None
         self.account = None
         self.region = None
+
+    def _get_aws_partition(self, context):
+        if context.invoked_function_arn.startswith("arn:aws-cn:"):
+            return "aws-cn"
+        elif context.invoked_function_arn.startswith("arn:aws-us-gov:"):
+            return "aws-us-gov"
+        else:
+            return "aws"
 
     def to_dict(self):
         awslogs = {
@@ -30,7 +41,7 @@ class AwsAttributes:
         return self.log_group
 
     def get_log_group_arn(self):
-        return f"arn:aws:logs:{self.region}:{self.account}:log-group:{self.log_group}"
+        return f"arn:{self.partition}:logs:{self.region}:{self.account}:log-group:{self.log_group}"
 
     def get_log_stream(self):
         return self.log_stream

--- a/aws/logs_monitoring/steps/handlers/awslogs_handler.py
+++ b/aws/logs_monitoring/steps/handlers/awslogs_handler.py
@@ -37,6 +37,7 @@ class AwsLogsHandler:
         logs = self.extract_logs(event)
         # Build aws attributes
         aws_attributes = AwsAttributes(
+            self.context,
             logs.get("logGroup"),
             logs.get("logStream"),
             logs.get("logEvents"),

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -934,7 +934,7 @@ Resources:
         - !Ref PermissionsBoundaryArn
         - !Ref AWS::NoValue
       Policies:
-        - PolicyName: ForwarderZipCopierRolpePolicy0
+        - PolicyName: ForwarderZipCopierRolePolicy0
           PolicyDocument:
             Version: "2012-10-17"
             Statement:

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -934,7 +934,7 @@ Resources:
         - !Ref PermissionsBoundaryArn
         - !Ref AWS::NoValue
       Policies:
-        - PolicyName: ForwarderZipCopierRolePolicy0
+        - PolicyName: ForwarderZipCopierRolpePolicy0
           PolicyDocument:
             Version: "2012-10-17"
             Statement:


### PR DESCRIPTION


<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
