### PR TITLE
feat(aws): AWSX-2034 Continue if we fail to validate api key but storage of failed event enabled

### DIFF
--- a/.github/workflows/aws_unit_test.yml
+++ b/.github/workflows/aws_unit_test.yml
@@ -18,6 +18,7 @@ jobs:
           AWS_DEFAULT_REGION: us-east-1
           DD_API_KEY: "11111111111111111111111111111111"
           DD_ADDITIONAL_TARGET_LAMBDAS: "ironmaiden,megadeth"
+          DD_STORE_FAILED_EVENTS: "true"
         run: |
           pip install boto3 mock approvaltests
           python -m unittest discover ./aws/logs_monitoring/

--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -95,7 +95,7 @@ If you can't install the Forwarder using the provided CloudFormation template, y
 8. Set environment variable `DD_STORE_FAILED_EVENTS` to `true` to enable the forwarder to also store event data in the S3 bucket. In case of exceptions when sending logs, metrics or traces to intake, the forwarder will store relevant data in the S3 bucket. On custom invocations i.e. on receiving an event with the `retry` keyword set to a non empty string (which can be manually triggered - see below), the forwarder will retry sending the stored events. When successful it will clear up the storage in the bucket.
 
 ```bash
-aws lambda invoke --function-name <function-name> --payload '{"retry":"true"}' out
+aws lambda invoke --function-name <function-name> --payload '{"retry":"true"}' --cli-binary-format raw-in-base64-out --log-type Tail /dev/stdout
 ```
 
 <div class="alert alert-warning">

--- a/aws/logs_monitoring/forwarder.py
+++ b/aws/logs_monitoring/forwarder.py
@@ -128,6 +128,9 @@ class Forwarder(object):
         if DD_STORE_FAILED_EVENTS and len(failed_logs) > 0 and not key:
             self.storage.store_data(RetryPrefix.LOGS, failed_logs)
 
+        if len(failed_logs) > 0:
+            send_event_metric("logs_failed", failed_logs)
+
         send_event_metric("logs_forwarded", len(logs_to_forward) - len(failed_logs))
 
     def _forward_metrics(self, metrics, key=None):
@@ -155,6 +158,9 @@ class Forwarder(object):
 
         if DD_STORE_FAILED_EVENTS and len(failed_metrics) > 0 and not key:
             self.storage.store_data(RetryPrefix.METRICS, failed_metrics)
+
+        if len(failed_metrics) > 0:
+            send_event_metric("metrics_failed", failed_metrics)
 
         send_event_metric("metrics_forwarded", len(metrics) - len(failed_metrics))
 

--- a/aws/logs_monitoring/logs/datadog_http_client.py
+++ b/aws/logs_monitoring/logs/datadog_http_client.py
@@ -68,6 +68,7 @@ class DatadogHTTPClient(object):
         self._session = None
         self._ssl_validation = not skip_ssl_validation
         self._futures = []
