### PR TITLE
[AWSX] fix(logs fowarder): Bump urllib3  version - CVE-2026-21441

### DIFF
--- a/aws/logs_monitoring/requirements.txt
+++ b/aws/logs_monitoring/requirements.txt
@@ -19,7 +19,7 @@ requests
 setuptools>=80.9.0
 six
 typing-extensions
-urllib3>=2.6.0,<3.0
+urllib3>=2.6.3,<3.0
 wrapt==1.14.0
 xmltodict
 zipp


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Bump `urllib3` version to `2.6.3`

### Motivation

https://nvd.nist.gov/vuln/detail/CVE-2026-21441

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
