### PR TITLE
feat(aws): Move tags enablement environment variable to settings

### DIFF
--- a/aws/logs_monitoring/caching/cloudwatch_log_group_cache.py
+++ b/aws/logs_monitoring/caching/cloudwatch_log_group_cache.py
@@ -13,6 +13,7 @@ from settings import (
     DD_S3_CACHE_DIRNAME,
     DD_S3_LOG_GROUP_CACHE_DIRNAME,
     DD_TAGS_CACHE_TTL_SECONDS,
+    get_fetch_log_group_tags,
 )
 from telemetry import send_forwarder_internal_metrics
 
@@ -61,7 +62,7 @@ class CloudwatchLogGroupTagsCache:
         return self._fetch_log_group_tags(log_group_arn)
 
     def _should_fetch_tags(self):
-        return os.environ.get("DD_FETCH_LOG_GROUP_TAGS", "false").lower() == "true"
+        return get_fetch_log_group_tags()
 
     def _fetch_log_group_tags(self, log_group_arn):
         # first, check in-memory cache

--- a/aws/logs_monitoring/caching/lambda_cache.py
+++ b/aws/logs_monitoring/caching/lambda_cache.py
@@ -1,5 +1,3 @@
-import os
-
 from botocore.exceptions import ClientError
 
 from caching.base_tags_cache import BaseTagsCache
@@ -8,6 +6,7 @@ from settings import (
     DD_S3_LAMBDA_CACHE_FILENAME,
     DD_S3_LAMBDA_CACHE_LOCK_FILENAME,
     GET_RESOURCES_LAMBDA_FILTER,
+    get_fetch_lambda_tags,
 )
 from telemetry import send_forwarder_internal_metrics
 
@@ -19,7 +18,7 @@ class LambdaTagsCache(BaseTagsCache):
         )
 
     def should_fetch_tags(self):
-        return os.environ.get("DD_FETCH_LAMBDA_TAGS", "false").lower() == "true"
+        return get_fetch_lambda_tags()
 
     def build_tags_cache(self):
         """Makes API calls to GetResources to get the live tags of the account's Lambda functions

--- a/aws/logs_monitoring/caching/s3_tags_cache.py
+++ b/aws/logs_monitoring/caching/s3_tags_cache.py
@@ -1,13 +1,14 @@
-import os
 from botocore.exceptions import ClientError
+
 from caching.base_tags_cache import BaseTagsCache
 from caching.common import parse_get_resources_response_for_tags_by_arn
-from telemetry import send_forwarder_internal_metrics
 from settings import (
     DD_S3_TAGS_CACHE_FILENAME,
     DD_S3_TAGS_CACHE_LOCK_FILENAME,
     GET_RESOURCES_S3_FILTER,
+    get_fetch_s3_tags,
 )
+from telemetry import send_forwarder_internal_metrics
 
 
 class S3TagsCache(BaseTagsCache):
@@ -18,7 +19,7 @@ class S3TagsCache(BaseTagsCache):
 
     def should_fetch_tags(self):
         # set it to true if we don't have the environment variable set to keep the default behavior
-        return os.environ.get("DD_FETCH_S3_TAGS", "true").lower() == "true"
+        return get_fetch_s3_tags()
 
     def build_tags_cache(self):
         """Makes API calls to GetResources to get the live tags of the account's S3 buckets

--- a/aws/logs_monitoring/caching/step_functions_cache.py
+++ b/aws/logs_monitoring/caching/step_functions_cache.py
@@ -1,16 +1,17 @@
-import os
 from botocore.exceptions import ClientError
+
 from caching.base_tags_cache import BaseTagsCache
 from caching.common import (
-    sanitize_aws_tag_string,
     parse_get_resources_response_for_tags_by_arn,
+    sanitize_aws_tag_string,
 )
-from telemetry import send_forwarder_internal_metrics
 from settings import (
     DD_S3_STEP_FUNCTIONS_CACHE_FILENAME,
     DD_S3_STEP_FUNCTIONS_CACHE_LOCK_FILENAME,
     GET_RESOURCES_STEP_FUNCTIONS_FILTER,
+    get_fetch_step_functions_tags,
 )
+from telemetry import send_forwarder_internal_metrics
 
 
 class StepFunctionsTagsCache(BaseTagsCache):
@@ -22,7 +23,7 @@ class StepFunctionsTagsCache(BaseTagsCache):
         )
 
     def should_fetch_tags(self):
