### PR TITLE
fix(logs forwarder -waf ): serialize WAF message to JSON string allowing exclusion/inclusion matching

### DIFF
--- a/aws/logs_monitoring/steps/transformation.py
+++ b/aws/logs_monitoring/steps/transformation.py
@@ -171,7 +171,7 @@ def parse_aws_waf_logs(event):
             non_terminating_rules
         )
 
-    event_copy["message"] = message
+    event_copy["message"] = json.dumps(message)
     return event_copy
 
 

--- a/aws/logs_monitoring/tests/approved_files/TestParseAwsWafLogs.test_waf_headers.approved.json
+++ b/aws/logs_monitoring/tests/approved_files/TestParseAwsWafLogs.test_waf_headers.approved.json
@@ -1,11 +1,4 @@
 {
     "ddsource": "waf",
-    "message": {
-        "httpRequest": {
-            "headers": {
-                "header1": "value1",
-                "header2": "value2"
-            }
-        }
-    }
+    "message": "{\"httpRequest\": {\"headers\": {\"header1\": \"value1\", \"header2\": \"value2\"}}}"
 }

--- a/aws/logs_monitoring/tests/approved_files/TestParseAwsWafLogs.test_waf_non_terminating_matching_rules.approved.json
+++ b/aws/logs_monitoring/tests/approved_files/TestParseAwsWafLogs.test_waf_non_terminating_matching_rules.approved.json
@@ -1,13 +1,4 @@
 {
     "ddsource": "waf",
-    "message": {
-        "nonTerminatingMatchingRules": {
-            "nonterminating1": {
-                "action": "COUNT"
-            },
-            "nonterminating2": {
-                "action": "COUNT"
-            }
-        }
-    }
+    "message": "{\"nonTerminatingMatchingRules\": {\"nonterminating1\": {\"action\": \"COUNT\"}, \"nonterminating2\": {\"action\": \"COUNT\"}}}"
 }

--- a/aws/logs_monitoring/tests/approved_files/TestParseAwsWafLogs.test_waf_rate_based_rules.approved.json
+++ b/aws/logs_monitoring/tests/approved_files/TestParseAwsWafLogs.test_waf_rate_based_rules.approved.json
@@ -1,19 +1,4 @@
 {
     "ddsource": "waf",
-    "message": {
-        "rateBasedRuleList": {
-            "no-rate-limit": {
-                "limitKey": "IP",
-                "limitValue": "195.154.122.189",
-                "maxRateAllowed": 300,
-                "rateBasedRuleId": "arn:aws:wafv2:ap-southeast-2:068133125972_MANAGED:regional/ipset/0f94bd8b-0fa5-4865-81ce-d11a60051fb4_fef50279-8b9a-4062-b733-88ecd1cfd889_IPV4/fef50279-8b9a-4062-b733-88ecd1cfd889"
-            },
-            "tf-rate-limit-5-min": {
-                "limitKey": "IP",
-                "limitValue": "195.154.122.189",
-                "maxRateAllowed": 300,
-                "rateBasedRuleId": "arn:aws:wafv2:ap-southeast-2:068133125972_MANAGED:regional/ipset/0f94bd8b-0fa5-4865-81ce-d11a60051fb4_fef50279-8b9a-4062-b733-88ecd1cfd889_IPV4/fef50279-8b9a-4062-b733-88ecd1cfd889"
-            }
-        }
-    }
+    "message": "{\"rateBasedRuleList\": {\"tf-rate-limit-5-min\": {\"limitValue\": \"195.154.122.189\", \"rateBasedRuleId\": \"arn:aws:wafv2:ap-southeast-2:068133125972_MANAGED:regional/ipset/0f94bd8b-0fa5-4865-81ce-d11a60051fb4_fef50279-8b9a-4062-b733-88ecd1cfd889_IPV4/fef50279-8b9a-4062-b733-88ecd1cfd889\", \"maxRateAllowed\": 300, \"limitKey\": \"IP\"}, \"no-rate-limit\": {\"limitValue\": \"195.154.122.189\", \"rateBasedRuleId\": \"arn:aws:wafv2:ap-southeast-2:068133125972_MANAGED:regional/ipset/0f94bd8b-0fa5-4865-81ce-d11a60051fb4_fef50279-8b9a-4062-b733-88ecd1cfd889_IPV4/fef50279-8b9a-4062-b733-88ecd1cfd889\", \"maxRateAllowed\": 300, \"limitKey\": \"IP\"}}}"
 }

