### PR TITLE
[azure] Enable AP2 in event hub log forwarder ARM template

### DIFF
--- a/azure/eventhub_log_forwarder/parent_template.json
+++ b/azure/eventhub_log_forwarder/parent_template.json
@@ -11,7 +11,8 @@
         "us5.datadoghq.com",
         "datadoghq.eu",
         "ddog-gov.com",
-        "ap1.datadoghq.com"
+        "ap1.datadoghq.com",
+        "ap2.datadoghq.com"
       ],
       "metadata": {
         "description": "Datadog site to send logs"


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Enable AP2 in the ARM template dropdown for the Azure event hub log forwarder. 

### Motivation
Support AP2 for existing Azure ARM templates


