### PR TITLE
[AWS] fix(CVE): pin versions of packages to resolve CVEs

### DIFF
--- a/aws/logs_monitoring/requirements.txt
+++ b/aws/logs_monitoring/requirements.txt
@@ -15,7 +15,7 @@ importlib-metadata
 opentelemetry-api
 protobuf==6.33.5
 requests-futures
-requests
+requests==2.33.0
 setuptools==80.10.2
 six
 typing-extensions
@@ -23,4 +23,4 @@ urllib3>=2.6.3,<3.0
 wrapt==1.14.0
 xmltodict
 zipp
-ujson
+ujson==5.12.0


### PR DESCRIPTION
Pins the requests/ujson requirements versions to resolve CVEs 
- requests==2.33.0 (fixes CVE-2026-25645)                                                                                                                                                                                                                                  
- ujson==5.12.0 (fixes CVE-2026-32874 and CVE-2026-32875)


Sources

  - CVE-2026-25645: https://cve.threatint.eu/CVE/CVE-2026-25645 / https://github.com/advisories/GHSA-gc5v-m9x4-r6x2
  - CVE-2026-32874: https://nvd.nist.gov/vuln/detail/CVE-2026-32874
  - CVE-2026-32875: https://nvd.nist.gov/vuln/detail/CVE-2026-32875