-        return os.environ.get("DD_FETCH_STEP_FUNCTIONS_TAGS", "false").lower() == "true"
+        return get_fetch_step_functions_tags()
 
     def build_tags_cache(self):
         """Makes API calls to GetResources to get the live tags of the account's Step Functions

--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -271,6 +271,37 @@ DD_MULTILINE_LOG_REGEX_PATTERN = get_env_var(
     "DD_MULTILINE_LOG_REGEX_PATTERN", default=None
 )
 
+DD_FETCH_S3_TAGS = get_env_var("DD_FETCH_S3_TAGS", default="true", boolean=True)
+
+DD_FETCH_LOG_GROUP_TAGS = get_env_var(
+    "DD_FETCH_LOG_GROUP_TAGS", default="true", boolean=True
+)
+
+DD_FETCH_LAMBDA_TAGS = get_env_var(
+    "DD_FETCH_LAMBDA_TAGS", default="false", boolean=True
+)
+
+DD_FETCH_STEP_FUNCTIONS_TAGS = get_env_var(
+    "DD_FETCH_STEP_FUNCTIONS_TAGS", default="false", boolean=True
+)
+
+
+def get_fetch_s3_tags():
+    return DD_FETCH_S3_TAGS
+
+
+def get_fetch_log_group_tags():
+    return DD_FETCH_LOG_GROUP_TAGS
+
+
+def get_fetch_lambda_tags():
+    return DD_FETCH_LAMBDA_TAGS
+
+
+def get_fetch_step_functions_tags():
+    return DD_FETCH_STEP_FUNCTIONS_TAGS
+
+
 DD_SOURCE = "ddsource"
 DD_CUSTOM_TAGS = "ddtags"
 DD_SERVICE = "service"

--- a/aws/logs_monitoring/tests/test_enrichment.py
+++ b/aws/logs_monitoring/tests/test_enrichment.py
@@ -1,6 +1,9 @@
 import json
+import os
+import sys
 import unittest
-from unittest.mock import MagicMock
+from importlib import reload
+from unittest.mock import MagicMock, patch
 
 from approvaltests.approvals import verify_as_json
 
@@ -181,7 +184,10 @@ class TestLambdaMetadataEnrichment(unittest.TestCase):
         add_metadata_to_lambda_log(event, cache_layer)
         verify_as_json(event)
 
+    @patch.dict(os.environ, {"DD_FETCH_LAMBDA_TAGS": "false"})
     def test_lambda_event_wo_service(self):
+        reload(sys.modules["settings"])
+
         cache_layer = CacheLayer("")
         event = {
             "lambda": {
@@ -191,7 +197,10 @@ class TestLambdaMetadataEnrichment(unittest.TestCase):
         add_metadata_to_lambda_log(event, cache_layer)
         verify_as_json(event)
 
+    @patch.dict(os.environ, {"DD_FETCH_LAMBDA_TAGS": "true"})
     def test_lambda_event_w_custom_tags_wo_service(self):
+        reload(sys.modules["settings"])
+
         cache_layer = CacheLayer("")
         cache_layer._lambda_cache.get = MagicMock(
             return_value=["service:customtags_service"]
@@ -204,7 +213,10 @@ class TestLambdaMetadataEnrichment(unittest.TestCase):
         add_metadata_to_lambda_log(event, cache_layer)
         verify_as_json(event)
 
+    @patch.dict(os.environ, {"DD_FETCH_LAMBDA_TAGS": "true"})
     def test_lambda_event_w_custom_tags_w_service(self):
+        reload(sys.modules["settings"])
+
         cache_layer = CacheLayer("")
         cache_layer._lambda_cache.get = MagicMock(
             return_value=["service:customtags_service"]
@@ -218,7 +230,10 @@ class TestLambdaMetadataEnrichment(unittest.TestCase):
         add_metadata_to_lambda_log(event, cache_layer)
         verify_as_json(event)
 
+    @patch.dict(os.environ, {"DD_FETCH_LAMBDA_TAGS": "false"})
     def test_lambda_event_w_service(self):
+        reload(sys.modules["settings"])
+
         cache_layer = CacheLayer("")
         event = {
             "lambda": {
@@ -229,7 +244,10 @@ class TestLambdaMetadataEnrichment(unittest.TestCase):
         add_metadata_to_lambda_log(event, cache_layer)
         verify_as_json(event)
 
+    @patch.dict(os.environ, {"DD_FETCH_LAMBDA_TAGS": "false"})
     def test_lambda_event_w_service_and_ddtags(self):
+        reload(sys.modules["settings"])
+
         cache_layer = CacheLayer("")
         event = {
             "lambda": {
@@ -241,7 +259,10 @@ class TestLambdaMetadataEnrichment(unittest.TestCase):
         add_metadata_to_lambda_log(event, cache_layer)
         verify_as_json(event)
 
+    @patch.dict(os.environ, {"DD_FETCH_LAMBDA_TAGS": "true"})
     def test_lambda_event_w_custom_tags_env(self):
+        reload(sys.modules["settings"])
+
         cache_layer = CacheLayer("")
         cache_layer._lambda_cache.get = MagicMock(return_value=["env:customtags_env"])
         event = {


### PR DESCRIPTION
### What does this PR do?

Refactor the load of the environment variables related to tags enrichment.

### Motivation

Reduce number of calls to `os.environ` and centralize the value into the settings.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
