### PR TITLE
[AWSINTS] chore(CVEs): bump libraries

### DIFF
--- a/aws/logs_monitoring/requirements.txt
+++ b/aws/logs_monitoring/requirements.txt
@@ -19,8 +19,8 @@ requests==2.33.0
 setuptools==80.10.2
 six
 typing-extensions
-urllib3>=2.6.3,<3.0
+urllib3==2.7.0
 wrapt==1.14.0
 xmltodict
 zipp
-ujson==5.12.0
+ujson==5.12.1


### PR DESCRIPTION
Fixing reported CVEs on the Forwarder:

[CVE-2026-44432](https://www.tenable.com/cve/CVE-2026-44432) / [CVE-2026-44431](https://www.tenable.com/cve/CVE-2026-44431) : Fixed by pinning urllib3 to the fixed version 2.7.0
[CVE-2026-44660](https://www.miggo.io/vulnerability-database/cve/CVE-2026-44660) : Fixed by pinning ujson to the fixed version 5.12.1
