### PR TITLE
Revert "[FIXED] Remove `DdApiKeySecretArn` `AllowedPattern` constraints to allow local secret name support in DD forwarder lambda"

### DIFF
--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -13,8 +13,9 @@ Parameters:
     Description: The Datadog API key, which can be found from the APIs page (/account/settings#api). It will be stored in AWS Secrets Manager securely. If DdApiKeySecretArn is also set, this value is ignored.
   DdApiKeySecretArn:
     Type: String
+    AllowedPattern: "arn:.*:secretsmanager:.*"
     Default: "arn:aws:secretsmanager:DEFAULT"
-    Description: The full ARN or name (if local) of the secret storing the Datadog API key, if you already have it stored in Secrets Manager. You must store the secret as a plaintext, rather than a key-value pair.
+    Description: The ARN of the secret storing the Datadog API key, if you already have it stored in Secrets Manager. You must store the secret as a plaintext, rather than a key-value pair.
   DdApiKeySsmParameterName:
     Type: String
     Default: "/my/parameter/path"
@@ -428,7 +429,7 @@ Resources:
             - !Ref DdForwarderExistingBucketName
           S3Key: !Sub
             - "aws-dd-forwarder-${DdForwarderVersion}.zip"
-            - { DdForwarderVersion: !FindInMap [Constants, DdForwarder, Version] }
+            - {DdForwarderVersion: !FindInMap [Constants, DdForwarder, Version]}
         - ZipFile: " "
       MemorySize: !Ref MemorySize
       Runtime: python3.12
@@ -831,7 +832,7 @@ Resources:
         - !Ref SourceZipUrl
         - !Sub
           - "https://github.com/DataDog/datadog-serverless-functions/releases/download/aws-dd-forwarder-${DdForwarderVersion}/aws-dd-forwarder-${DdForwarderVersion}.zip"
-          - { DdForwarderVersion: !FindInMap [Constants, DdForwarder, Version] }
+          - {DdForwarderVersion: !FindInMap [Constants, DdForwarder, Version]}
   # The Forwarder's source code is too big to fit the inline code size limit for CloudFormation. In most of AWS
   # partitions and regions, the Forwarder is able to load its source code from a Lambda layer attached to it.
   # In places where Datadog can't/doesn't yet publish Lambda layers, use another Lambda to copy the source code


### PR DESCRIPTION
Reverts DataDog/datadog-serverless-functions#961

Reverting this PR as it will break policy document when referencing the secret ARN [here](https://github.com/DataDog/datadog-serverless-functions/blob/a94fd772fce073fa52ed194c64e7f4bae9f06cc7/aws/logs_monitoring/template.yaml#L678)