### PR TITLE
Revert "Remove `DdApiKeySecretArn` `AllowedPattern` constraints to allow friendly name support in DD forwarder lambda"

### DIFF
--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -13,7 +13,9 @@ Parameters:
     Description: The Datadog API key, which can be found from the APIs page (/account/settings#api). It will be stored in AWS Secrets Manager securely. If DdApiKeySecretArn is also set, this value is ignored.
   DdApiKeySecretArn:
     Type: String
-    Description: The full ARN or name (if local) of the secret storing the Datadog API key, if you already have it stored in Secrets Manager. You must store the secret as a plaintext, rather than a key-value pair.
+    AllowedPattern: "arn:.*:secretsmanager:.*"
+    Default: "arn:aws:secretsmanager:DEFAULT"
+    Description: The ARN of the secret storing the Datadog API key, if you already have it stored in Secrets Manager. You must store the secret as a plaintext, rather than a key-value pair.
   DdApiKeySsmParameterName:
     Type: String
     Default: "/my/parameter/path"


### PR DESCRIPTION
Reverts DataDog/datadog-serverless-functions#956