### PR TITLE
[AWS] feat(forwarder): update requirements

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'go', 'javascript', 'python' ]
+        language: [ 'javascript', 'python' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/
 

--- a/aws/logs_monitoring/requirements.txt
+++ b/aws/logs_monitoring/requirements.txt
@@ -16,7 +16,7 @@ opentelemetry-api
 protobuf==6.33.5
 requests-futures
 requests
-setuptools=80.10.2
+setuptools==80.10.2
 six
 typing-extensions
 urllib3>=2.6.3,<3.0

--- a/aws/logs_monitoring/requirements.txt
+++ b/aws/logs_monitoring/requirements.txt
@@ -13,10 +13,10 @@ exceptiongroup
 idna==3.7
 importlib-metadata
 opentelemetry-api
-protobuf>=6.31.1
+protobuf==6.33.5
 requests-futures
 requests
-setuptools>=80.9.0
+setuptools=80.10.2
 six
 typing-extensions
 urllib3>=2.6.3,<3.0


### PR DESCRIPTION
Updates the requirements to solve a few CVEs and also pin the versions:
Setuptools upgrade:
* wheel v0.45.1 -- CVE-2026-24049
* jaraco.context v5.3.0 -- CVE-2026-23949
Protobuf upgrade:
* protobuf v6.33.4 -- CVE-2026-0994