+
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(
                 f"Initialized http client for logs intake: "

--- a/aws/logs_monitoring/tests/run_unit_tests.sh
+++ b/aws/logs_monitoring/tests/run_unit_tests.sh
@@ -2,5 +2,6 @@
 
 export DD_API_KEY=11111111111111111111111111111111
 export DD_ADDITIONAL_TARGET_LAMBDAS=ironmaiden,megadeth
+export DD_STORE_FAILED_EVENTS="true"
 export DD_S3_BUCKET_NAME=dd-s3-bucket
 python3 -m unittest discover .

--- a/aws/logs_monitoring/tools/integration_tests/docker-compose.yml
+++ b/aws/logs_monitoring/tools/integration_tests/docker-compose.yml
@@ -27,50 +27,54 @@ services:
       AWS_SECURITY_TOKEN: "${AWS_SECURITY_TOKEN}"
       AWS_SESSION_TOKEN: "${AWS_SESSION_TOKEN}"
       AWS_DEFAULT_REGION: us-east-1
-      DD_LOG_LEVEL: ${LOG_LEVEL:-info}
-      DD_API_KEY: abcdefghijklmnopqrstuvwxyz012345 # Must be 32 characters exactly
-      DD_URL: recorder # Used for logs intake
-      DD_PORT: 8080 # API port to use
-      DD_SITE: datadog.com
-      DD_API_URL: http://recorder:8080
-      DD_LOGS_INTAKE_URL: recorder:8080
-      DD_TRACE_INTAKE_URL: http://recorder:8080
-      DD_NO_SSL: "true"
-      DD_SKIP_SSL_VALIDATION: "true"
-      DD_USE_COMPRESSION: "false"
       DD_ADDITIONAL_TARGET_LAMBDAS: "${EXTERNAL_LAMBDAS}"
-      DD_S3_BUCKET_NAME: "${DD_S3_BUCKET_NAME}"
+      DD_API_KEY: abcdefghijklmnopqrstuvwxyz012345 # Must be 32 characters exactly
+      DD_API_URL: http://recorder:8080
       DD_FETCH_LAMBDA_TAGS: "${DD_FETCH_LAMBDA_TAGS:-false}"
       DD_FETCH_LOG_GROUP_TAGS: "${DD_FETCH_LOG_GROUP_TAGS:-false}"
       DD_FETCH_STEP_FUNCTIONS_TAGS: "${DD_FETCH_STEP_FUNCTIONS_TAGS:-false}"
-      DD_STORE_FAILED_EVENTS: "false"
+      DD_LOG_LEVEL: ${LOG_LEVEL:-info}
+      DD_LOGS_INTAKE_URL: recorder:8080
+      DD_NO_SSL: "true"
+      DD_PORT: 8080 # API port to use
+      DD_S3_BUCKET_NAME: "${DD_S3_BUCKET_NAME}"
+      DD_SITE: datadog.com
+      DD_SKIP_SSL_VALIDATION: "true"
+      DD_STORE_FAILED_EVENTS: "${DD_STORE_FAILED_EVENTS:-true}"
       DD_TRACE_ENABLED: "true"
+      DD_TRACE_INTAKE_URL: http://recorder:8080
+      DD_URL: recorder # Used for logs intake
+      DD_USE_COMPRESSION: "false"
     expose:
       - 8080
     depends_on:
       recorder:
         condition: service_healthy
     healthcheck:
-        test: ["CMD", "curl", "-f", "http://localhost:8080/2015-03-31/functions/function/invocations"]
-        interval: 10s
-        timeout: 5s
-        retries: 3
-
+      test:
+        [
+          "CMD",
+          "curl",
+          "-f",
+          "http://localhost:8080/2015-03-31/functions/function/invocations",
+        ]
+      interval: 10s
+      timeout: 5s
 
   tester:
     image: ${PYTHON_BASE}
     command: /bin/sh -c 'pip install "deepdiff<6" && python -m unittest discover'
     volumes:
       - ./tester:/tester
-      - ${SNAPSHOTS_DIR_NAME}:/snapshots
+      - "${SNAPSHOTS_DIR_NAME}:/snapshots"
     working_dir: /tester
     environment:
-      RECORDER_URL: http://recorder:8080/recording
       FORWARDER_URL: http://forwarder:8080/2015-03-31/functions/function/invocations
-      UPDATE_SNAPSHOTS: ${UPDATE_SNAPSHOTS:-false}
-      SNAPSHOTS_DIR_NAME: ${SNAPSHOTS_DIR_NAME}
+      RECORDER_URL: http://recorder:8080/recording
+      SNAPSHOTS_DIR_NAME: "${SNAPSHOTS_DIR_NAME}"
+      UPDATE_SNAPSHOTS: "${UPDATE_SNAPSHOTS:-false}"
     depends_on:
-        forwarder:
-            condition: service_healthy
-        recorder:
-            condition: service_healthy
+      forwarder:
+        condition: service_healthy
+      recorder:
+        condition: service_healthy

--- a/aws/logs_monitoring/tools/integration_tests/integration_tests.sh
+++ b/aws/logs_monitoring/tools/integration_tests/integration_tests.sh
@@ -23,6 +23,7 @@ CACHE_TEST=false
 DD_FETCH_LAMBDA_TAGS="true"
 DD_FETCH_LOG_GROUP_TAGS="true"
 DD_FETCH_STEP_FUNCTIONS_TAGS="true"
+DD_STORE_FAILED_EVENTS="true"
 
 script_start_time=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 echo "Starting script time: $script_start_time"
@@ -154,6 +155,7 @@ LOG_LEVEL=${LOG_LEVEL} \
         DD_FETCH_LAMBDA_TAGS=${DD_FETCH_LAMBDA_TAGS} \
         DD_FETCH_LOG_GROUP_TAGS=${DD_FETCH_LOG_GROUP_TAGS} \
         DD_FETCH_STEP_FUNCTIONS_TAGS=${DD_FETCH_STEP_FUNCTIONS_TAGS} \
+        DD_STORE_FAILED_EVENTS=${DD_STORE_FAILED_EVENTS} \
         docker compose up --build --abort-on-container-exit
 
 if [ $ADDITIONAL_LAMBDA == true ]; then

--- a/aws/logs_monitoring/tools/integration_tests/tester/test_snapshots.py
+++ b/aws/logs_monitoring/tools/integration_tests/tester/test_snapshots.py
@@ -13,7 +13,7 @@ forwarder_url = os.environ.get("FORWARDER_URL", default="")
 update_snapshot = os.environ.get("UPDATE_SNAPSHOTS")
 if not update_snapshot:
     update_snapshot = "false"
-update_snapshot = True
+update_snapshot = update_snapshot.lower() == "true"
 
 snapshot_dir = "/snapshots"
 

--- a/aws/logs_monitoring/tools/integration_tests/tester/test_snapshots.py
+++ b/aws/logs_monitoring/tools/integration_tests/tester/test_snapshots.py
@@ -13,7 +13,7 @@ forwarder_url = os.environ.get("FORWARDER_URL", default="")
 update_snapshot = os.environ.get("UPDATE_SNAPSHOTS")
 if not update_snapshot:
     update_snapshot = "false"
-update_snapshot = update_snapshot.lower() == "true"
+update_snapshot = True
 
 snapshot_dir = "/snapshots"
 


### PR DESCRIPTION
The idea is to not fail at the API validation step, at the very beginning of the forwarder, for an external reason.

If we know for sure that the API key is wrong (default of invalid length), we fail as usual. But, if we failed to validate against Datadog API and failed event is enabled, we continue the process and best case scenario, the API verification had a hiccup and logs forwarding just works, or the events will be stored into the S3 bucket to be reprocess later.

When we fail at the very beginning of the forwarder, there is no retry mechanism built-in in Lambda to retry it, so we can lose events for 429 reason for example.

<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
