### PR TITLE
[AWSCORE-688] Add version fetching to forwarder release script

### DIFF
--- a/aws/logs_monitoring/release.sh
+++ b/aws/logs_monitoring/release.sh
@@ -363,6 +363,15 @@ else
     sandbox_release
 fi
 
+if [[ ${ACCOUNT} == "prod" ]]; then
+    log_info "Generating and uploading versions.json"
+    
+    generate_versions_json
+    upload_versions_json
+
+    log_success "Done generating and uploading versions.json!"
+fi
+
 log_info "Uploading template.yaml to s3://${BUCKET}/aws/forwarder/${FORWARDER_VERSION}.yaml"
 
 if [[ ${ACCOUNT} == "prod" ]]; then
@@ -389,7 +398,4 @@ log_success "Forwarder release process complete!"
 if [[ ${ACCOUNT} == "prod" ]]; then
     log_info "Don't forget to add release notes in GitHub!"
     log_info "\thttps://github.com/DataDog/datadog-serverless-functions/releases"
-
-    generate_versions_json
-    upload_versions_json
 fi

--- a/aws/logs_monitoring/release.sh
+++ b/aws/logs_monitoring/release.sh
@@ -125,6 +125,8 @@ CURRENT_VERSION=$(yq '.Mappings.Constants.DdForwarder.Version' "template.yaml")
 
 LAYER_NAME="Datadog-Forwarder"
 BUNDLE_PATH=".forwarder/aws-dd-forwarder-${FORWARDER_VERSION}.zip"
