### PR TITLE
Update function template to enforce HTTPS and remove CORS

### DIFF
--- a/azure/eventhub_log_forwarder/function_template.json
+++ b/azure/eventhub_log_forwarder/function_template.json
@@ -92,12 +92,8 @@
       "properties": {
         "name": "[parameters('functionAppName')]",
         "clientAffinityEnabled": false,
+        "httpsOnly": true,
         "siteConfig": {
-          "cors": {
-            "allowedOrigins": [
-              "*"
-            ]
-          },
           "appSettings": [
             {
               "name": "FUNCTIONS_EXTENSION_VERSION",


### PR DESCRIPTION
**Still requires testing**

### What does this PR do?

Removed CORS configuration and enforced HTTPS.
To my knowledge, this function app is not intended to be reachable by a browser, and should only be accessed over HTTPS (though I'm not sure it should even allow inbound HTTP(S) traffic at all?). 

### Motivation

Our security scanner was throwing some warnings (also about not using managed identities). 

### Testing Guidelines

I could not run this easily as the template refers to the online scripts and tough to run locally without publishing somewhere. **Still requires testing**

### Additional Notes

I wonder if a guidance on how to create and setup the various resources would be more helpful. For example, we have pretty strict requirements for using managed identities, private links between all resources etc. Because it's all in JSON files it's a bit tough to find out what details are crucial, and which aren't. For example, why does the function app accept http? Maybe the event hub forwards it over http or perhaps it's just a side effect of not locking http down. What is stored in the storage account and by whom and could it use a managed identity? I can of course spend the time digging deep into this. We use Bicep to provision (which can just consume your templates, which is very easy, but it means it's also a bit tougher to realize the conversion when you don't know the requirements of the various resources). I'd be happy to pair with someone on your team to get this working in Bicep locked down to our environment so we can verify these requirements for other customers.

### Types of changes

- [x] Bug fix

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)

