### PR TITLE
[AWSX] fix(logs forwarder): Update docs on trace forwarding

### DIFF
--- a/aws/logs_monitoring/enhanced_lambda_metrics.py
+++ b/aws/logs_monitoring/enhanced_lambda_metrics.py
@@ -85,7 +85,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.getLevelName(os.environ.get("DD_LOG_LEVEL", "INFO").upper()))
 
 try:
-    from datadog_lambda.metric import lambda_stats
+    from datadog_lambda.metric import lambda_metric
 
     DD_SUBMIT_ENHANCED_METRICS = True
 except ImportError:
@@ -136,9 +136,7 @@ class DatadogMetricPoint(object):
         logger.debug(
             "Submitting metric {} {} {}".format(self.name, self.value, self.tags)
         )
-        lambda_stats.distribution(
-            self.name, self.value, timestamp=timestamp, tags=self.tags
-        )
+        lambda_metric(self.name, self.value, timestamp=timestamp, tags=self.tags)
 
 
 def get_last_modified_time(s3_file):

--- a/aws/logs_monitoring/forwarder.py
+++ b/aws/logs_monitoring/forwarder.py
@@ -144,7 +144,7 @@ class Forwarder(object):
     def _forward_metrics(self, metrics, key=None):
         """
         Forward custom metrics submitted via logs to Datadog in a background thread
-        using `lambda_stats` that is provided by the Datadog Python Lambda Layer.
+        using `lambda_metric` that is provided by the Datadog Python Lambda Layer.
         """
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(f"Forwarding {len(metrics)} metrics")

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -292,11 +292,13 @@ Parameters:
       - CRITICAL
   DdTraceEnabled:
     Type: String
-    Default: "true"
+    Default: "false"
     AllowedValues:
       - "true"
       - "false"
-    Description: Set to false to disable trace creation and forwarding for the forwarder itself. Enabling this may incur additional Serverless APM charges. See https://docs.datadoghq.com/tracing/trace_collection/library_config/python/#traces
+    Description: Set to false to disable trace creation for the forwarder itself.
+    Lambda forwarder should be instrumented to forward these traces to Datadog, see https://docs.datadoghq.com/serverless/aws_lambda/.
+    Enabling this may incur additional Serverless APM charges. See https://docs.datadoghq.com/tracing/trace_collection/library_config/python/#traces.
   DdEnhancedMetrics:
     Type: String
     Default: "false"

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -296,9 +296,10 @@ Parameters:
     AllowedValues:
       - "true"
       - "false"
-    Description: Set to true to enable trace creation for the forwarder itself.
-    Lambda forwarder should be instrumented to forward these traces to Datadog, see https://docs.datadoghq.com/serverless/aws_lambda/.
-    Enabling this may incur additional Serverless APM charges. See https://docs.datadoghq.com/tracing/trace_collection/library_config/python/#traces.
+    Description: |
+      Set to true to enable trace creation for the forwarder itself.
+      Lambda forwarder should be instrumented to forward these traces to Datadog, see https://docs.datadoghq.com/serverless/aws_lambda/.
+      Enabling this may incur additional Serverless APM charges. See https://docs.datadoghq.com/tracing/trace_collection/library_config/python/#traces.
   DdEnhancedMetrics:
     Type: String
     Default: "false"

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -296,7 +296,7 @@ Parameters:
     AllowedValues:
       - "true"
       - "false"
-    Description: Set to false to disable trace creation for the forwarder itself.
+    Description: Set to true to enable trace creation for the forwarder itself.
     Lambda forwarder should be instrumented to forward these traces to Datadog, see https://docs.datadoghq.com/serverless/aws_lambda/.
     Enabling this may incur additional Serverless APM charges. See https://docs.datadoghq.com/tracing/trace_collection/library_config/python/#traces.
   DdEnhancedMetrics:

--- a/aws/logs_monitoring/tools/integration_tests/docker-compose.yml
+++ b/aws/logs_monitoring/tools/integration_tests/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   recorder:
     image: ${PYTHON_BASE}

