### PR TITLE
[AWSX] fix(logs forwarder): Override service tag from StepFunction tags

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -828,9 +828,10 @@ The value of the `service` tag is determined based on multiple inputs. These inp
 
 1. Log message custom tags: If the log message has a `ddtags` key which contains a `service` tag value, it will be used to override the `service` tag in the log event.
 2. Lambda tags cache (applicable for Lambda logs only): Activating `DdFetchLambdaTags` will fetch and store all Lambda functions tags and will override the `service` tag if it wasn't set previously or was set to a default value i.e. `source` value.
-3. Cloudwatch log group tags cache (applicable for Cloudwatch logs only): Activating `DdFetchLogGroupTags` will fetch and store all Cloudwatch log groups tags which are added to the `ddtags` entry in the log event. If `service` tag value was set in the tags cache it will be used to set the `service` tag for the log event.
-4. Directly setting a `service` tag value in the forwarder's `ddtags` ENV var.
-5. Default value equal to the `source` tag.
+3. Directly setting a `service` tag value in the forwarder's `ddtags` ENV var.
+4. Step Function tags cache (applicable for step Functions logs only): Activating `DdFetchStepFunctionsTags` will fetch and store all Step Functions tags and override `service` tag if wasn't set previously.
+5. Cloudwatch log group tags cache (applicable for Cloudwatch logs only): Activating `DdFetchLogGroupTags` will fetch and store all Cloudwatch log groups tags which are added to the `ddtags` entry in the log event. If `service` tag value was set in the tags cache it will be used to set the `service` tag for the log event.
+6. Default value equal to the `source` tag.
 
 ## Further Reading
 

--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -242,12 +242,10 @@ def is_api_key_valid():
 
     # Check if the API key is the correct number of characters
     if len(DD_API_KEY) != 32:
-        raise Exception(
-            f"""
+        raise Exception(f"""
             Invalid Datadog API key format. Expected 32 characters, received {len(DD_API_KEY)}.
             Verify your API key at https://app.{DD_SITE}/organization-settings/api-keys
-            """
-        )
+            """)
 
     # Validate the API key
     logger.debug("Validating the Datadog API key")

--- a/aws/logs_monitoring/steps/handlers/awslogs_handler.py
+++ b/aws/logs_monitoring/steps/handlers/awslogs_handler.py
@@ -51,11 +51,11 @@ class AwsLogsHandler:
 
         # Add custom tags from cache
         self.add_cloudwatch_tags_from_cache(metadata, aws_attributes)
+        # Set host as log group where cloudwatch is source
+        self.set_host(metadata, aws_attributes)
         # Set service from custom tags, which may include the tags set on the log group
         # Returns DD_SOURCE by default
         add_service_tag(metadata)
-        # Set host as log group where cloudwatch is source
-        self.set_host(metadata, aws_attributes)
         # For Lambda logs we want to extract the function name,
         # then rebuild the arn of the monitored lambda using that name.
         if metadata[DD_SOURCE] == str(AwsEventSource.LAMBDA):

--- a/aws/logs_monitoring/tests/approved_files/TestAWSLogsHandler.test_awslogs_handler_step_functions_tags_added_properly.approved.json
+++ b/aws/logs_monitoring/tests/approved_files/TestAWSLogsHandler.test_awslogs_handler_step_functions_tags_added_properly.approved.json
@@ -10,11 +10,11 @@
         },
         "ddsource": "stepfunction",
         "ddsourcecategory": "aws",
-        "ddtags": "forwardername:function_name,forwarder_version:<redacted>,test_tag_key:test_tag_value,dd_step_functions_trace_enabled:true",
+        "ddtags": "forwardername:function_name,forwarder_version:<redacted>,test_tag_key:test_tag_value,service:customservice,dd_step_functions_trace_enabled:true",
         "host": "arn:aws:states:us-east-1:12345678910:stateMachine:StepFunction1",
         "id": "37199773595581154154810589279545129148442535997644275712",
         "message": "{\"id\": \"1\",\"type\": \"ExecutionStarted\",\"details\": {\"input\": \"{}\",\"inputDetails\": {\"truncated\": \"false\"},\"roleArn\": \"arn:aws:iam::12345678910:role/service-role/StepFunctions-test-role-a0iurr4pt\"},\"previous_event_id\": \"0\",\"event_timestamp\": \"1716992192441\",\"execution_arn\": \"arn:aws:states:us-east-1:12345678910:execution:StepFunction1:ccccccc-d1da-4c38-b32c-2b6b07d713fa\",\"redrive_count\": \"0\"}",
