### PR TITLE
[AWSX] fix(logs forwarder): Bump datadog-lambda and ddtrace packages versions

### DIFF
--- a/aws/logs_monitoring/requirements.txt
+++ b/aws/logs_monitoring/requirements.txt
@@ -3,10 +3,10 @@ bytecode
 cattrs
 certifi
 charset-normalizer
-datadog-lambda==6.107.0
+datadog-lambda==8.120.0
 datadog==0.52.0
 ddsketch==3.0.1
-ddtrace==3.10.2
+ddtrace==3.16.2
 deprecated
 envier
 exceptiongroup

--- a/aws/logs_monitoring/telemetry.py
+++ b/aws/logs_monitoring/telemetry.py
@@ -56,6 +56,4 @@ def send_log_metric(metric):
     if not DD_SUBMIT_ENHANCED_METRICS:
         return
 
-    lambda_metric(
-        metric["m"], metric["v"], timestamp=metric["e"], tags=metric["t"]
-    )
+    lambda_metric(metric["m"], metric["v"], timestamp=metric["e"], tags=metric["t"])

--- a/aws/logs_monitoring/telemetry.py
+++ b/aws/logs_monitoring/telemetry.py
@@ -4,7 +4,7 @@
 # Copyright 2021 Datadog, Inc.
 
 try:
-    from datadog_lambda.metric import lambda_stats
+    from datadog_lambda.metric import lambda_metric
 
     DD_SUBMIT_ENHANCED_METRICS = True
 except ImportError:
@@ -34,7 +34,7 @@ def send_forwarder_internal_metrics(name, additional_tags=[]):
         return
 
     """Send forwarder's internal metrics to DD"""
-    lambda_stats.distribution(
+    lambda_metric(
         "{}.{}".format(DD_FORWARDER_TELEMETRY_NAMESPACE_PREFIX, name),
         1,
         tags=DD_FORWARDER_TELEMETRY_TAGS + additional_tags,
@@ -45,7 +45,7 @@ def send_event_metric(metric_name, metric_value):
     if not DD_SUBMIT_ENHANCED_METRICS:
         return
 
-    lambda_stats.distribution(
+    lambda_metric(
         "{}.{}".format(DD_FORWARDER_TELEMETRY_NAMESPACE_PREFIX, metric_name),
         metric_value,
         tags=DD_FORWARDER_TELEMETRY_TAGS,
@@ -56,6 +56,6 @@ def send_log_metric(metric):
     if not DD_SUBMIT_ENHANCED_METRICS:
         return
 
-    lambda_stats.distribution(
+    lambda_metric(
         metric["m"], metric["v"], timestamp=metric["e"], tags=metric["t"]
     )

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_customized_log_group_lambda_invocation.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_customized_log_group_lambda_invocation.json~snapshot
@@ -101,7 +101,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -115,7 +116,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -129,7 +131,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -143,7 +146,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -157,7 +161,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -171,7 +176,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           }

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log.json~snapshot
@@ -74,7 +74,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -88,7 +89,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -102,7 +104,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -116,7 +119,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -130,7 +134,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -144,7 +149,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           }

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_cloudtrail.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_cloudtrail.json~snapshot
@@ -110,7 +110,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -124,7 +125,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -138,7 +140,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -152,7 +155,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -166,7 +170,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -180,7 +185,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           }

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_coldstart.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_coldstart.json~snapshot
@@ -13,7 +13,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -27,7 +28,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -41,7 +43,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -55,7 +58,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -69,7 +73,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -83,7 +88,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -97,7 +103,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           }

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_custom_tags.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_custom_tags.json~snapshot
@@ -56,7 +56,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -70,7 +71,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -84,7 +86,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -98,7 +101,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           }

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_lambda_invocation.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_lambda_invocation.json~snapshot
@@ -728,7 +728,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -742,7 +743,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -756,7 +758,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -770,7 +773,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -784,7 +788,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -798,7 +803,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -812,7 +818,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -836,7 +843,8 @@
               "aws_account:012345678912",
               "functionname:hello-dog-node-dev-hello12x",
               "region:us-east-1",
-              "service:hello-dog-node-dev-hello12x"
+              "service:hello-dog-node-dev-hello12x",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -855,7 +863,8 @@
               "aws_account:012345678912",
               "functionname:hello-dog-node-dev-hello12x",
               "region:us-east-1",
-              "service:hello-dog-node-dev-hello12x"
+              "service:hello-dog-node-dev-hello12x",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_service_tag.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_service_tag.json~snapshot
@@ -56,7 +56,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -70,7 +71,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -84,7 +86,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -98,7 +101,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           }

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_timeout.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_timeout.json~snapshot
@@ -122,7 +122,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -136,7 +137,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -150,7 +152,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -164,7 +167,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/step_functions_log.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/step_functions_log.json~snapshot
@@ -56,7 +56,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -70,7 +71,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -84,7 +86,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -98,7 +101,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -112,7 +116,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           },
@@ -126,7 +131,8 @@
               "forwardername:test_function",
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs"
+              "event_type:awslogs",
+              "dd_lambda_layer:datadog-python313_8.120.0"
             ],
             "type": "distribution"
           }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Bump the version of datadog-lambda and ddtrace to the latest available 

We've previously downgraded datadog-lambda package version https://github.com/DataDog/datadog-serverless-functions/pull/972 due to a bug in loading dependencies on the latter's side.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
