### PR TITLE
Logs forwarder support Python 3.13 AFTER 4.12.0

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -148,8 +148,8 @@ The <a href="#cloudformation-parameters">environment variables provided on this 
 
 If you encounter issues upgrading to the latest version, check the Troubleshooting section.
 
-### Upgrade an older verison to 4.12.0+
-Starting version 4.12.0+ Lambda function has been updated to require **Python 3.13**. If upgrading an older forwarder installation to 4.12.0+, ensure AWS Lambda function is configured to use Python 3.13
+### Upgrade an older verison to >4.12.0
+Starting version >4.12.0 Lambda function has been updated to require **Python 3.13**. If upgrading an older forwarder installation to >4.12.0, ensure AWS Lambda function is configured to use Python 3.13.
 
 ### Upgrade an older verison to 4.3.0+
 Starting verison 4.3.0 Lambda forwarder will support a single python version only. The supported Python version of this release is 3.12.


### PR DESCRIPTION
4.12.0 still supports only Python 3.12


### What does this PR do?

It clear docs misconception.

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
