### PR TITLE
Clarify DdTraceEnabled description

### DIFF
--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -292,7 +292,7 @@ Parameters:
     AllowedValues:
       - "true"
       - "false"
-    Description: Set to false to disable trace creation and forwarding. See https://docs.datadoghq.com/tracing/trace_collection/library_config/python/#traces
+    Description: Set to false to disable trace creation and forwarding for the forwarder itself. Enabling this may incur additional Serverless APM charges. See https://docs.datadoghq.com/tracing/trace_collection/library_config/python/#traces
   DdEnhancedMetrics:
     Type: String
     Default: "false"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"bee493f0-04a8-4886-a532-1de7d050ec0f","source":"chat","resourceId":"589c4ba0-1bcc-4b13-96b2-190e3016288d","workflowId":"dd77c393-3ba3-4e1c-b0ae-777b23342f6f","codeChangeId":"dd77c393-3ba3-4e1c-b0ae-777b23342f6f","sourceType":"chat"} -->
PR by Bits from Dev Agent Session
[View Dev Agent Session](https://app.datadoghq.com/code/589c4ba0-1bcc-4b13-96b2-190e3016288d)

You can ask for changes by mentioning @datadog in a comment.

Feedback (especially what can be better) welcome in [#code-gen-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

### What does this PR do?
Clarifies the DdTraceEnabled parameter description to note it controls tracing for the forwarder itself and that enabling it may incur Serverless APM charges.

### Motivation
Provide clearer guidance to avoid unexpected tracing charges for customers.

### Testing Guidelines
Not applicable (documentation-only change).

### Additional Notes
None.

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)