### PR TITLE
Remove --grants from S3 cp command in release script

### DIFF
--- a/aws/logs_monitoring/release.sh
+++ b/aws/logs_monitoring/release.sh
@@ -377,10 +377,8 @@ fi
 log_info "Uploading template.yaml to s3://${BUCKET}/aws/forwarder/${FORWARDER_VERSION}.yaml"
 
 if [[ ${ACCOUNT} == "prod" ]]; then
-    aws_login aws s3 cp template.yaml "s3://${BUCKET}/aws/forwarder/${FORWARDER_VERSION}.yaml" \
-        --grants "read=uri=http://acs.amazonaws.com/groups/global/AllUsers"
-    aws_login aws s3 cp template.yaml "s3://${BUCKET}/aws/forwarder/latest.yaml" \
-        --grants "read=uri=http://acs.amazonaws.com/groups/global/AllUsers"
+    aws_login aws s3 cp template.yaml "s3://${BUCKET}/aws/forwarder/${FORWARDER_VERSION}.yaml"
+    aws_login aws s3 cp template.yaml "s3://${BUCKET}/aws/forwarder/latest.yaml"
 elif [[ ${ACCOUNT} == "datadog" ]]; then
     aws_login aws s3 cp template.yaml "s3://${BUCKET}/aws/forwarder/${FORWARDER_VERSION}.yaml"
     aws_login aws s3 cp template.yaml "s3://${BUCKET}/aws/forwarder/latest.yaml"


### PR DESCRIPTION
* this setting enforced by default
* we can't make `--grants` API call, so this fails

Removing it achieves the same result with no errors.