### PR TITLE
Update version from 5.2.1 to 5.2.2

### DIFF
--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -337,7 +337,7 @@ DD_SOURCE = "ddsource"
 DD_CUSTOM_TAGS = "ddtags"
 DD_SERVICE = "service"
 DD_HOST = "host"
-DD_FORWARDER_VERSION = "5.2.1"
+DD_FORWARDER_VERSION = "5.2.2"
 
 # CONST STRINGS
 AWS_STRING = "aws"

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -3,8 +3,8 @@ Description: Pushes logs, metrics and traces from AWS to Datadog.
 Mappings:
   Constants:
     DdForwarder:
-      Version: 5.2.1
-      LayerVersion: "95"
+      Version: 5.2.2
+      LayerVersion: "96"
 Parameters:
   DdApiKey:
     Type: String


### PR DESCRIPTION
This PR updates the AWS Forwarder version to 5.2.2 and the layer version to 96.