### PR TITLE
[AWSX] fix(logs forwarder): Scrub logs once

### DIFF
--- a/aws/logs_monitoring/forwarder.py
+++ b/aws/logs_monitoring/forwarder.py
@@ -94,16 +94,9 @@ class Forwarder(object):
             evaluated_log = log
             to_forward = None
 
-            # apply scrubbing rules to inner log message
             if isinstance(log, dict):
                 if log.get("message"):
-                    try:
-                        log["message"] = scrubber.scrub(log["message"])
-                        evaluated_log = log["message"]
-                    except Exception as e:
-                        logger.error(
-                            f"Exception while scrubbing log message {log['message']}: {e}"
-                        )
+                    evaluated_log = log["message"]
                 else:
                     to_forward = dump_event(log)
                     evaluated_log = to_forward


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Scrub forwarder logs only once before sending.

### Motivation

https://github.com/DataDog/datadog-serverless-functions/issues/1059

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
