### PR TITLE
[FIXED] Remove `DdApiKeySecretArn` `AllowedPattern` constraints to allow local secret name support in DD forwarder lambda

### DIFF
--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -13,9 +13,8 @@ Parameters:
     Description: The Datadog API key, which can be found from the APIs page (/account/settings#api). It will be stored in AWS Secrets Manager securely. If DdApiKeySecretArn is also set, this value is ignored.
   DdApiKeySecretArn:
     Type: String
-    AllowedPattern: "arn:.*:secretsmanager:.*"
     Default: "arn:aws:secretsmanager:DEFAULT"
-    Description: The ARN of the secret storing the Datadog API key, if you already have it stored in Secrets Manager. You must store the secret as a plaintext, rather than a key-value pair.
+    Description: The full ARN or name (if local) of the secret storing the Datadog API key, if you already have it stored in Secrets Manager. You must store the secret as a plaintext, rather than a key-value pair.
   DdApiKeySsmParameterName:
     Type: String
     Default: "/my/parameter/path"
@@ -429,7 +428,7 @@ Resources:
             - !Ref DdForwarderExistingBucketName
           S3Key: !Sub
             - "aws-dd-forwarder-${DdForwarderVersion}.zip"
-            - {DdForwarderVersion: !FindInMap [Constants, DdForwarder, Version]}
+            - { DdForwarderVersion: !FindInMap [Constants, DdForwarder, Version] }
         - ZipFile: " "
       MemorySize: !Ref MemorySize
       Runtime: python3.12
@@ -832,7 +831,7 @@ Resources:
         - !Ref SourceZipUrl
         - !Sub
           - "https://github.com/DataDog/datadog-serverless-functions/releases/download/aws-dd-forwarder-${DdForwarderVersion}/aws-dd-forwarder-${DdForwarderVersion}.zip"
-          - {DdForwarderVersion: !FindInMap [Constants, DdForwarder, Version]}
+          - { DdForwarderVersion: !FindInMap [Constants, DdForwarder, Version] }
   # The Forwarder's source code is too big to fit the inline code size limit for CloudFormation. In most of AWS
   # partitions and regions, the Forwarder is able to load its source code from a Lambda layer attached to it.
   # In places where Datadog can't/doesn't yet publish Lambda layers, use another Lambda to copy the source code


### PR DESCRIPTION
### What does this PR do?

To allow the use of the simple (aka friendly) name of the DD API key account-local secret, I'm removing the `AllowedPattern` constraints on the `DdApiKeySecretArn` template variable and updating the variable description accordingly.

- **This change include a fix for [the previous mistake](https://github.com/DataDog/datadog-serverless-functions/pull/956/files#diff-7c5bda646bf6435d9285913888d0473f0ac98ed0fdd025ae5d9ea357ad9b3ffaL17) of removing the default value `arn:aws:secretsmanager:DEFAULT` required in the template.**

### Motivation

This allows to use a naming convention for the secret names and deploy the lambda without having to know the full ARN of the secret. This makes scaling the use of the Datadog Forwarder much easier.

### Testing Guidelines

The lambda code is using `boto3.client.get_secret_value(SecretId=<var>)`, which, [according to its documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/secretsmanager/client/get_secret_value.html), allows to retrieve a secret from its ARN **or** its name (if the secret is in the same account):
```
SecretId (string) – [REQUIRED]
The ARN -->or name<-- of the secret to retrieve. To retrieve a secret from another account, you must use an ARN.
```

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