--- a/aws/logs_monitoring/tests/approved_files/TestParseAwsWafLogs.test_waf_rule_group_three_rules_two_group_ids.approved.json
+++ b/aws/logs_monitoring/tests/approved_files/TestParseAwsWafLogs.test_waf_rule_group_three_rules_two_group_ids.approved.json
@@ -1,24 +1,4 @@
 {
     "ddsource": "waf",
-    "message": {
-        "ruleGroupList": {
-            "AWS#AWSManagedRulesSQLiRuleSet": {
-                "terminatingRule": {
-                    "SQLi_QUERYARGUMENTS": {
-                        "action": "BLOCK"
-                    },
-                    "secondRULE": {
-                        "action": "BLOCK"
-                    }
-                }
-            },
-            "A_DIFFERENT_ID": {
-                "terminatingRule": {
-                    "thirdRULE": {
-                        "action": "BLOCK"
-                    }
-                }
-            }
-        }
-    }
+    "message": "{\"ruleGroupList\": {\"AWS#AWSManagedRulesSQLiRuleSet\": {\"terminatingRule\": {\"SQLi_QUERYARGUMENTS\": {\"action\": \"BLOCK\"}, \"secondRULE\": {\"action\": \"BLOCK\"}}}, \"A_DIFFERENT_ID\": {\"terminatingRule\": {\"thirdRULE\": {\"action\": \"BLOCK\"}}}}}"
 }

--- a/aws/logs_monitoring/tests/approved_files/TestParseAwsWafLogs.test_waf_rule_group_two_rules_same_group_id.approved.json
+++ b/aws/logs_monitoring/tests/approved_files/TestParseAwsWafLogs.test_waf_rule_group_two_rules_same_group_id.approved.json
@@ -1,17 +1,4 @@
 {
     "ddsource": "waf",
-    "message": {
-        "ruleGroupList": {
-            "AWS#AWSManagedRulesSQLiRuleSet": {
-                "terminatingRule": {
-                    "SQLi_QUERYARGUMENTS": {
-                        "action": "BLOCK"
-                    },
-                    "secondRULE": {
-                        "action": "BLOCK"
-                    }
-                }
-            }
-        }
-    }
+    "message": "{\"ruleGroupList\": {\"AWS#AWSManagedRulesSQLiRuleSet\": {\"terminatingRule\": {\"SQLi_QUERYARGUMENTS\": {\"action\": \"BLOCK\"}, \"secondRULE\": {\"action\": \"BLOCK\"}}}}}"
 }

--- a/aws/logs_monitoring/tests/approved_files/TestParseAwsWafLogs.test_waf_rule_group_with_excluded_and_nonterminating_rules.approved.json
+++ b/aws/logs_monitoring/tests/approved_files/TestParseAwsWafLogs.test_waf_rule_group_with_excluded_and_nonterminating_rules.approved.json
@@ -1,30 +1,4 @@
 {
     "ddsource": "waf",
-    "message": {
-        "ruleGroupList": {
-            "AWS#AWSManagedRulesSQLiRuleSet": {
-                "excludedRules": {
-                    "GenericRFI_BODY": {
-                        "exclusionType": "EXCLUDED_AS_COUNT"
-                    },
-                    "second_exclude": {
-                        "exclusionType": "EXCLUDED_AS_COUNT"
-                    }
-                },
-                "nonTerminatingMatchingRules": {
-                    "first_nonterminating": {
-                        "exclusionType": "REGULAR"
-                    },
-                    "second_nonterminating": {
-                        "exclusionType": "REGULAR"
-                    }
-                },
-                "terminatingRule": {
-                    "SQLi_QUERYARGUMENTS": {
-                        "action": "BLOCK"
-                    }
-                }
-            }
-        }
-    }
+    "message": "{\"ruleGroupList\": {\"AWS#AWSManagedRulesSQLiRuleSet\": {\"terminatingRule\": {\"SQLi_QUERYARGUMENTS\": {\"action\": \"BLOCK\"}}, \"nonTerminatingMatchingRules\": {\"first_nonterminating\": {\"exclusionType\": \"REGULAR\"}, \"second_nonterminating\": {\"exclusionType\": \"REGULAR\"}}, \"excludedRules\": {\"GenericRFI_BODY\": {\"exclusionType\": \"EXCLUDED_AS_COUNT\"}, \"second_exclude\": {\"exclusionType\": \"EXCLUDED_AS_COUNT\"}}}}}"
 }

