### PR TITLE
Fix `verison` typos in readme

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -148,11 +148,11 @@ The <a href="#cloudformation-parameters">environment variables provided on this 
 
 If you encounter issues upgrading to the latest version, check the Troubleshooting section.
 
-### Upgrade an older verison to 4.12.0+
+### Upgrade an older version to 4.12.0+
 Starting version 4.12.0+ Lambda function has been updated to require **Python 3.13**. If upgrading an older forwarder installation to 4.12.0+, ensure AWS Lambda function is configured to use Python 3.13
 
-### Upgrade an older verison to 4.3.0+
-Starting verison 4.3.0 Lambda forwarder will support a single python version only. The supported Python version of this release is 3.12.
+### Upgrade an older version to 4.3.0+
+Starting version 4.3.0 Lambda forwarder will support a single python version only. The supported Python version of this release is 3.12.
 
 ### Upgrade an older version to +4.0.0
 Starting version 4.0.0 `source`, `service` and `host` identification logic will be pulled out from the Lambda forwarder's code and set in directly in Datadog's backend. The first migrated log source is `RDS`.


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Fixes a couple of places in the readme where it says `verison` but should say `version`.
<!--- A brief description of the change being made with this pull request. --->

### Motivation
Nerdiness
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
