### PR TITLE
Make sure docker is running before starting release

### DIFF
--- a/aws/logs_monitoring/release.sh
+++ b/aws/logs_monitoring/release.sh
@@ -94,7 +94,6 @@ if ! docker info > /dev/null 2>&1; then
     log_error "Docker is not running, please start it"
 fi
 
-
 # Read the desired version
 if [[ ! ${1} =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
     log_error "You must use a semantic version (e.g. 3.1.4)"

--- a/aws/logs_monitoring/release.sh
+++ b/aws/logs_monitoring/release.sh
@@ -89,6 +89,12 @@ if ! command -v gh >/dev/null 2>&1; then
     log_error "gh not found, please install it following instructions here https://github.com/cli/cli?tab=readme-ov-file#installation"
 fi
 
+# Before we start the release, ensure that Docker is running
+if ! docker info > /dev/null 2>&1; then
+    log_error "Docker is not running, please start it"
+fi
+
+
 # Read the desired version
 if [[ ! ${1} =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
     log_error "You must use a semantic version (e.g. 3.1.4)"


### PR DESCRIPTION
In case Docker is not running we'll exit quickly, and save time.