### PR TITLE
fix(aws): fix broken link in docs

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -23,7 +23,7 @@ For more information about sending AWS services logs with the Datadog Forwarder,
 
 ## Installation
 
-Datadog recommends using [CloudFormation](?tab=cloudformation#cloudformation) to automatically install the Forwarder. You can also complete the setup process using [Terraform](?tab=terraform#terraform) or [manually](?tab=manual#manual). For multi-region or multi-account deployments, see [Multi-Region & Multi-Account](?tab=multiregionmultiaccount#multi-region-multi-account) for CloudFormation StackSets or use the [Terraform](?tab=terraform#terraform) module. Once installed, you can subscribe the Forwarder to log sources such as S3 buckets or CloudWatch log groups by [setting up triggers][4].
+Datadog recommends using [CloudFormation](?tab=cloudformation#cloudformation) to automatically install the Forwarder. You can also complete the setup process using [Terraform](?tab=terraform#terraform) or [manually](?tab=manual#manual). For multi-region or multi-account deployments, see [Multi-Region & Multi-Account](?tab=multiregionmultiaccountawsorganizations#multi-region-multi-account) for CloudFormation StackSets or use the [Terraform](?tab=terraform#terraform) module. Once installed, you can subscribe the Forwarder to log sources such as S3 buckets or CloudWatch log groups by [setting up triggers][4].
 
 **Note**: Forwarder v4.1.0+ does not support x86_64 architecture. If you are using x86_64, you must migrate to ARM64 to use the Datadog Forwarder.
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
Fixes the broken link in docs that is supposed to direct to https://docs.datadoghq.com/logs/guide/forwarder/?tab=multiregionmultiaccountawsorganizations#installation

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
