### PR TITLE
[AWSX] feat(lambda logs forwarder): Allow to opt-out from S3 tags enrichment

### DIFF
--- a/aws/logs_monitoring/caching/s3_tags_cache.py
+++ b/aws/logs_monitoring/caching/s3_tags_cache.py
@@ -17,7 +17,8 @@ class S3TagsCache(BaseTagsCache):
         )
 
     def should_fetch_tags(self):
-        return os.environ.get("DD_FETCH_S3_TAGS", "false").lower() == "true"
+        # set it to true if we don't have the environment variable set to keep the default behavior
+        return os.environ.get("DD_FETCH_S3_TAGS", "true").lower() == "true"
 
     def build_tags_cache(self):
         """Makes API calls to GetResources to get the live tags of the account's S3 buckets

--- a/aws/logs_monitoring/caching/s3_tags_cache.py
+++ b/aws/logs_monitoring/caching/s3_tags_cache.py
@@ -1,3 +1,4 @@
+import os
 from botocore.exceptions import ClientError
 from caching.base_tags_cache import BaseTagsCache
 from caching.common import parse_get_resources_response_for_tags_by_arn
@@ -16,7 +17,7 @@ class S3TagsCache(BaseTagsCache):
         )
 
     def should_fetch_tags(self):
-        return True
+        return os.environ.get("DD_FETCH_S3_TAGS", "false").lower() == "true"
 
     def build_tags_cache(self):
         """Makes API calls to GetResources to get the live tags of the account's S3 buckets
@@ -56,6 +57,13 @@ class S3TagsCache(BaseTagsCache):
         return tags_fetch_success, tags_by_arn_cache
 
     def get(self, bucket_arn):
+        if not self.should_fetch_tags():
+            self.logger.debug(
+                "Not fetching S3  tags because the env variable DD_FETCH_S3_TAGS is "
+                "not set to true"
+            )
+            return []
+
         if self._is_expired():
             send_forwarder_internal_metrics("local_s3_tags_cache_expired")
             self.logger.debug("Local cache expired, fetching cache from S3")

--- a/aws/logs_monitoring/steps/handlers/s3_handler.py
+++ b/aws/logs_monitoring/steps/handlers/s3_handler.py
@@ -109,7 +109,7 @@ class S3EventHandler:
             self.metadata[DD_CUSTOM_TAGS] = (
                 ",".join(s3_tags)
                 if not self.metadata[DD_CUSTOM_TAGS]
-                else self.metadata[DD_CUSTOM_TAGS] + "," + ",".join(s3_tags)
+                else ",".join(s3_tags) + "," + self.metadata[DD_CUSTOM_TAGS]
             )
 
     def _extract_data(self):

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -96,6 +96,13 @@ Parameters:
       - true
       - false
     Description: Let the forwarder fetch Step Functions tags using GetResources API calls and apply them to logs, metrics and traces. If set to true, permission tag:GetResources will be automatically added to the Lambda execution IAM role. The tags are cached in memory and S3 so that they'll only be fetched when the function cold starts or when the TTL (1 hour) expires. The forwarder increments the aws.lambda.enhanced.get_resources_api_calls metric for each API call made.
+  DdFetchS3Tags:
+    Type: String
+    Default: true
+    AllowedValues:
+      - true
+      - false
+    Description: Let the forwarder fetch S3 buckets tags using GetResources API calls and apply them to S3 based logs. If set to true, permission tag:GetResources will be automatically added to the Lambda execution IAM role. The tags are cached in memory and S3 so that they'll only be fetched when the function cold starts or when the TTL (1 hour) expires. The forwarder increments the aws.lambda.enhanced.get_resources_api_calls metric for each API call made.
   DdUseTcp:
     Type: String
     Default: false
@@ -459,6 +466,7 @@ Resources:
             - SetDdFetchLambdaTags
             - !Ref DdFetchLambdaTags
             - !Ref AWS::NoValue
+          DD_FETCH_S3_TAGS: !Ref DdFetchS3Tags
           DD_FETCH_LOG_GROUP_TAGS: !If
             - SetDdFetchLogGroupTags
             - !Ref DdFetchLogGroupTags
@@ -1036,6 +1044,7 @@ Metadata:
           - DdFetchLambdaTags
           - DdFetchLogGroupTags
           - DdFetchStepFunctionsTags
+          - DdFetchS3Tags
           - DdStepFunctionsTraceEnabled
           - DdEnhancedMetrics
           - TagsCacheTTLSeconds


### PR DESCRIPTION


<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Allow to opt out from S3 tags enrichment + re-order fetched tags to have a higher priority for Forwarder set tags, notable `service`. 

If S3 tags enrichment is enabled, the fetched tags will be added infront, which should be deduplicated if the same tags are set as ENV vars on the forwarder's side.

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
