### PR TITLE
Clarify JSON array ingestion behavior for S3 log files

### DIFF
--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -282,6 +282,17 @@ If you still couldn't figure out, please create a ticket for [Datadog Support][1
 
 If your logs contain an attribute that Datadog parses as a timestamp, you need to make sure that the timestamp is both current and in the correct format. See [Log Date Remapper][24] to learn about which attributes are parsed as timestamps and how to make sure that the timestamp is valid.
 
+### S3 log files containing JSON arrays are ingested as a single event
+
+The Forwarder ingests each line of a log file as a separate event. If your S3 log file contains a JSON array (for example, `[{...}, {...}]`), the entire array is treated as a single log event. Datadog pipelines and processors cannot split a JSON array into multiple individual events after ingestion.
+
+To ensure each log entry is ingested as a separate event, format your log files as newline-delimited JSON (NDJSON), where each JSON object is on its own line:
+
+```json
+{"key": "value1"}
+{"key": "value2"}
+```
+
 ### Issue creating S3 triggers
 
 In case you encounter the following error when creating S3 triggers, we recommend considering following a fanout architecture proposed by AWS [in this article](https://aws.amazon.com/blogs/compute/fanout-s3-event-notifications-to-multiple-endpoints/)

--- a/aws/logs_monitoring/README.md
+++ b/aws/logs_monitoring/README.md
@@ -284,7 +284,7 @@ If your logs contain an attribute that Datadog parses as a timestamp, you need t
 
 ### S3 log files containing JSON arrays are ingested as a single event
 
-The Forwarder ingests each line of a log file as a separate event. If your S3 log file contains a JSON array (for example, `[{...}, {...}]`), the entire array is treated as a single log event. Datadog pipelines and processors cannot split a JSON array into multiple individual events after ingestion.
+The Forwarder ingests each line of a log file as a separate event. If your S3 log file contains a JSON array (for example, `[{...}, {...}]`), the entire array is treated as a single log event. Datadog log pipelines and processors cannot split a JSON array into multiple individual events after ingestion.
 
 To ensure each log entry is ingested as a separate event, format your log files as newline-delimited JSON (NDJSON), where each JSON object is on its own line:
 


### PR DESCRIPTION
### What does this PR do?
Adds a troubleshooting subsection to the Forwarder README clarifying that S3 log files containing JSON arrays are ingested as a single log event, and that newline-delimited JSON (NDJSON) is required to ingest each entry as a separate event.

  ### Motivation
Customers sending logs from S3 via the Lambda Log Forwarder have encountered unexpected behavior when their log files contain JSON arrays. The current documentation states that logs must be in JSON format but does not specify that JSON arrays are treated as a single event. This change surfaces that requirement upfront to help users avoid ingestion issues.

  ### Testing Guidelines
 No functional changes — documentation update only.

  ### Additional Notes
  This change was requested in [DOCS-13685](https://datadoghq.atlassian.net/browse/DOCS-13685) based on customer feedback.

  ### Types of changes
  - Documentation update

[DOCS-13685]: https://datadoghq.atlassian.net/browse/DOCS-13685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