### PR TITLE
Update version from 5.3.0 to 5.4.0

### DIFF
--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -337,7 +337,7 @@ DD_SOURCE = "ddsource"
 DD_CUSTOM_TAGS = "ddtags"
 DD_SERVICE = "service"
 DD_HOST = "host"
-DD_FORWARDER_VERSION = "5.3.0"
+DD_FORWARDER_VERSION = "5.4.0"
 
 # CONST STRINGS
 AWS_STRING = "aws"

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -3,8 +3,8 @@ Description: Pushes logs, metrics and traces from AWS to Datadog.
 Mappings:
   Constants:
     DdForwarder:
-      Version: 5.3.0
-      LayerVersion: "97"
+      Version: 5.4.0
+      LayerVersion: "98"
 Parameters:
   DdApiKey:
     Type: String


### PR DESCRIPTION
This PR updates the AWS Forwarder version to 5.4.0 and the layer version to 98.