### PR TITLE
perf(forwarder): compile multiline regex patterns once at module level

### DIFF
--- a/aws/logs_monitoring/steps/handlers/s3_handler.py
+++ b/aws/logs_monitoring/steps/handlers/s3_handler.py
@@ -27,6 +27,18 @@ from steps.common import (
 )
 
 
+_MULTILINE_REGEX_START_PATTERN = (
+    re.compile("^{}".format(DD_MULTILINE_LOG_REGEX_PATTERN))
+    if DD_MULTILINE_LOG_REGEX_PATTERN
+    else None
+)
+_MULTILINE_REGEX_PATTERN = (
+    re.compile("[\n\r\f]+(?={})".format(DD_MULTILINE_LOG_REGEX_PATTERN))
+    if DD_MULTILINE_LOG_REGEX_PATTERN
+    else None
+)
+
+
 class S3EventDataStore:
     def __init__(self):
         self.bucket = None
@@ -45,17 +57,8 @@ class S3EventHandler:
         self.context = context
         self.metadata = metadata
         self.cache_layer = cache_layer
-        self.multiline_regex_start_pattern = (
-            re.compile("^{}".format(DD_MULTILINE_LOG_REGEX_PATTERN))
-            if DD_MULTILINE_LOG_REGEX_PATTERN
-            else None
-        )
-        self.multiline_regex_pattern = (
-            re.compile("[\n\r\f]+(?={})".format(DD_MULTILINE_LOG_REGEX_PATTERN))
-            if DD_MULTILINE_LOG_REGEX_PATTERN
-            else None
-        )
-        # a private data store for event attributes
+        self.multiline_regex_start_pattern = _MULTILINE_REGEX_START_PATTERN
+        self.multiline_regex_pattern = _MULTILINE_REGEX_PATTERN
         self.data_store = S3EventDataStore()
 
     def handle(self, event):

--- a/aws/logs_monitoring/steps/handlers/s3_handler.py
+++ b/aws/logs_monitoring/steps/handlers/s3_handler.py
@@ -26,7 +26,6 @@ from steps.common import (
     parse_event_source,
 )
 
-
 _MULTILINE_REGEX_START_PATTERN = (
     re.compile("^{}".format(DD_MULTILINE_LOG_REGEX_PATTERN))
     if DD_MULTILINE_LOG_REGEX_PATTERN


### PR DESCRIPTION
## Summary
- `DD_MULTILINE_LOG_REGEX_PATTERN` was compiled into 2 regex objects on every `S3EventHandler` instantiation
- For SQS batches with ~10 records, that is 20 redundant `re.compile` calls per invocation
- Move the two compilations to module-level constants (`_MULTILINE_REGEX_START_PATTERN`, `_MULTILINE_REGEX_PATTERN`) and assign the pre-compiled references in `__init__`

## Test plan
- [ ] Existing `test_s3_handler.py` tests pass (tests set instance attributes directly, so they are unaffected)
- [ ] Verify multiline log regex still works end-to-end via integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)