### PR TITLE
perf(forwarder): parse event message JSON once in split()

### DIFF
--- a/aws/logs_monitoring/steps/splitting.py
+++ b/aws/logs_monitoring/steps/splitting.py
@@ -7,29 +7,23 @@ logger = logging.getLogger()
 logger.setLevel(logging.getLevelName(os.environ.get("DD_LOG_LEVEL", "INFO").upper()))
 
 
-_PARSE_FAILED = object()
-
-
-def _try_parse_message(event):
-    """Parse event message JSON once. Returns parsed object or _PARSE_FAILED sentinel."""
-    try:
-        return json.loads(event["message"])
-    except Exception:
-        return _PARSE_FAILED
-
-
 def split(events):
     """Split events into metrics, logs, and trace payloads"""
     metrics, logs, trace_payloads = [], [], []
     for event in events:
-        parsed = _try_parse_message(event)
-        metric = extract_metric(event, parsed_message=parsed)
+        try:
+            parsed = json.loads(event["message"])
+        except Exception:
+            logs.append(event)
+            continue
+
+        metric = extract_metric(parsed, event)
         if metric:
             metrics.append(metric)
-            continue
-        trace_payload = extract_trace_payload(event, parsed_message=parsed)
-        if trace_payload:
-            trace_payloads.append(trace_payload)
+        elif is_trace(parsed):
+            trace_payloads.append(
+                {"message": event["message"], "tags": event[DD_CUSTOM_TAGS]}
+            )
         else:
             logs.append(event)
 
@@ -41,53 +35,36 @@ def split(events):
     return metrics, logs, trace_payloads
 
 
-def extract_metric(event, parsed_message=None):
-    """Extract metric from an event if possible"""
+def extract_metric(parsed, event):
+    """Extract metric from a parsed event message if it matches the metric schema"""
     try:
-        if parsed_message is _PARSE_FAILED:
-            return None
-        metric = (
-            parsed_message
-            if parsed_message is not None
-            else json.loads(event["message"])
-        )
-
         required_attrs = {"m", "v", "e", "t"}
-        if not all(attr in metric for attr in required_attrs):
+        if not all(attr in parsed for attr in required_attrs):
             return None
-        if not isinstance(metric["t"], list):
+        if not isinstance(parsed["t"], list):
             return None
-        if not isinstance(metric["v"], (int, float)):
+        if not isinstance(parsed["v"], (int, float)):
             return None
 
         lambda_log_arn = event.get("lambda", {}).get("arn")
         if lambda_log_arn:
-            metric["t"] += [f"function_arn:{lambda_log_arn.lower()}"]
+            parsed["t"] += [f"function_arn:{lambda_log_arn.lower()}"]
 
-        metric["t"] += event[DD_CUSTOM_TAGS].split(",")
-        return metric
+        parsed["t"] += event[DD_CUSTOM_TAGS].split(",")
+        return parsed
     except Exception:
         return None
 
 
-def extract_trace_payload(event, parsed_message=None):
-    """Extract trace payload from an event if possible"""
+def is_trace(parsed):
+    """Check if a parsed message contains a valid Datadog trace payload"""
     try:
-        if parsed_message is _PARSE_FAILED:
-            return None
-        obj = (
-            parsed_message
-            if parsed_message is not None
-            else json.loads(event["message"])
-        )
-
-        traces = obj.get("traces")
+        traces = parsed.get("traces")
         if not isinstance(traces, list) or not traces or not traces[0]:
-            return None
+            return False
         # Verify this is a Datadog trace, not an unrelated "traces" array
         if traces[0][0].get("trace_id") is None:
-            return None
-
-        return {"message": event["message"], "tags": event[DD_CUSTOM_TAGS]}
+            return False
+        return True
     except Exception:
-        return None
+        return False

--- a/aws/logs_monitoring/steps/splitting.py
+++ b/aws/logs_monitoring/steps/splitting.py
@@ -7,15 +7,28 @@ logger = logging.getLogger()
 logger.setLevel(logging.getLevelName(os.environ.get("DD_LOG_LEVEL", "INFO").upper()))
 
 