--- a/aws/logs_monitoring/tools/integration_tests/integration_tests.sh
+++ b/aws/logs_monitoring/tools/integration_tests/integration_tests.sh
@@ -20,10 +20,10 @@ SNAPSHOT_DIR="${INTEGRATION_TESTS_DIR}/${SNAPSHOTS_DIR_NAME}/*"
 SNAPS=($SNAPSHOT_DIR)
 ADDITIONAL_LAMBDA=false
 CACHE_TEST=false
-DD_FETCH_LAMBDA_TAGS="true"
-DD_FETCH_LOG_GROUP_TAGS="true"
-DD_FETCH_STEP_FUNCTIONS_TAGS="true"
-DD_STORE_FAILED_EVENTS="true"
+DD_FETCH_LAMBDA_TAGS="false"
+DD_FETCH_LOG_GROUP_TAGS="false"
+DD_FETCH_STEP_FUNCTIONS_TAGS="false"
+DD_STORE_FAILED_EVENTS="false"
 
 script_start_time=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 echo "Starting script time: $script_start_time"
@@ -85,6 +85,8 @@ if [ $CACHE_TEST == true ]; then
 
         SNAPSHOTS_DIR_NAME="snapshots-cache-test"
         DD_FETCH_LAMBDA_TAGS="true"
+        DD_FETCH_LOG_GROUP_TAGS="true"
+        DD_FETCH_STEP_FUNCTIONS_TAGS="true"
 
         # Deploy test lambda function with tags
         AWS_LAMBDA_FUNCTION_INVOKED="cache_test_lambda"

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_customized_log_group_lambda_invocation.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_customized_log_group_lambda_invocation.json~snapshot
@@ -95,51 +95,6 @@
             "device": null,
             "host": null,
             "interval": 10,
-            "metric": "aws.dd_forwarder.loggroup_cache_fetch_failure",
-            "points": "<redacted from snapshot>",
-            "tags": [
-              "forwardername:test_function",
-              "forwarder_memorysize:3008",
-              "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs",
-              "dd_lambda_layer:<redacted from snapshot>"
-            ],
-            "type": "distribution"
-          },
-          {
-            "device": null,
-            "host": null,
-            "interval": 10,
-            "metric": "aws.dd_forwarder.list_tags_log_group_api_call",
-            "points": "<redacted from snapshot>",
-            "tags": [
-              "forwardername:test_function",
-              "forwarder_memorysize:3008",
-              "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs",
-              "dd_lambda_layer:<redacted from snapshot>"
-            ],
-            "type": "distribution"
-          },
-          {
-            "device": null,
-            "host": null,
-            "interval": 10,
-            "metric": "aws.dd_forwarder.loggroup_cache_write_failure",
-            "points": "<redacted from snapshot>",
-            "tags": [
-              "forwardername:test_function",
-              "forwarder_memorysize:3008",
-              "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs",
-              "dd_lambda_layer:<redacted from snapshot>"
-            ],
-            "type": "distribution"
-          },
-          {
-            "device": null,
-            "host": null,
-            "interval": 10,
             "metric": "aws.dd_forwarder.incoming_events",
             "points": "<redacted from snapshot>",
             "tags": [

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_customized_log_group_lambda_invocation.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_customized_log_group_lambda_invocation.json~snapshot
@@ -102,7 +102,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -117,7 +117,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -132,7 +132,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -147,7 +147,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -162,7 +162,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -177,7 +177,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           }

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log.json~snapshot
@@ -68,51 +68,6 @@
             "device": null,
             "host": null,
             "interval": 10,
-            "metric": "aws.dd_forwarder.loggroup_cache_fetch_failure",
-            "points": "<redacted from snapshot>",
-            "tags": [
-              "forwardername:test_function",
-              "forwarder_memorysize:3008",
-              "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs",
-              "dd_lambda_layer:<redacted from snapshot>"
-            ],
-            "type": "distribution"
-          },
-          {
-            "device": null,
-            "host": null,
-            "interval": 10,
-            "metric": "aws.dd_forwarder.list_tags_log_group_api_call",
-            "points": "<redacted from snapshot>",
-            "tags": [
-              "forwardername:test_function",
-              "forwarder_memorysize:3008",
-              "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs",
-              "dd_lambda_layer:<redacted from snapshot>"
-            ],
-            "type": "distribution"
-          },
-          {
-            "device": null,
-            "host": null,
-            "interval": 10,
-            "metric": "aws.dd_forwarder.loggroup_cache_write_failure",
-            "points": "<redacted from snapshot>",
-            "tags": [
-              "forwardername:test_function",
-              "forwarder_memorysize:3008",
-              "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs",
-              "dd_lambda_layer:<redacted from snapshot>"
-            ],
-            "type": "distribution"
-          },
-          {
-            "device": null,
-            "host": null,
-            "interval": 10,
             "metric": "aws.dd_forwarder.incoming_events",
             "points": "<redacted from snapshot>",
             "tags": [

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log.json~snapshot
@@ -75,7 +75,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -90,7 +90,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -105,7 +105,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -120,7 +120,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -135,7 +135,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -150,7 +150,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           }

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_cloudtrail.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_cloudtrail.json~snapshot
@@ -111,7 +111,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -126,7 +126,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -141,7 +141,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -156,7 +156,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -171,7 +171,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -186,7 +186,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           }

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_cloudtrail.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_cloudtrail.json~snapshot
@@ -104,51 +104,6 @@
             "device": null,
             "host": null,
             "interval": 10,