+VERSIONS_JSON_PATH=".forwarder/versions.json"
+VERSIONS_BUCKET="datadog-opensource-asset-versions"
 
 aws_login() {
     cfg=("$@")
@@ -150,6 +152,65 @@ get_max_layer_version() {
     else
         echo "${last_layer_version}"
     fi
+}
+
+generate_versions_json() {
+    log_info "Generating versions.json from GitHub release data..."
+
+    local releases_json
+    releases_json=$(gh release list --repo DataDog/datadog-serverless-functions --limit 200 --json tagName,name,publishedAt)
+
+    local versions_json
+    versions_json=$(echo "${releases_json}" | jq -r '
+        [
+            .[] |
+            select(.tagName | startswith("aws-dd-forwarder-")) |
+
+            # Extract forwarder version from tag (e.g., aws-dd-forwarder-5.1.0 -> 5.1.0)
+            (.tagName | capture("aws-dd-forwarder-(?<version>[0-9]+\\.[0-9]+\\.[0-9]+)")) as $forwarder |
+
+            # Extract layer version from name (e.g., "aws-dd-forwarder-5.1.0 (Layer v92)" -> 92)
+            (.name | capture("\\(Layer v(?<layer>[0-9]+)\\)")) as $layer |
+
+            # Only include if both extractions succeeded
+            select($forwarder != null and $layer != null) |
+
+            {
+                layer_version: $layer.layer,
+                forwarder_version: $forwarder.version,
+                release_date: (.publishedAt | split("T")[0])
+            }
+        ] |
+
+        sort_by(.layer_version | tonumber) | reverse |
+
+        {
+            latest: {
+                layer_version: .[0].layer_version,
+                forwarder_version: .[0].forwarder_version,
+                release_date: .[0].release_date
+            },
+            mappings: (
+                reduce .[] as $item (
+                    {};
+                    . + {($item.layer_version): $item.forwarder_version}
+                )
+            )
+        }
+    ')
+
+    # Write to file
+    echo "${versions_json}" > "${VERSIONS_JSON_PATH}"
+    log_success "Generated ${VERSIONS_JSON_PATH}"
+}
+
+upload_versions_json() {
+    log_info "Uploading versions.json to s3://${VERSIONS_BUCKET}/forwarder/versions.json..."
+
+    aws_login aws s3 cp "${VERSIONS_JSON_PATH}" "s3://${VERSIONS_BUCKET}/forwarder/versions.json" \
+        --grants "read=uri=http://acs.amazonaws.com/groups/global/AllUsers"
+
+    log_success "Uploaded versions.json to S3!"
 }
 
 datadog_release() {
@@ -328,4 +389,8 @@ log_success "Forwarder release process complete!"
 if [[ ${ACCOUNT} == "prod" ]]; then
     log_info "Don't forget to add release notes in GitHub!"
     log_info "\thttps://github.com/DataDog/datadog-serverless-functions/releases"
+
+    # Generate and upload versions.json for Terraform module consumption
+    generate_versions_json
+    upload_versions_json
 fi

--- a/aws/logs_monitoring/release.sh
+++ b/aws/logs_monitoring/release.sh
@@ -199,7 +199,6 @@ generate_versions_json() {
         }
     ')
 
-    # Write to file
     echo "${versions_json}" > "${VERSIONS_JSON_PATH}"
     log_success "Generated ${VERSIONS_JSON_PATH}"
 }

--- a/aws/logs_monitoring/release.sh
+++ b/aws/logs_monitoring/release.sh
@@ -400,6 +400,8 @@ if [[ ${ACCOUNT} == "prod" ]]; then
     upload_versions_json
 
     log_success "Done generating and uploading versions.json!"
+    log_info "Please verify the uploaded file:"
+    log_info "\thttps://${VERSIONS_BUCKET}.s3.amazonaws.com/forwarder/versions.json"
 
     log_info "Don't forget to add release notes in GitHub!"
     log_info "\thttps://github.com/DataDog/datadog-serverless-functions/releases"

--- a/aws/logs_monitoring/release.sh
+++ b/aws/logs_monitoring/release.sh
@@ -362,15 +362,6 @@ else
     sandbox_release
 fi
 
-if [[ ${ACCOUNT} == "prod" ]]; then
-    log_info "Generating and uploading versions.json"
-    
-    generate_versions_json
-    upload_versions_json
-
-    log_success "Done generating and uploading versions.json!"
-fi
-
 log_info "Uploading template.yaml to s3://${BUCKET}/aws/forwarder/${FORWARDER_VERSION}.yaml"
 
 if [[ ${ACCOUNT} == "prod" ]]; then
@@ -395,6 +386,13 @@ log_success ""
 log_success "Forwarder release process complete!"
 
 if [[ ${ACCOUNT} == "prod" ]]; then
+    log_info "Generating and uploading versions.json for the new release..."
+    
+    generate_versions_json
+    upload_versions_json
+
+    log_success "Done generating and uploading versions.json!"
+    
     log_info "Don't forget to add release notes in GitHub!"
     log_info "\thttps://github.com/DataDog/datadog-serverless-functions/releases"
 fi

--- a/aws/logs_monitoring/release.sh
+++ b/aws/logs_monitoring/release.sh
@@ -390,7 +390,6 @@ if [[ ${ACCOUNT} == "prod" ]]; then
     log_info "Don't forget to add release notes in GitHub!"
     log_info "\thttps://github.com/DataDog/datadog-serverless-functions/releases"
 
-    # Generate and upload versions.json for Terraform module consumption
     generate_versions_json
     upload_versions_json
 fi


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

This PR updates the forwarder release script to generate version information as a json file and upload it to the `datadog-opensource-asset-versions` bucket in forwarder/versions.json.

Currently, the versions.json looks like:
```
{
  "latest": {
    "layer_version": "95",
    "forwarder_version": "5.2.1",
    "release_date": "2026-01-20"
  },
  "mappings": {
    "95": "5.2.1",
    "94": "5.2.0",
    "93": "5.1.1",
    "92": "5.1.0",
    "91": "5.0.0",
    "90": "4.15.0",
    "89": "4.14.0",
    "88": "4.13.0",
    "87": "4.12.0",
    "86": "4.11.0",
    "85": "4.10.0",
    "84": "4.9.0",
    "83": "4.8.0",
    "82": "4.7.0",
    "81": "4.6.0",
    "80": "4.5.0",
    "79": "4.4.0",
    "78": "4.3.0",
    "77": "4.2.0",
    "76": "4.1.0",
    "75": "4.0.2",
    "74": "4.0.1",
    "73": "4.0.0",
    "71": "3.133.0",
    "70": "3.132.0",
    "69": "3.131.0",
    "67": "3.130.0",
    "66": "3.128.0",
    "65": "3.127.0",
    "64": "3.124.0",
    "63": "3.123.0",
    "62": "3.122.0",
    "61": "3.121.0",
    "60": "3.120.1",
    "57": "3.118.0",
    "56": "3.117.0",
    "55": "3.116.0",
    "54": "3.115.0",
    "53": "3.114.0",
    "51": "3.112.0",
    "50": "3.111.0",
    "49": "3.110.0",
    "48": "3.108.0",
    "47": "3.106.0",
    "46": "3.105.0",
    "45": "3.103.0",
    "44": "3.100.0",
    "43": "3.99.0",
    "42": "3.98.0",
    "41": "3.97.0",
    "40": "3.96.0",
    "39": "3.95.0",
    "38": "3.92.0",
    "37": "3.91.0",
    "35": "3.83.0",
    "34": "3.79.0",
    "33": "3.77.0",
    "32": "3.76.0",
    "31": "3.74.0",
    "30": "3.73.0",
    "29": "3.71.0",
    "28": "3.66.0",
    "27": "3.62.0",
    "26": "3.61.0",
    "25": "3.60.0",
    "24": "3.59.0",
    "23": "3.58.0",
    "22": "3.55.0",
    "21": "3.53.0",
    "20": "3.52.0",
    "19": "3.51.0",
    "17": "3.50.0",
    "16": "3.48.0",
    "15": "3.47.0",
    "14": "3.46.0",
    "13": "3.44.0",
    "11": "3.43.0",
    "10": "3.41.0",
    "9": "3.40.0",
    "8": "3.39.1",
    "7": "3.39.0",
    "6": "3.38.0",
    "5": "3.37.0",
    "4": "3.36.0",
    "3": "3.35.0",
    "2": "3.34.0",
    "1": "3.33.0"
  }
}
```

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

I tested the forwarder by modifying the script to upload to buckets in the `aws-ints-playground` account. Test bucket: https://us-east-1.console.aws.amazon.com/s3/buckets/datadog-opensource-asset-versions-test2?region=us-east-1&tab=objects

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
