### PR TITLE
(Azure) Resolve invalid JSON Object under properties field

### DIFF
--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -396,12 +396,15 @@ class EventhubLogHandler {
                 // If the check is true, find and replace single quotes
                 // with double quotes, to make a proper JSON
                 // which is then converted into a JSON Object
-                parsedProperties = JSON.parse(record.properties.replace(/'/g, '"'));
-                record.properties = parsedProperties;
+                record.properties = JSON.parse(record.properties.replace(/'/g, '"'));
+                return record;
             } catch {
                 this.context.error('Unable to fix properties field to JSON Object');
+                return record;
             }
-        return record;
+        } else {
+            return record;
+        }
     }
 
     handleLogs(logs) {

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -381,11 +381,35 @@ class EventhubLogHandler {
                     this.records.push(originalRecord);
                 }
             } else {
-                this.records.push(originalRecord);
+                this.records.push(this.fixPropertiesJsonString(originalRecord));
             }
         } else {
             record = this.addTagsToStringLog(record);
             this.records.push(record);
+        }
+    }
+
+    fixPropertiesJsonString(record) {
+        try {
+            // Check if properties field is a string
+            if (typeof record.properties === 'string') {
+                // If it is a string, check if it is a malformed JSON String
+                // By checking for ':'
+                if (record.properties.includes("':'")) {
+                    // If the check is true, find / replace single quotes
+                    // with double quotes, to make a proper JSON
+                    // which is then converted into a JSON Object
+                    record.properties = JSON.parse(record.properties.replace(/'/g, '"'));
+                    return record;
+                }else {
+                    return record;
+                }
+            } else {
+                return record;
+            }
+        } catch {
+            this.context.error('Unable to fix properties field to JSON Object');
+            return record;
         }
     }
 

--- a/azure/activity_logs_monitoring/index.js
+++ b/azure/activity_logs_monitoring/index.js
@@ -390,27 +390,18 @@ class EventhubLogHandler {
     }
 
     fixPropertiesJsonString(record) {
-        try {
-            // Check if properties field is a string
-            if (typeof record.properties === 'string') {
-                // If it is a string, check if it is a malformed JSON String
-                // By checking for ':'
-                if (record.properties.includes("':'")) {
-                    // If the check is true, find / replace single quotes
-                    // with double quotes, to make a proper JSON
-                    // which is then converted into a JSON Object
-                    record.properties = JSON.parse(record.properties.replace(/'/g, '"'));
-                    return record;
-                }else {
-                    return record;
-                }
-            } else {
-                return record;
+        // Check if properties field is a malformed JSON String
+        if (Object.hasOwn(record, 'properties') && (typeof record.properties === 'string') && (record.properties.includes("':'"))) {
+            try {
+                // If the check is true, find and replace single quotes
+                // with double quotes, to make a proper JSON
+                // which is then converted into a JSON Object
+                parsedProperties = JSON.parse(record.properties.replace(/'/g, '"'));
+                record.properties = parsedProperties;
+            } catch {
+                this.context.error('Unable to fix properties field to JSON Object');
             }
-        } catch {
-            this.context.error('Unable to fix properties field to JSON Object');
-            return record;
-        }
+        return record;
     }
 
     handleLogs(logs) {

--- a/azure/test/activity_logs_monitoring.test.js
+++ b/azure/test/activity_logs_monitoring.test.js
@@ -827,6 +827,43 @@ describe('EventhubLogHandler Fix Properties Json String', function() {
 	it('parses properties string with single quotes into object', function() {
 		const record = { properties: "{'key':'value'}" };
         const result = this.forwarder.fixPropertiesJsonString(record);
+
+        const expectedProperties = { properties: { key: "value" } };
+
+        assert.deepEqual(
+            expectedProperties,
+            result
+        );
+        assert.equal(
+            'object',
+            typeof result.properties
+        )
+	});
+
+    it('parses object that doesnt have properties', function() {
+		const record = { hostname: "server_name", subObject: { key:"value"} };
+        const result = this.forwarder.fixPropertiesJsonString(record);
+
+        assert.deepEqual(
+            record,
+            result
+        );
+        assert.equal(
+            'object',
+            typeof result
+        )
+	});
+
+	it('parses properties string with nested objects', function() {
+		const record = { properties: "{'key':'value','subObj':{ 'subKey' : 'subValue' }}" };
+        const result = this.forwarder.fixPropertiesJsonString(record);
+
+        const expectedProperties = { properties: { key: "value", subObj: { subKey: "subValue"} } };
+
+        assert.deepEqual(
+            expectedProperties,
+            result
+        );
         assert.equal(
             'object',
             typeof result.properties
@@ -836,6 +873,11 @@ describe('EventhubLogHandler Fix Properties Json String', function() {
 	it("leaves properties string unchanged when it doesn't match the malformed pattern", function() {
 		const record = { properties: 'some plain string without colons' };
 		const result = this.forwarder.fixPropertiesJsonString(record);
+
+        assert.deepEqual(
+            record,
+            result
+        );
         assert.equal(
             'string',
             typeof result.properties
@@ -846,6 +888,11 @@ describe('EventhubLogHandler Fix Properties Json String', function() {
 		// includes the "':'" marker so the function attempts replacement, but JSON remains invalid
 		const badRecord = { properties: "Look i know i shouldn't but, i will do this ':' " };
 		const result = this.forwarder.fixPropertiesJsonString(badRecord);
+        
+        assert.deepEqual(
+            badRecord,
+            result
+        );
         assert.equal(
             'string',
             typeof result.properties

--- a/azure/test/activity_logs_monitoring.test.js
+++ b/azure/test/activity_logs_monitoring.test.js
@@ -818,3 +818,37 @@ describe('Log Splitting', function() {
         });
     });
 });
+describe('EventhubLogHandler Fix Properties Json String', function() {
+	
+    beforeEach(function() {
+        this.forwarder = setUp();
+    });
+
+	it('parses properties string with single quotes into object', function() {
+		const record = { properties: "{'key':'value'}" };
+        const result = this.forwarder.fixPropertiesJsonString(record);
+        assert.equal(
+            'object',
+            typeof result.properties
+        )
+	});
+
+	it("leaves properties string unchanged when it doesn't match the malformed pattern", function() {
+		const record = { properties: 'some plain string without colons' };
+		const result = this.forwarder.fixPropertiesJsonString(record);
+        assert.equal(
+            'string',
+            typeof result.properties
+        )
+	});
+
+	it('logs an error and returns original record when replacement results in invalid JSON', function() {
+		// includes the "':'" marker so the function attempts replacement, but JSON remains invalid
+		const badRecord = { properties: "Look i know i shouldn't but, i will do this ':' " };
+		const result = this.forwarder.fixPropertiesJsonString(badRecord);
+        assert.equal(
+            'string',
+            typeof result.properties
+        )
+	});
+});


### PR DESCRIPTION
### What does this PR do?

Added a function call `fixPropertiesJsonString`, that works on converting malformed JSON String that is part of the properties field into a proper JSON object. This issue is documented in the follow [Microsoft Post](https://learn.microsoft.com/en-us/answers/questions/1001797/invalid-json-logs-produced-for-function-apps).

### Motivation

This will allow Datadog Log Processor to extract the proper message and log level field. This fixes issue #1014 

### Testing Guidelines

It has been tested in two manners:
- Tested in my Datadog Instance
- Test cases have been created under `EventhubLogHandler Fix Properties Json String`

### Additional Notes

This issue is documented in the follow [Microsoft Post](https://learn.microsoft.com/en-us/answers/questions/1001797/invalid-json-logs-produced-for-function-apps).

### Types of changes

- [x] Bug fix

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