+_PARSE_FAILED = object()
+
+
+def _try_parse_message(event):
+    """Parse event message JSON once. Returns parsed object or _PARSE_FAILED sentinel."""
+    try:
+        return json.loads(event["message"])
+    except Exception:
+        return _PARSE_FAILED
+
+
 def split(events):
     """Split events into metrics, logs, and trace payloads"""
     metrics, logs, trace_payloads = [], [], []
     for event in events:
-        metric = extract_metric(event)
-        trace_payload = extract_trace_payload(event)
+        parsed = _try_parse_message(event)
+        metric = extract_metric(event, parsed_message=parsed)
         if metric:
             metrics.append(metric)
-        elif trace_payload:
+            continue
+        trace_payload = extract_trace_payload(event, parsed_message=parsed)
+        if trace_payload:
             trace_payloads.append(trace_payload)
         else:
             logs.append(event)
@@ -28,21 +41,26 @@ def split(events):
     return metrics, logs, trace_payloads
 
 
-def extract_metric(event):
+def extract_metric(event, parsed_message=None):
     """Extract metric from an event if possible"""
     try:
-        metric = json.loads(event["message"])
+        if parsed_message is _PARSE_FAILED:
+            return None
+        metric = (
+            parsed_message
+            if parsed_message is not None
+            else json.loads(event["message"])
+        )
+
         required_attrs = {"m", "v", "e", "t"}
         if not all(attr in metric for attr in required_attrs):
             return None
         if not isinstance(metric["t"], list):
             return None
-        if not (isinstance(metric["v"], int) or isinstance(metric["v"], float)):
+        if not isinstance(metric["v"], (int, float)):
             return None
 
-        lambda_log_metadata = event.get("lambda", {})
-        lambda_log_arn = lambda_log_metadata.get("arn")
-
+        lambda_log_arn = event.get("lambda", {}).get("arn")
         if lambda_log_arn:
             metric["t"] += [f"function_arn:{lambda_log_arn.lower()}"]
 
@@ -52,23 +70,24 @@ def extract_metric(event):
         return None
 
 
-def extract_trace_payload(event):
+def extract_trace_payload(event, parsed_message=None):
     """Extract trace payload from an event if possible"""
     try:
