### PR TITLE
ci(docker): Make apple container usable in place of docker

### DIFF
--- a/aws/logs_monitoring/tools/build_bundle.sh
+++ b/aws/logs_monitoring/tools/build_bundle.sh
@@ -53,6 +53,21 @@ make_path_absolute() {
     )/$(basename "$1")"
 }
 
+# Make us of Docker or apple/container seamless
+docker_build() {
+    docker buildx build "${@}"
+}
+
+if command -v container >/dev/null 2>&1; then
+    docker() {
+        container "${@}"
+    }
+
+    docker_build() {
+        container build "${@}"
+    }
+fi
+
 ../trace_forwarder/scripts/build_linux_go_bin.sh
 
 docker_build_zip() {
@@ -64,7 +79,7 @@ docker_build_zip() {
     # between different python runtimes.
     temp_dir=$(mktemp -d)
 
-    docker buildx build --platform linux/arm64 --file "${DIR}/Dockerfile_bundle" -t "datadog-bundle:$1" .. --no-cache --build-arg "runtime=${PYTHON_VERSION}"
+    docker_build --platform linux/arm64 --file "${DIR}/Dockerfile_bundle" -t "datadog-bundle:$1" .. --no-cache --build-arg "runtime=${PYTHON_VERSION}"
 
     # Run the image by runtime tag, tar its generated `python` directory to sdout,
     # then extract it to a temp directory.

--- a/aws/logs_monitoring/trace_forwarder/scripts/build_linux_go_bin.sh
+++ b/aws/logs_monitoring/trace_forwarder/scripts/build_linux_go_bin.sh
@@ -13,14 +13,27 @@ cd $(dirname "$0")/..
 
 rm -rf ./bin
 
+# Make us of Docker or apple/container seamless
+docker_build() {
+    docker buildx build "${@}"
+}
+
+if command -v container >/dev/null 2>&1; then
+    docker() {
+        container "${@}"
+    }
+
+    docker_build() {
+        container build "${@}"
+    }
+fi
+
 # Install datadogpy in a docker container to avoid the mess from switching
 # between different python runtimes.
 
 if [[ $(docker image ls | grep -c golang) -lt 1 ]]; then
-    docker buildx build --platform linux/arm64 -t golang . --no-cache --build-arg "runtime=python:3.13"
+    docker_build --platform linux/arm64 -t golang . --no-cache --build-arg "runtime=python:3.13"
 fi
 
-id=$(docker create --platform linux/arm64 golang)
-docker cp "${id}:/go/src/github.com/DataDog/datadog-serverless-functions/aws/logs_monitoring/trace_forwarder/bin" .
-docker rm -v "${id}"
+docker run --rm --platform linux/arm64 --volume "$(pwd):/root/bin" golang cp -r /go/src/github.com/DataDog/datadog-serverless-functions/aws/logs_monitoring/trace_forwarder/bin /root/bin
 echo "Done creating archive bin"


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

This pull-request make the building script compatible with the [apple/container](https://github.com/apple/container) which is not a drop-in replacement of `docker` for macOS user.

### Motivation

Having a build script that work with regular docker or `container` on macOS.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
