### PR TITLE
Update version from 4.11.0 to 4.12.0

### DIFF
--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -275,7 +275,7 @@ DD_SOURCE = "ddsource"
 DD_CUSTOM_TAGS = "ddtags"
 DD_SERVICE = "service"
 DD_HOST = "host"
-DD_FORWARDER_VERSION = "4.11.0"
+DD_FORWARDER_VERSION = "4.12.0"
 
 # CONST STRINGS
 AWS_STRING = "aws"

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -3,8 +3,8 @@ Description: Pushes logs, metrics and traces from AWS to Datadog.
 Mappings:
   Constants:
     DdForwarder:
-      Version: 4.11.0
-      LayerVersion: "86"
+      Version: 4.12.0
+      LayerVersion: "87"
 Parameters:
   DdApiKey:
     Type: String


### PR DESCRIPTION
This PR updates the AWS Forwarder version to 4.12.0 and the layer version to 87.