-        "service": "stepfunction",
+        "service": "customservice",
         "timestamp": 1668095539607
     }
 ]

--- a/aws/logs_monitoring/tests/test_awslogs_handler.py
+++ b/aws/logs_monitoring/tests/test_awslogs_handler.py
@@ -195,7 +195,7 @@ class TestAWSLogsHandler(unittest.TestCase):
         mock_cache_init.return_value = None
         cache_layer = CacheLayer("")
         cache_layer._step_functions_cache.get = MagicMock(
-            return_value=["test_tag_key:test_tag_value"]
+            return_value=["test_tag_key:test_tag_value", "service:customservice"]
         )
         cache_layer._cloudwatch_log_group_cache.get = MagicMock()
 

--- a/aws/logs_monitoring/tools/integration_tests/recorder/pb/span_pb2.py
+++ b/aws/logs_monitoring/tools/integration_tests/recorder/pb/span_pb2.py
@@ -4,6 +4,7 @@
 # source: span.proto
 # Protobuf Python Version: 5.28.1
 """Generated protocol buffer code."""
+
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import descriptor_pool as _descriptor_pool
 from google.protobuf import runtime_version as _runtime_version

--- a/aws/logs_monitoring/tools/integration_tests/recorder/pb/trace_payload_pb2.py
+++ b/aws/logs_monitoring/tools/integration_tests/recorder/pb/trace_payload_pb2.py
@@ -4,6 +4,7 @@
 # source: trace_payload.proto
 # Protobuf Python Version: 5.28.1
 """Generated protocol buffer code."""
+
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import descriptor_pool as _descriptor_pool
 from google.protobuf import runtime_version as _runtime_version

--- a/aws/logs_monitoring/tools/integration_tests/recorder/pb/trace_pb2.py
+++ b/aws/logs_monitoring/tools/integration_tests/recorder/pb/trace_pb2.py
@@ -4,6 +4,7 @@
 # source: trace.proto
 # Protobuf Python Version: 5.28.1
 """Generated protocol buffer code."""
+
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import descriptor_pool as _descriptor_pool
 from google.protobuf import runtime_version as _runtime_version

--- a/aws/rds_enhanced_monitoring/lambda_function.py
+++ b/aws/rds_enhanced_monitoring/lambda_function.py
@@ -17,7 +17,6 @@ from urllib.parse import urlencode
 import botocore
 import boto3
 
-
 DD_SITE = os.getenv("DD_SITE", default="datadoghq.com")
 
 

--- a/aws/rds_enhanced_monitoring/tests/test_rds_metrics.py
+++ b/aws/rds_enhanced_monitoring/tests/test_rds_metrics.py
@@ -226,11 +226,7 @@ full_message_example = """
             "rss": 441652
         }]
     }
-""".replace(
-    " ", ""
-).replace(
-    "\n", ""
-)
+""".replace(" ", "").replace("\n", "")
 
 
 class TestRDSEnhancedMetrics(unittest.TestCase):

--- a/aws/vpc_flow_log_monitoring/lambda_function.py
+++ b/aws/vpc_flow_log_monitoring/lambda_function.py
@@ -16,7 +16,6 @@ from urllib.parse import urlencode
 import boto3
 import botocore
 
-
 logger = logging.getLogger()
 logger.setLevel(logging.getLevelName(os.environ.get("DD_LOG_LEVEL", "INFO").upper()))
 


### PR DESCRIPTION


<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

* Fix service tag/field setting behavior for StepFunctions by allowing to override the service from the function tags when `DdFetchStepFunctionsTags` is enabled. 

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