-        message = event["message"]
-        obj = json.loads(event["message"])
-
-        obj_has_traces = "traces" in obj
-        traces_is_a_list = isinstance(obj["traces"], list)
-        # check that the log is not containing a trace array unrelated to Datadog
-        trace_id_found = (
-            len(obj["traces"]) > 0
-            and len(obj["traces"][0]) > 0
-            and obj["traces"][0][0]["trace_id"] is not None
+        if parsed_message is _PARSE_FAILED:
+            return None
+        obj = (
+            parsed_message
+            if parsed_message is not None
+            else json.loads(event["message"])
         )
 
-        if obj_has_traces and traces_is_a_list and trace_id_found:
-            return {"message": message, "tags": event[DD_CUSTOM_TAGS]}
-        return None
+        traces = obj.get("traces")
+        if not isinstance(traces, list) or not traces or not traces[0]:
+            return None
+        # Verify this is a Datadog trace, not an unrelated "traces" array
+        if traces[0][0].get("trace_id") is None:
+            return None
+
+        return {"message": event["message"], "tags": event[DD_CUSTOM_TAGS]}
     except Exception:
         return None

--- a/aws/logs_monitoring/tests/test_splitting.py
+++ b/aws/logs_monitoring/tests/test_splitting.py
@@ -1,54 +1,60 @@
 import unittest
 from steps.splitting import (
     extract_metric,
-    extract_trace_payload,
+    is_trace,
 )
 
 
 class TestExtractMetric(unittest.TestCase):
-    def test_empty_event(self):
-        self.assertEqual(extract_metric({}), None)
+    def test_empty_parsed(self):
+        self.assertEqual(extract_metric({}, {}), None)
 
     def test_missing_keys(self):
-        self.assertEqual(extract_metric({"e": 0, "v": 1, "m": "foo"}), None)
+        self.assertEqual(extract_metric({"e": 0, "v": 1, "m": "foo"}, {}), None)
 
     def test_tags_instance(self):
-        self.assertEqual(extract_metric({"e": 0, "v": 1, "m": "foo", "t": 666}), None)
+        self.assertEqual(
+            extract_metric({"e": 0, "v": 1, "m": "foo", "t": 666}, {}), None
+        )
 
-    def test_value_instance(self):
-        self.assertEqual(extract_metric({"e": 0, "v": 1.1, "m": "foo", "t": []}), None)
+    def test_value_not_numeric(self):
+        self.assertEqual(
+            extract_metric({"e": 0, "v": None, "m": "foo", "t": []}, {}), None
+        )
+
+    def test_value_instance_int(self):
+        event = {"ddtags": "env:test"}
+        parsed = {"e": 0, "v": 1, "m": "foo", "t": []}
+        result = extract_metric(parsed, event)
+        self.assertIsNotNone(result)
+        self.assertIn("env:test", result["t"])
 
     def test_value_instance_float(self):
-        self.assertEqual(extract_metric({"e": 0, "v": None, "m": "foo", "t": []}), None)
+        event = {"ddtags": "env:test"}
+        parsed = {"e": 0, "v": 1.1, "m": "foo", "t": []}
+        result = extract_metric(parsed, event)
+        self.assertIsNotNone(result)
+        self.assertIn("env:test", result["t"])
 
 
-class TestLambdaFunctionExtractTracePayload(unittest.TestCase):
-    def test_extract_trace_payload_none_no_trace(self):
-        message_json = """{
-            "key": "value"
-        }"""
-        self.assertEqual(extract_trace_payload({"message": message_json}), None)
+class TestIsTrace(unittest.TestCase):
+    def test_no_traces_key(self):
+        self.assertFalse(is_trace({"key": "value"}))
 
-    def test_extract_trace_payload_none_exception(self):
-        message_json = """{
-            "invalid_json"
-        }"""
-        self.assertEqual(extract_trace_payload({"message": message_json}), None)
+    def test_invalid_json_type(self):
+        self.assertFalse(is_trace("not a dict"))
 
-    def test_extract_trace_payload_unrelated_datadog_trace(self):
-        message_json = """{"traces":["I am a trace"]}"""
-        self.assertEqual(extract_trace_payload({"message": message_json}), None)
+    def test_unrelated_traces_array(self):
+        self.assertFalse(is_trace({"traces": ["I am a trace"]}))
 
-    def test_extract_trace_payload_valid_trace(self):
-        message_json = """{"traces":[[{"trace_id":1234}]]}"""
-        tags_json = """["key0:value", "key1:value1"]"""
-        item = {
-            "message": '{"traces":[[{"trace_id":1234}]]}',
-            "tags": '["key0:value", "key1:value1"]',
-        }
-        self.assertEqual(
-            extract_trace_payload({"message": message_json, "ddtags": tags_json}), item
-        )
+    def test_valid_trace(self):
+        self.assertTrue(is_trace({"traces": [[{"trace_id": 1234}]]}))
+
+    def test_empty_traces(self):
+        self.assertFalse(is_trace({"traces": []}))
+
+    def test_traces_not_list(self):
+        self.assertFalse(is_trace({"traces": "not a list"}))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `extract_metric()` and `extract_trace_payload()` both called `json.loads(event["message"])` independently
- For plain log events (the majority), both fail with exceptions — 2x parse + 2x exception overhead per event
- Parse once in `split()` and pass the pre-parsed dict directly to the extractors
- `extract_metric(parsed, event)` validates and enriches a pre-parsed dict
- `is_trace(parsed)` is a pure predicate — the trace payload dict is built in `split()` since it only needs the raw message and tags
- Events that fail JSON parsing are classified as logs immediately, skipping both extractors

## Test plan
- [ ] `test_splitting.py` tests pass (12 tests covering metric validation, trace detection, and edge cases)
- [ ] Verify log/metric/trace splitting works end-to-end via integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)