### PR TITLE
fix(docs): retry using aws cli

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -125,7 +125,7 @@ If you can't install the Forwarder using the provided CloudFormation template, y
 8. Set environment variable `DD_STORE_FAILED_EVENTS` to `true` to enable the forwarder to also store event data in the S3 bucket. In case of exceptions when sending logs, metrics or traces to intake, the forwarder will store relevant data in the S3 bucket. On custom invocations i.e. on receiving an event with the `retry` keyword set to a non empty string (which can be manually triggered - see below), the forwarder will retry sending the stored events. When successful it will clear up the storage in the bucket.
 
 ```bash
-aws lambda invoke --function-name <function-name> --payload '{"retry":"true"}' out
+aws lambda invoke --function-name <function-name> --cli-binary-format raw-in-base64-out --payload '{"retry":"true"}' out
 ```
 
 <div class="alert alert-warning">


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Fixes retry command in documentation.
AWS cli v2 expects a base64 payload. Using `cli-binary-format` option is required to use raw json.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

```bash
# Before
aws lambda invoke --function-name REDACTED --payload '{"retry":"true"}' out  

Invalid base64: "{"retry":"true"}"

# After
aws lambda invoke --function-name REDACTED --cli-binary-format raw-in-base64-out --payload '{"retry":"true"}' out 
{
    "StatusCode": 200,
    "ExecutedVersion": "$LATEST"
}
```
<!--- What inspired you to submit this pull request? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