--- a/aws/logs_monitoring/tests/approved_files/TestTransform.test_transform_mixed.approved.json
+++ b/aws/logs_monitoring/tests/approved_files/TestTransform.test_transform_mixed.approved.json
@@ -1,25 +1,11 @@
 [
     {
         "ddsource": "waf",
-        "message": {
-            "httpRequest": {
-                "headers": {
-                    "header2": "value2"
-                }
-            },
-            "request_id": "1"
-        }
+        "message": "{\"request_id\": \"1\", \"httpRequest\": {\"headers\": {\"header2\": \"value2\"}}}"
     },
     {
         "ddsource": "waf",
-        "message": {
-            "httpRequest": {
-                "headers": {
-                    "header1": "value1"
-                }
-            },
-            "request_id": "2"
-        }
+        "message": "{\"request_id\": \"2\", \"httpRequest\": {\"headers\": {\"header1\": \"value1\"}}}"
     },
     {
         "ddsource": "securityhub",

--- a/aws/logs_monitoring/tests/approved_files/TestTransform.test_transform_waf.approved.json
+++ b/aws/logs_monitoring/tests/approved_files/TestTransform.test_transform_waf.approved.json
@@ -1,36 +1,14 @@
 [
     {
         "ddsource": "waf",
-        "message": {
-            "httpRequest": {
-                "headers": {
-                    "header1": "value1",
-                    "header2": "value2"
-                }
-            },
-            "request_id": "1"
-        }
+        "message": "{\"httpRequest\": {\"headers\": {\"header1\": \"value1\", \"header2\": \"value2\"}}, \"request_id\": \"1\"}"
     },
     {
         "ddsource": "waf",
-        "message": {
-            "httpRequest": {
-                "headers": {
-                    "header1": "value1"
-                }
-            },
-            "request_id": "2"
-        }
+        "message": "{\"httpRequest\": {\"headers\": {\"header1\": \"value1\"}}, \"request_id\": \"2\"}"
     },
     {
         "ddsource": "waf",
-        "message": {
-            "httpRequest": {
-                "headers": {
-                    "header3": "value3"
-                }
-            },
-            "request_id": "3"
-        }
+        "message": "{\"httpRequest\": {\"headers\": {\"header3\": \"value3\"}}, \"request_id\": \"3\"}"
     }
 ]

--- a/aws/logs_monitoring/tests/test_logs.py
+++ b/aws/logs_monitoring/tests/test_logs.py
@@ -112,6 +112,34 @@ class TestFilterLogs(unittest.TestCase):
         filtered_logs = filter_logs(DatadogMatcher(), self.example_logs)
         self.assertEqual(filtered_logs, self.example_logs)
 
+    def test_exclude_at_match_with_waf_logs(self):
+        """Test that EXCLUDE_AT_MATCH works on WAF logs after transformation serializes message back to JSON string"""
+        import json
+
+        logs = [
+            {"message": json.dumps({"action": "ALLOW", "httpRequest": {}})},
+            {"message": json.dumps({"action": "BLOCK", "httpRequest": {}})},
+        ]
+        filtered = filter_logs(
+            DatadogMatcher(exclude_pattern='"action": "BLOCK"'), logs
+        )
+        self.assertEqual(len(filtered), 1)
+        self.assertIn("ALLOW", filtered[0]["message"])
+
+    def test_include_at_match_with_waf_logs(self):
+        """Test that INCLUDE_AT_MATCH works on WAF logs after transformation serializes message back to JSON string"""
+        import json
+
+        logs = [
+            {"message": json.dumps({"action": "ALLOW", "httpRequest": {}})},
+            {"message": json.dumps({"action": "BLOCK", "httpRequest": {}})},
+        ]
+        filtered = filter_logs(
+            DatadogMatcher(include_pattern='"action": "ALLOW"'), logs
+        )
+        self.assertEqual(len(filtered), 1)
+        self.assertIn("ALLOW", filtered[0]["message"])
+
 
 def filter_logs(matcher, logs):
     filtered = []


### PR DESCRIPTION
### What does this PR do?

WAF log transformation was leaving message as a Python dict, causing regex-based filtering (EXCLUDE_AT_MATCH/INCLUDE_AT_MATCH) to fail since str(dict) uses single quotes instead of JSON double quotes.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
