### PR TITLE
Check if docker or container system are running

### DIFF
--- a/aws/logs_monitoring/release.sh
+++ b/aws/logs_monitoring/release.sh
@@ -89,9 +89,13 @@ if ! command -v gh >/dev/null 2>&1; then
     log_error "gh not found, please install it following instructions here https://github.com/cli/cli?tab=readme-ov-file#installation"
 fi
 
-# Before we start the release, ensure that Docker is running
-if ! docker info > /dev/null 2>&1; then
-    log_error "Docker is not running, please start it"
+# Before we start the release, ensure that Docker or container is running
+if docker info > /dev/null 2>&1; then
+    log_info "Using Docker for container operations"
+elif container system status > /dev/null 2>&1; then
+    log_info "Using Apple container for container operations"
+else
+    log_error "Neither Docker nor container is running. Please start Docker or run 'container system start'"
 fi
 
 # Read the desired version


### PR DESCRIPTION
Now that we support Apple Containers https://github.com/DataDog/datadog-serverless-functions/pull/1036 let's modify a release script, to check if either `docker` or `container` commands exists and systems are running.

Without this, even if `container` exists and runnning, but docker is not, the release script will exit.