-            "metric": "aws.dd_forwarder.loggroup_cache_fetch_failure",
-            "points": "<redacted from snapshot>",
-            "tags": [
-              "forwardername:test_function",
-              "forwarder_memorysize:3008",
-              "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs",
-              "dd_lambda_layer:<redacted from snapshot>"
-            ],
-            "type": "distribution"
-          },
-          {
-            "device": null,
-            "host": null,
-            "interval": 10,
-            "metric": "aws.dd_forwarder.list_tags_log_group_api_call",
-            "points": "<redacted from snapshot>",
-            "tags": [
-              "forwardername:test_function",
-              "forwarder_memorysize:3008",
-              "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs",
-              "dd_lambda_layer:<redacted from snapshot>"
-            ],
-            "type": "distribution"
-          },
-          {
-            "device": null,
-            "host": null,
-            "interval": 10,
-            "metric": "aws.dd_forwarder.loggroup_cache_write_failure",
-            "points": "<redacted from snapshot>",
-            "tags": [
-              "forwardername:test_function",
-              "forwarder_memorysize:3008",
-              "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs",
-              "dd_lambda_layer:<redacted from snapshot>"
-            ],
-            "type": "distribution"
-          },
-          {
-            "device": null,
-            "host": null,
-            "interval": 10,
             "metric": "aws.dd_forwarder.incoming_events",
             "points": "<redacted from snapshot>",
             "tags": [

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_coldstart.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_coldstart.json~snapshot
@@ -14,7 +14,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -29,7 +29,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -44,7 +44,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -59,7 +59,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -74,7 +74,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -89,7 +89,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -104,7 +104,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           }

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_coldstart.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_coldstart.json~snapshot
@@ -1,53 +1,96 @@
 {
   "events": [
     {
+      "data": [
+        {
+          "aws": {
+            "awslogs": {
+              "logGroup": "/aws/lambda/storms-cloudwatch-event",
+              "logStream": "2020/06/04/[$LATEST]af2b1e1843b84a2d80c67840ae3ffa72",
+              "owner": "601427279990"
+            },
+            "invoked_function_arn": "arn:aws:lambda:us-east-1:012345678912:function:test_function"
+          },
+          "ddsource": "lambda",
+          "ddsourcecategory": "aws",
+          "ddtags": "forwardername:test_function,forwarder_version:<redacted from snapshot>,env:none,aws_account:012345678912,functionname:storms-cloudwatch-event,region:us-east-1,service:storms-cloudwatch-event",
+          "host": "arn:aws:lambda:us-east-1:012345678912:function:storms-cloudwatch-event",
+          "id": "35486831490800643125153606102923171443962457178576257024",
+          "lambda": {
+            "arn": "arn:aws:lambda:us-east-1:012345678912:function:storms-cloudwatch-event"
+          },
+          "message": "START RequestId: <redacted from snapshot> Version: $LATEST\\n",
+          "service": "storms-cloudwatch-event",
+          "timestamp": 1591284559098
+        },
+        {
+          "aws": {
+            "awslogs": {
+              "logGroup": "/aws/lambda/storms-cloudwatch-event",
+              "logStream": "2020/06/04/[$LATEST]af2b1e1843b84a2d80c67840ae3ffa72",
+              "owner": "601427279990"
+            },
+            "invoked_function_arn": "arn:aws:lambda:us-east-1:012345678912:function:test_function"
+          },
+          "ddsource": "lambda",
+          "ddsourcecategory": "aws",
+          "ddtags": "forwardername:test_function,forwarder_version:<redacted from snapshot>,env:none,aws_account:012345678912,functionname:storms-cloudwatch-event,region:us-east-1,service:storms-cloudwatch-event",
+          "host": "arn:aws:lambda:us-east-1:012345678912:function:storms-cloudwatch-event",
+          "id": "35486831490867545360749197972347778598780402263094198273",
+          "lambda": {
+            "arn": "arn:aws:lambda:us-east-1:012345678912:function:storms-cloudwatch-event"
+          },
+          "message": "END RequestId: <redacted from snapshot>\\n",
+          "service": "storms-cloudwatch-event",
+          "timestamp": 1591284559101
+        },
+        {
+          "aws": {
+            "awslogs": {
+              "logGroup": "/aws/lambda/storms-cloudwatch-event",
+              "logStream": "2020/06/04/[$LATEST]af2b1e1843b84a2d80c67840ae3ffa72",
+              "owner": "601427279990"
+            },
+            "invoked_function_arn": "arn:aws:lambda:us-east-1:012345678912:function:test_function"
+          },
+          "ddsource": "lambda",
+          "ddsourcecategory": "aws",
+          "ddtags": "forwardername:test_function,forwarder_version:<redacted from snapshot>,env:none,aws_account:012345678912,functionname:storms-cloudwatch-event,region:us-east-1,service:storms-cloudwatch-event",
+          "host": "arn:aws:lambda:us-east-1:012345678912:function:storms-cloudwatch-event",
+          "id": "35486831490867545360749197972347778598780402263094198274",
+          "lambda": {
+            "arn": "arn:aws:lambda:us-east-1:012345678912:function:storms-cloudwatch-event"
+          },
+          "message": "REPORT RequestId: <redacted from snapshot>\\tDuration: 1.76 ms\\tBilled Duration: 100 ms\\tMemory Size: 128 MB\\tMax Memory Used: 48 MB\\tInit Duration: 120.96 ms\\t\\n",
+          "service": "storms-cloudwatch-event",
+          "timestamp": 1591284559101
+        }
+      ],
+      "headers": {
+        "Accept": "*/*",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "<redacted from snapshot>",
+        "Content-type": "application/json",
+        "DD-API-KEY": "abcdefghijklmnopqrstuvwxyz012345",
+        "DD-EVP-ORIGIN": "aws_forwarder",
+        "DD-EVP-ORIGIN-VERSION": "<redacted from snapshot>",
+        "DD-STORAGE-TAG": "s3,cloudwatch",
+        "Host": "recorder:8080",
+        "User-Agent": "<redacted from snapshot>",
+        "traceparent": "<redacted from snapshot>",
+        "tracestate": "<redacted from snapshot>",
+        "x-datadog-parent-id": "<redacted from snapshot>",
+        "x-datadog-sampling-priority": "1",
+        "x-datadog-tags": "<redacted from snapshot>",
+        "x-datadog-trace-id": "<redacted from snapshot>"
+      },
+      "path": "/api/v2/logs",
+      "verb": "POST"
+    },
+    {
       "data": {
         "series": [
-          {
-            "device": null,
-            "host": null,
-            "interval": 10,
-            "metric": "aws.dd_forwarder.loggroup_cache_fetch_failure",
-            "points": "<redacted from snapshot>",
-            "tags": [
-              "forwardername:test_function",
-              "forwarder_memorysize:3008",
-              "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs",
-              "dd_lambda_layer:<redacted from snapshot>"
-            ],
-            "type": "distribution"
-          },
-          {
-            "device": null,
-            "host": null,
-            "interval": 10,
-            "metric": "aws.dd_forwarder.list_tags_log_group_api_call",
-            "points": "<redacted from snapshot>",
-            "tags": [
-              "forwardername:test_function",
-              "forwarder_memorysize:3008",
-              "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs",
-              "dd_lambda_layer:<redacted from snapshot>"
-            ],
-            "type": "distribution"
-          },
-          {
-            "device": null,
-            "host": null,
-            "interval": 10,
-            "metric": "aws.dd_forwarder.loggroup_cache_write_failure",
-            "points": "<redacted from snapshot>",
-            "tags": [
-              "forwardername:test_function",
-              "forwarder_memorysize:3008",
-              "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs",
-              "dd_lambda_layer:<redacted from snapshot>"
-            ],
-            "type": "distribution"
-          },
           {
             "device": null,
             "host": null,
@@ -67,7 +110,7 @@
             "device": null,
             "host": null,
             "interval": 10,
-            "metric": "aws.dd_forwarder.local_lambda_cache_expired",
+            "metric": "aws.dd_forwarder.logs_forwarded",
             "points": "<redacted from snapshot>",
             "tags": [
               "forwardername:test_function",
@@ -82,22 +125,7 @@
             "device": null,
             "host": null,
             "interval": 10,
-            "metric": "aws.dd_forwarder.s3_cache_fetch_failure",
-            "points": "<redacted from snapshot>",
-            "tags": [
-              "forwardername:test_function",
-              "forwarder_memorysize:3008",
-              "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs",
-              "dd_lambda_layer:<redacted from snapshot>"
-            ],
-            "type": "distribution"
-          },
-          {
-            "device": null,
-            "host": null,
-            "interval": 10,
-            "metric": "aws.dd_forwarder.s3_cache_expired",
+            "metric": "aws.dd_forwarder.metrics_forwarded",
             "points": "<redacted from snapshot>",
             "tags": [
               "forwardername:test_function",

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_custom_tags.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_custom_tags.json~snapshot
@@ -50,21 +50,6 @@
             "device": null,
             "host": null,
             "interval": 10,
-            "metric": "aws.dd_forwarder.loggroup_local_cache_hit",
-            "points": "<redacted from snapshot>",
-            "tags": [
-              "forwardername:test_function",
-              "forwarder_memorysize:3008",
-              "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs",
-              "dd_lambda_layer:<redacted from snapshot>"
-            ],
-            "type": "distribution"
-          },
-          {
-            "device": null,
-            "host": null,
-            "interval": 10,
             "metric": "aws.dd_forwarder.incoming_events",
             "points": "<redacted from snapshot>",
             "tags": [

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_custom_tags.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_custom_tags.json~snapshot
@@ -57,7 +57,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -72,7 +72,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -87,7 +87,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -102,7 +102,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           }

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_lambda_invocation.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_lambda_invocation.json~snapshot
@@ -712,7 +712,7 @@
         "Host": "recorder:8080",
         "User-Agent": "<redacted from snapshot>"
       },
-      "path": "/api/v0.2/traces",
+      "path": "/api/v0.4/traces",
       "verb": "POST"
     },
     {
@@ -729,7 +729,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -744,7 +744,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -759,7 +759,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -774,7 +774,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -789,7 +789,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -804,7 +804,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -819,7 +819,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -844,7 +844,7 @@
               "functionname:hello-dog-node-dev-hello12x",
               "region:us-east-1",
               "service:hello-dog-node-dev-hello12x",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -855,7 +855,7 @@
             "metric": "hello.js10x.dog-2",
             "points": "<redacted from snapshot>",
             "tags": [
-              "dd_lambda_layer:datadog-nodev12.14.1",
+              "dd_lambda_layer:<redacted from snapshot>",
               "function_arn:arn:aws:lambda:us-east-1:012345678912:function:hello-dog-node-dev-hello12x",
               "forwardername:test_function",
               "forwarder_version:<redacted from snapshot>",
@@ -864,7 +864,7 @@
               "functionname:hello-dog-node-dev-hello12x",
               "region:us-east-1",
               "service:hello-dog-node-dev-hello12x",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -879,7 +879,8 @@
               "cold_start:false",
               "region:us-east-1",
               "aws_account:012345678912",
-              "functionname:hello-dog-node-dev-hello12x"
+              "functionname:hello-dog-node-dev-hello12x",
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -894,7 +895,8 @@
               "cold_start:false",
               "region:us-east-1",
               "aws_account:012345678912",
-              "functionname:hello-dog-node-dev-hello12x"
+              "functionname:hello-dog-node-dev-hello12x",
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -909,7 +911,8 @@
               "cold_start:false",
               "region:us-east-1",
               "aws_account:012345678912",
-              "functionname:hello-dog-node-dev-hello12x"
+              "functionname:hello-dog-node-dev-hello12x",
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -924,7 +927,8 @@
               "cold_start:false",
               "region:us-east-1",
               "aws_account:012345678912",
-              "functionname:hello-dog-node-dev-hello12x"
+              "functionname:hello-dog-node-dev-hello12x",
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           }

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_lambda_invocation.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_lambda_invocation.json~snapshot
@@ -712,57 +712,12 @@
         "Host": "recorder:8080",
         "User-Agent": "<redacted from snapshot>"
       },
-      "path": "/api/v0.4/traces",
+      "path": "/api/v0.2/traces",
       "verb": "POST"
     },
     {
       "data": {
         "series": [
-          {
-            "device": null,
-            "host": null,
-            "interval": 10,
-            "metric": "aws.dd_forwarder.loggroup_cache_fetch_failure",
-            "points": "<redacted from snapshot>",
-            "tags": [
-              "forwardername:test_function",
-              "forwarder_memorysize:3008",
-              "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs",
-              "dd_lambda_layer:<redacted from snapshot>"
-            ],
-            "type": "distribution"
-          },
-          {
-            "device": null,
-            "host": null,
-            "interval": 10,
-            "metric": "aws.dd_forwarder.list_tags_log_group_api_call",
-            "points": "<redacted from snapshot>",
-            "tags": [
-              "forwardername:test_function",
-              "forwarder_memorysize:3008",
-              "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs",
-              "dd_lambda_layer:<redacted from snapshot>"
-            ],
-            "type": "distribution"
-          },
-          {
-            "device": null,
-            "host": null,
-            "interval": 10,
-            "metric": "aws.dd_forwarder.loggroup_cache_write_failure",
-            "points": "<redacted from snapshot>",
-            "tags": [
-              "forwardername:test_function",
-              "forwarder_memorysize:3008",
-              "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs",
-              "dd_lambda_layer:<redacted from snapshot>"
-            ],
-            "type": "distribution"
-          },
           {
             "device": null,
             "host": null,

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_service_tag.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_service_tag.json~snapshot
@@ -50,21 +50,6 @@
             "device": null,
             "host": null,
             "interval": 10,
-            "metric": "aws.dd_forwarder.loggroup_local_cache_hit",
-            "points": "<redacted from snapshot>",
-            "tags": [
-              "forwardername:test_function",
-              "forwarder_memorysize:3008",
-              "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs",
-              "dd_lambda_layer:<redacted from snapshot>"
-            ],
-            "type": "distribution"
-          },
-          {
-            "device": null,
-            "host": null,
-            "interval": 10,
             "metric": "aws.dd_forwarder.incoming_events",
             "points": "<redacted from snapshot>",
             "tags": [

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_service_tag.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_service_tag.json~snapshot
@@ -57,7 +57,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -72,7 +72,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -87,7 +87,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -102,7 +102,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           }

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_timeout.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_timeout.json~snapshot
@@ -123,7 +123,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -138,7 +138,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -153,7 +153,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -168,7 +168,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -181,7 +181,8 @@
             "tags": [
               "region:us-east-1",
               "aws_account:012345678912",
-              "functionname:storms-cloudwatch-event"
+              "functionname:storms-cloudwatch-event",
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           }

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_timeout.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/cloudwatch_log_timeout.json~snapshot
@@ -116,21 +116,6 @@
             "device": null,
             "host": null,
             "interval": 10,
-            "metric": "aws.dd_forwarder.loggroup_local_cache_hit",
-            "points": "<redacted from snapshot>",
-            "tags": [
-              "forwardername:test_function",
-              "forwarder_memorysize:3008",
-              "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs",
-              "dd_lambda_layer:<redacted from snapshot>"
-            ],
-            "type": "distribution"
-          },
-          {
-            "device": null,
-            "host": null,
-            "interval": 10,
             "metric": "aws.dd_forwarder.incoming_events",
             "points": "<redacted from snapshot>",
             "tags": [

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/step_functions_log.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/step_functions_log.json~snapshot
@@ -50,51 +50,6 @@
             "device": null,
             "host": null,
             "interval": 10,
-            "metric": "aws.dd_forwarder.loggroup_cache_fetch_failure",
-            "points": "<redacted from snapshot>",
-            "tags": [
-              "forwardername:test_function",
-              "forwarder_memorysize:3008",
-              "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs",
-              "dd_lambda_layer:<redacted from snapshot>"
-            ],
-            "type": "distribution"
-          },
-          {
-            "device": null,
-            "host": null,
-            "interval": 10,
-            "metric": "aws.dd_forwarder.list_tags_log_group_api_call",
-            "points": "<redacted from snapshot>",
-            "tags": [
-              "forwardername:test_function",
-              "forwarder_memorysize:3008",
-              "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs",
-              "dd_lambda_layer:<redacted from snapshot>"
-            ],
-            "type": "distribution"
-          },
-          {
-            "device": null,
-            "host": null,
-            "interval": 10,
-            "metric": "aws.dd_forwarder.loggroup_cache_write_failure",
-            "points": "<redacted from snapshot>",
-            "tags": [
-              "forwardername:test_function",
-              "forwarder_memorysize:3008",
-              "forwarder_version:<redacted from snapshot>",
-              "event_type:awslogs",
-              "dd_lambda_layer:<redacted from snapshot>"
-            ],
-            "type": "distribution"
-          },
-          {
-            "device": null,
-            "host": null,
-            "interval": 10,
             "metric": "aws.dd_forwarder.incoming_events",
             "points": "<redacted from snapshot>",
             "tags": [

--- a/aws/logs_monitoring/tools/integration_tests/snapshots/step_functions_log.json~snapshot
+++ b/aws/logs_monitoring/tools/integration_tests/snapshots/step_functions_log.json~snapshot
@@ -57,7 +57,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -72,7 +72,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -87,7 +87,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -102,7 +102,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -117,7 +117,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           },
@@ -132,7 +132,7 @@
               "forwarder_memorysize:3008",
               "forwarder_version:<redacted from snapshot>",
               "event_type:awslogs",
-              "dd_lambda_layer:datadog-python313_8.120.0"
+              "dd_lambda_layer:<redacted from snapshot>"
             ],
             "type": "distribution"
           }

--- a/aws/logs_monitoring/tools/integration_tests/tester/test_snapshots.py
+++ b/aws/logs_monitoring/tools/integration_tests/tester/test_snapshots.py
@@ -74,6 +74,12 @@ class TestForwarderSnapshots(unittest.TestCase):
             "forwarder_version:<redacted from snapshot>",
             snapshot,
         )
+        # Lambda layer version in tags
+        snapshot = re.sub(
+            r"dd_lambda_layer:[^,\s\"]+",
+            "dd_lambda_layer:<redacted from snapshot>",
+            snapshot,
+        )
         # Forwarder version in trace payloads
         snapshot = re.sub(
             r"\"forwarder_version\":\s\"\d+\.\d+\.\d+\"",


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

* Update docs on trace forwarding indicating that the forwarder needs to be instrumented. 
* Update enhanced metrics submission to use [`lambda_metric`](https://github.com/DataDog/datadog-lambda-python/blob/main/datadog_lambda/metric.py#L64)  which automatically selects the handler based on what's available. 
* The forwarder used `lambda_stats.distribution` directly which could be null sometimes depending on different factors like having the extension enabled.

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
