### PR TITLE
AWS KMS.1 compliant policy with dedicated kms key list

### DIFF
--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -289,6 +289,9 @@ Parameters:
       - "true"
       - "false"
     Description: Set to true to enable enhanced Lambda metrics. This will generate additional custom metrics for Lambda functions, including cold starts, estimated AWS costs, and custom tags. Default is false.
+  KmsKeyList:
+    Type: CommaDelimitedList
+    Description: List of KMS Key ARNs the Lambda forwarder function can use to decrypt, seperated by comma  
 Conditions:
   IsAWSChina: !Equals [!Ref "AWS::Partition", aws-cn]
   IsGovCloud: !Equals [!Ref "AWS::Partition", aws-us-gov]
@@ -378,6 +381,8 @@ Conditions:
     - !Equals [!Join ["", !Ref VPCSubnetIds], ""]
   SetDdLogLevel: !Not
     - !Equals [!Ref DdLogLevel, ""]
+  SetDdForwarderDecrypt: !Not
+    - !Equals [!Join ["", !Ref KmsKeyList], ""]
 Rules:
   MustSetDdApiKey:
     Assertions:
@@ -654,10 +659,13 @@ Resources:
                 Effect: Allow
               # To get object from encrypted s3 buckets. Use PermissionsBoundaryArn to limit access if needed.
               # https://aws.amazon.com/premiumsupport/knowledge-center/s3-troubleshoot-403/#AWS_KMS_encryption
-              - Action:
-                  - kms:Decrypt
-                Resource: "*"
-                Effect: Allow
+              - !If
+                - SetDdForwarderDecrypt
+                - Action:
+                    - kms:Decrypt
+                  Resource: !Ref KmsKeyList
+                  Effect: Allow
+                - !Ref AWS::NoValue
               - !If
                 - SetDDApiSsmParamName # Access the Datadog API key from Secrets Manager
                 - !Ref AWS::NoValue

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -291,6 +291,7 @@ Parameters:
     Description: Set to true to enable enhanced Lambda metrics. This will generate additional custom metrics for Lambda functions, including cold starts, estimated AWS costs, and custom tags. Default is false.
   KmsKeyList:
     Type: CommaDelimitedList
+    Default: ""
     Description: List of KMS Key ARNs the Lambda forwarder function can use to decrypt, seperated by comma  
 Conditions:
   IsAWSChina: !Equals [!Ref "AWS::Partition", aws-cn]
@@ -381,7 +382,7 @@ Conditions:
     - !Equals [!Join ["", !Ref VPCSubnetIds], ""]
   SetDdLogLevel: !Not
     - !Equals [!Ref DdLogLevel, ""]
-  SetDdForwarderDecrypt: !Not
+  SetDdForwarderDecryptKeys: !Not
     - !Equals [!Join ["", !Ref KmsKeyList], ""]
 Rules:
   MustSetDdApiKey:
@@ -659,13 +660,13 @@ Resources:
                 Effect: Allow
               # To get object from encrypted s3 buckets. Use PermissionsBoundaryArn to limit access if needed.
               # https://aws.amazon.com/premiumsupport/knowledge-center/s3-troubleshoot-403/#AWS_KMS_encryption
-              - !If
-                - SetDdForwarderDecrypt
-                - Action:
-                    - kms:Decrypt
-                  Resource: !Ref KmsKeyList
-                  Effect: Allow
-                - !Ref AWS::NoValue
+              - Action:
+                  - kms:Decrypt
+                Resource: !If
+                  - SetDdForwarderDecryptKeys
+                  - !Ref KmsKeyList
+                  - "*"
+                Effect: Allow
               - !If
                 - SetDDApiSsmParamName # Access the Datadog API key from Secrets Manager
                 - !Ref AWS::NoValue


### PR DESCRIPTION
### What does this PR do?

Adding an input parameter **KmsKeyList** to the CFN template.yaml to define a comma seperated list of KMS Key ARNs.
That list will be used to tailor kms:decrypt resource access in the IAM policy of the datadog serverless forwarder.

### Motivation

AWS security Hub finding KMS.1 as well as CKV_AWS_356 in the default template.
Having wildcard permissions on all AWS KMS keys is a security issue. 
Allowing access to only dedicated KMS keys keeps the setup secure.
Keys using default encryption aws/secretsmanager are accessible by default.

### Testing Guidelines

### Additional Notes
While the original CFN template contains a wildcard permission for "customer managed" keys, integrating this version will break access to those CMKs, if they are not listed in the parameter.

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
