### PR TITLE
[azure] fix bug causing log splitting to not work properly

### DIFF
--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -5,7 +5,7 @@
 
 const { app, InvocationContext } = require('@azure/functions');
 
-const VERSION = '2.0.0';
+const VERSION = '2.1.0';
 
 const STRING = 'string'; // example: 'some message'
 const STRING_ARRAY = 'string-array'; // example: ['one message', 'two message', ...]
@@ -290,7 +290,8 @@ class EventhubLogHandler {
 
     findSplitRecords(record, fields) {
         let tempRecord = record;
-        for (const fieldName in fields) {
+        for (const fieldIndex in fields) {
+            const fieldName = fields[fieldIndex];
             // loop through the fields to find the one we want to split
             if (
                 tempRecord[fieldName] === undefined ||


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
There was a bug in our log forwarder which caused log splitting to not function properly. We were incorrectly assuming we had a field name when we actually had an index. 

### Motivation
Log splitting was not working no matter what setting were used. 

### Testing Guidelines
Unit tests added to test this behavior

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
