### PR TITLE
fix(azure): Add security properties to ARM template for policy compliance

### DIFF
--- a/azure/eventhub_log_forwarder/function_template.json
+++ b/azure/eventhub_log_forwarder/function_template.json
@@ -77,7 +77,9 @@
         "name": "Standard_LRS"
       },
       "properties": {
-        "minimumTlsVersion": "TLS1_2"
+        "minimumTlsVersion": "TLS1_2",
+        "supportsHttpsTrafficOnly": true,
+        "allowBlobPublicAccess": false
       }
     },
     {
@@ -92,6 +94,7 @@
       "properties": {
         "name": "[parameters('functionAppName')]",
         "clientAffinityEnabled": false,
+        "httpsOnly": true,
         "siteConfig": {
           "cors": {
             "allowedOrigins": [


### PR DESCRIPTION

Added required security properties to fix Azure policy violations:
- Storage account: supportsHttpsTrafficOnly and allowBlobPublicAccess
- Function app: httpsOnly property

These changes ensure compliance with storage-secure-transfer, storage-no-anonymous, and functionapp-https policies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### Motivation

<!--- What inspired you to submit this pull request? --->
We have policies in place that prevent testing our event hub forwarder

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
