### PR TITLE
Feat/ AWS Log monitoring: set source using template parameter

### DIFF
--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -75,6 +75,10 @@ Parameters:
     Type: String
     Default: ""
     Description: Add custom tags to forwarded logs, comma-delimited string, no trailing comma, e.g., env:prod,stack:classic
+  DdSource:
+    Type: String
+    Default: ""
+    Description: Define forwarded logs source (default to s3)
   DdFetchLambdaTags:
     Type: String
     Default: true
@@ -310,6 +314,8 @@ Conditions:
   SetS3SourceZip: !Equals [!Select [0, !Split [/, !Ref SourceZipUrl]], "s3:"]
   SetDdTags: !Not
     - !Equals [!Ref DdTags, ""]
+  SetDdSource: !Not
+    - !Equals [ !Ref DdSource, "" ]
   SetDdUseTcp: !Equals [!Ref DdUseTcp, true]
   SetDdNoSsl: !Equals [!Ref DdNoSsl, true]
   SetDdUrl: !Not
@@ -461,6 +467,10 @@ Resources:
           DD_TAGS: !If
             - SetDdTags
             - !Ref DdTags
+            - !Ref AWS::NoValue
+          DD_SOURCE: !If
+            - SetDdSource
+            - !Ref DdSource
             - !Ref AWS::NoValue
           DD_TAGS_CACHE_TTL_SECONDS: !Ref TagsCacheTTLSeconds
           DD_FETCH_LAMBDA_TAGS: !If
@@ -1017,6 +1027,7 @@ Metadata:
           default: Log Forwarding (Optional)
         Parameters:
           - DdTags
+          - DdSource
           - DdMultilineLogRegexPattern
           - DdUseTcp
           - DdNoSsl


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

- Add a new optional parameter `DdSource` for the cloudformation template to set the source of forwarded logs (setting the env var `DD_SOURCE`)

### Motivation

- We can set tags with `DdTags` , however when setting the source using this parameter : (eg. DdTags: source:test), the forwarded logs still keep the `source:s3` tag 
- By using `DdSource` to set `DD_SOURCE` this solves the issue: we have only one source which is the one set with the new parameter

Config | Output
--- | ---
`DdTags: source:kandji,service:kandji` | <img width="969" height="258" alt="Screenshot 2025-09-19 at 12 13 07" src="https://github.com/user-attachments/assets/a0f61fc1-bc46-475e-9963-2af69bd03a6d" />
`DdTags: service:kandji` <br /> `DdSource: kandji` | <img width="961" height="238" alt="Screenshot 2025-09-19 at 12 17 24" src="https://github.com/user-attachments/assets/29f0590a-a43d-44a5-832a-3955c226c65c" />


<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

- ✅ ran python unitests
- ✅ uploaded the template and tested the new parameter on our AWS account

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [x] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
