### PR TITLE
Patch 1

### DIFF
--- a/aws/logs_monitoring/steps/enrichment.py
+++ b/aws/logs_monitoring/steps/enrichment.py
@@ -161,7 +161,9 @@ def extract_ddtags_from_message(event):
         extracted_ddtags = extracted_ddtags.replace(" ", "")
 
         # Extract service tag from message.ddtags if exists
-        service_tags = [tag for tag in extracted_ddtags.split(",") if tag.startswith("service:")]
+        service_tags = [
+            tag for tag in extracted_ddtags.split(",") if tag.startswith("service:")
+        ]
         if service_tags:
             event[DD_SERVICE] = service_tags[0][8:]
             event[DD_CUSTOM_TAGS] = ",".join(

--- a/aws/logs_monitoring/steps/enrichment.py
+++ b/aws/logs_monitoring/steps/enrichment.py
@@ -161,12 +161,9 @@ def extract_ddtags_from_message(event):
         extracted_ddtags = extracted_ddtags.replace(" ", "")
 
         # Extract service tag from message.ddtags if exists
-        if "service:" in extracted_ddtags:
-            event[DD_SERVICE] = next(
-                tag[8:]
-                for tag in extracted_ddtags.split(",")
-                if tag.startswith("service:")
-            )
+        service_tags = [tag for tag in extracted_ddtags.split(",") if tag.startswith("service:")]
+        if service_tags:
+            event[DD_SERVICE] = service_tags[0][8:]
             event[DD_CUSTOM_TAGS] = ",".join(
                 [
                     tag


### PR DESCRIPTION
### What does this PR do?

This change swaps the check to use the same split/startswith functionality that's used inside the conditional.

### Motivation

extract_ddtags_from_message checks for a service tag override using `if "service:" in` which returns true if there's a tag key that ends with `service`, eg `mail_send_service:production`.

This causes the lambda to enter the conditional to extract the tag to a first class datadog tag, but the enclosed logic includes a non-defaulted generator which checks for `startswith("service:")`. Since this second check does _not_ match the example, the generator has no elements, and the call to `next` causes the lambda to crash. 

### Testing Guidelines

Added a unit test that fails on main in the same way we experienced in prod. The test passes with this change.

### Additional Notes

Logs from the lambda when this crash occurred in our prod environment:

[ERROR] StopIteration
Traceback (most recent call last):
  File "/opt/python/datadog_lambda/wrapper.py", line 239, in __call__
    """Executes when the wrapped function gets called"""
  File "/opt/python/ddtrace/contrib/internal/aws_lambda/patch.py", line 119, in __call__
    self.response = self.func(*args, **kwargs)
  File "/opt/python/datadog_lambda/wrapper.py", line 242, in __call__
    self.response = self.func(event, context, **kwargs)
  File "/opt/python/lambda_function.py", line 85, in datadog_forwarder
    enriched = enrich(parsed, cache_layer)
  File "/opt/python/steps/enrichment.py", line 30, in enrich
    extract_ddtags_from_message(event)
  File "/opt/python/steps/enrichment.py", line 171, in extract_ddtags_from_message
    event[DD_SERVICE] = next(

NB: The log was cut off like that in cloudwatch.

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
