### PR TITLE
[AWSINTS-3657] feat(go-forwarder): add WAF

### DIFF
--- a/aws/logs_monitoring_go/internal/handling/cloudtrail.go
+++ b/aws/logs_monitoring_go/internal/handling/cloudtrail.go
@@ -8,13 +8,14 @@ package handling
 import (
 	"compress/gzip"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"iter"
 	"log/slog"
 	"regexp"
 	"strings"
+
+	"github.com/DataDog/datadog-serverless-functions/aws/logs_monitoring_go/internal/parsing"
 )
 
 const (
@@ -31,23 +32,14 @@ func decodeCloudTrail(r io.Reader) iter.Seq2[string, error] {
 	return func(yield func(string, error) bool) {
 		gz, err := gzip.NewReader(r)
 		if err != nil {
-			yield("", fmt.Errorf("decode cloudtrail gzip: %w", err))
+			yield("", fmt.Errorf("gzip: %w", err))
 			return
 		}
 		defer gz.Close() //nolint:errcheck
 
 		dec := json.NewDecoder(gz)
-
-		if t, err := dec.Token(); err != nil || t != json.Delim('{') {
-			yield("", errors.New("decode cloudtrail: expected '{' at start of JSON"))
-			return
-		}
-		if t, err := dec.Token(); err != nil || t != "Records" {
-			yield("", errors.New("decode cloudtrail: expected 'Records' key"))
-			return
-		}
-		if t, err := dec.Token(); err != nil || t != json.Delim('[') {
-			yield("", errors.New("decode cloudtrail: expected '[' at start of Records array"))
+		if err := parsing.SkipToRecords(dec); err != nil {
+			yield("", fmt.Errorf("cloudtrail: %w", err))
 			return
 		}
 
@@ -64,55 +56,33 @@ func decodeCloudTrail(r io.Reader) iter.Seq2[string, error] {
 	}
 }
 
-func cloudtrailHost(message string) string {
+func cloudtrailHost(message string) (host string) {
 	dec := json.NewDecoder(strings.NewReader(message))
-	if t, err := dec.Token(); err != nil || t != json.Delim('{') {
-		return ""
+	if err := parsing.SkipBrace(dec); err != nil {
+		return
 	}
 
-	for dec.More() {
-		key, err := dec.Token()
-		if err != nil {
-			return ""
-		}
-		if key != cloudTrailUserIdentityKey {
-			var skip json.RawMessage
-			if err := dec.Decode(&skip); err != nil {
-				return ""
-			}
-			continue
-		}
-
-		if t, err := dec.Token(); err != nil || t != json.Delim('{') {
-			return ""
-		}
-
-		for dec.More() {
-			innerKey, err := dec.Token()
-			if err != nil {
-				return ""
-			}
-			if innerKey != cloudTrailARNKey {
-				var skip json.RawMessage
-				if err := dec.Decode(&skip); err != nil {
-					return ""
-				}
-				continue
-			}
-
-			var arn string
-			if err := dec.Decode(&arn); err != nil {
-				return ""
-			}
-
-			matches := ec2InstanceRegexp.FindStringSubmatch(arn)
-			if matches == nil {
-				slog.Debug(arn + " arn did not match an EC2 host instance, cloudtrail host extraction skipped")
-				return ""
-			}
-			return matches[ec2InstanceRegexp.SubexpIndex("host")]
-		}
-		return ""
+	if err := parsing.SkipToKey(dec, "userIdentity"); err != nil {
+		return
 	}
-	return ""
+
+	if err := parsing.SkipBrace(dec); err != nil {
+		return
+	}
+
+	if err := parsing.SkipToKey(dec, "arn"); err != nil {
+		return
+	}
+
+	var arn string
+	if err := dec.Decode(&arn); err != nil {
+		return
+	}
+
+	matches := ec2InstanceRegexp.FindStringSubmatch(arn)
+	if matches != nil {
+		host = matches[ec2InstanceRegexp.SubexpIndex("host")]
+		slog.Debug("ec2 host found in userIdentity.arn")
+	}
+	return
 }

--- a/aws/logs_monitoring_go/internal/handling/cloudtrail.go
+++ b/aws/logs_monitoring_go/internal/handling/cloudtrail.go
@@ -18,11 +18,6 @@ import (
 	"github.com/DataDog/datadog-serverless-functions/aws/logs_monitoring_go/internal/parsing"
 )
 
-const (
-	cloudTrailARNKey          = "arn"
-	cloudTrailUserIdentityKey = "userIdentity"
-)
-
 var (
 	cloudTrailRegex   = regexp.MustCompile(`\d+_CloudTrail(|-Digest|-Insight)_\w{2}(|-gov|-cn)-\w{4,9}-\d_(|.+)\d{8}T\d{4,6}Z(|.+)\.json\.gz$`)
 	ec2InstanceRegexp = regexp.MustCompile(`^arn:aws:sts::.*?:assumed-role/(?P<role>.*?)/(?P<host>i-([0-9a-f]{8}|[0-9a-f]{17}))$`)

--- a/aws/logs_monitoring_go/internal/handling/s3.go
+++ b/aws/logs_monitoring_go/internal/handling/s3.go
@@ -7,10 +7,11 @@ package handling
 
 import (
 	"cmp"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
-	"iter"
+	"io"
 	"log/slog"
 	"slices"
 	"strings"
@@ -22,10 +23,9 @@ import (
 )
 
 const (
-	s3KeyWAF1       = "aws-waf-logs"
-	s3KeyWAF2       = "waflogs"
-	s3KeyKinesis    = "amazon_kinesis"
-	s3KeyCloudtrail = "_CloudTrail_"
+	s3KeyWAF1    = "aws-waf-logs"
+	s3KeyWAF2    = "waflogs"
+	s3KeyKinesis = "amazon_kinesis"
 )
 
 type S3Handler struct {
@@ -63,65 +63,30 @@ func (h *S3Handler) Handle(ctx context.Context, event json.RawMessage, out chan<
 }
 
 func (h S3Handler) processRecord(ctx context.Context, client S3APIClient, out chan<- model.LogEntry, eventRecord events.S3EventRecord, lambdaOrigin model.LambdaOrigin) error {
-	bucket := eventRecord.S3.Bucket.Name
-	key := eventRecord.S3.Object.URLDecodedKey
-
-	body, err := getS3Object(ctx, client, bucket, key)
+	body, err := getS3Object(ctx, client, eventRecord.S3.Bucket.Name, eventRecord.S3.Object.URLDecodedKey)
 	if err != nil {
 		return err
 	}
 	defer func() {
 		if err := body.Close(); err != nil {
-			slog.Warn("failed to close response body", slog.Any("error", err))
+			slog.Warn("close response body", slog.Any("error", err))
 		}
 	}()
 
-	var records iter.Seq2[string, error]
-	isCloudTrail := cloudTrailRegex.MatchString(key)
-	if isCloudTrail {
-		records = decodeCloudTrail(body)
-	} else {
-		records = scan(body, h.cfg.S3MultilineLogRegex)
+	source := S3Source(eventRecord.S3.Object.URLDecodedKey)
+	switch source {
+	case sourceCloudtrail:
+		err = h.CloudTrail(ctx, out, body, eventRecord, lambdaOrigin)
+	case sourceWAF:
+		err = h.WAF(ctx, out, body, eventRecord, lambdaOrigin)
+	default:
+		err = h.S3(ctx, out, body, eventRecord, lambdaOrigin)
 	}
 
-	for message, err := range records {
-		if err != nil {
-			return err
-		}
-		entry := h.newS3LogEntry(eventRecord, message, lambdaOrigin)
-		if h.cfg.Filter.ShouldExclude(entry.Message) {
-			continue
-		}
-
-		if isCloudTrail {
-			entry.Host = cloudtrailHost(message)
-		}
-		entry.Message = h.cfg.Scrubber.Scrub(entry.Message)
-		if err := concurrent.SafeSender(ctx, out, entry); err != nil {
-			return err
-		}
+	if err != nil {
+		return fmt.Errorf("source %s: %w", source, err)
 	}
 	return nil
-}
-
-func (h S3Handler) newS3LogEntry(eventRecord events.S3EventRecord, message string, lambdaOrigin model.LambdaOrigin) model.LogEntry {
-	key := eventRecord.S3.Object.URLDecodedKey
-	metadata := model.S3Metadata{
-		LambdaOrigin: lambdaOrigin,
-		Origin: model.S3Origin{
-			Bucket: eventRecord.S3.Bucket.Name,
-			Key:    key,
-		},
-	}
-	tags, service, message := extractFromMessage(message)
-
-	entry := model.NewLogEntry()
-	entry.Message = message
-	entry.Metadata = metadata
-	entry.Source = cmp.Or(h.cfg.Source, S3Source(key))
-	entry.Service = cmp.Or(h.cfg.Service, service, entry.Source)
-	entry.Tags = slices.Concat(tags, h.cfg.Tags)
-	return entry
 }
 
 func S3Source(key string) string {
@@ -131,8 +96,102 @@ func S3Source(key string) string {
 	if strings.Contains(key, s3KeyKinesis) {
 		return sourceKinesis
 	}
-	if strings.Contains(key, s3KeyCloudtrail) {
+	if cloudTrailRegex.Match([]byte(key)) {
 		return sourceCloudtrail
 	}
 	return sourceS3
+}
+
+func (h S3Handler) S3(ctx context.Context, out chan<- model.LogEntry, body io.ReadCloser, eventRecord events.S3EventRecord, lambdaOrigin model.LambdaOrigin) error {
+	base := h.newBaseEntry(eventRecord, lambdaOrigin)
+	for message, err := range scan(body, h.cfg.S3MultilineLogRegex) {
+		if err != nil {
+			return err
+		}
+
+		tags, service, message := extractFromMessage(message)
+		if h.cfg.Filter.ShouldExclude(message) {
+			continue
+		}
+
+		entry := base
+		entry.Message = h.cfg.Scrubber.Scrub(message)
+		entry.Service = cmp.Or(service, entry.Service)
+		entry.Tags = slices.Concat(tags, entry.Tags)
+
+		if err := concurrent.SafeSender(ctx, out, entry); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (h S3Handler) WAF(ctx context.Context, out chan<- model.LogEntry, body io.ReadCloser, eventRecord events.S3EventRecord, lambdaOrigin model.LambdaOrigin) error {
+	gz, err := gzip.NewReader(body)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := gz.Close(); err != nil {
+			slog.Warn("close gzip reader", slog.Any("error", err))
+		}
+	}()
+
+	base := h.newBaseEntry(eventRecord, lambdaOrigin)
+	for message, err := range scan(gz, nil) {
+		if err != nil {
+			return err
+		}
+
+		message = flattenWAFMessage(message)
+		if h.cfg.Filter.ShouldExclude(message) {
+			continue
+		}
+
+		entry := base
+		entry.Message = h.cfg.Scrubber.Scrub(message)
+
+		if err := concurrent.SafeSender(ctx, out, entry); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (h S3Handler) CloudTrail(ctx context.Context, out chan<- model.LogEntry, body io.ReadCloser, eventRecord events.S3EventRecord, lambdaOrigin model.LambdaOrigin) error {
+	base := h.newBaseEntry(eventRecord, lambdaOrigin)
+	for message, err := range decodeCloudTrail(body) {
+		if err != nil {
+			return err
+		}
+		if h.cfg.Filter.ShouldExclude(message) {
+			continue
+		}
+
+		entry := base
+		entry.Host = cloudtrailHost(message)
+		entry.Message = h.cfg.Scrubber.Scrub(message)
+
+		if err := concurrent.SafeSender(ctx, out, entry); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (h S3Handler) newBaseEntry(eventRecord events.S3EventRecord, lambdaOrigin model.LambdaOrigin) model.LogEntry {
+	source := S3Source(eventRecord.S3.Object.URLDecodedKey)
+
+	entry := model.NewLogEntry()
+	entry.Source = cmp.Or(h.cfg.Source, source)
+	entry.Service = cmp.Or(h.cfg.Service, source)
+	entry.Tags = h.cfg.Tags
+	entry.Metadata = model.S3Metadata{
+		LambdaOrigin: lambdaOrigin,
+		Origin: model.S3Origin{
+			Bucket: eventRecord.S3.Bucket.Name,
+			Key:    eventRecord.S3.Object.URLDecodedKey,
+		},
+	}
+	return entry
 }

--- a/aws/logs_monitoring_go/internal/handling/s3_test.go
+++ b/aws/logs_monitoring_go/internal/handling/s3_test.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -36,6 +35,14 @@ var (
 		S3: events.S3Entity{
 			Bucket: events.S3Bucket{Name: "trail-bucket"},
 			Object: events.S3Object{URLDecodedKey: testCloudTrailKey},
+		},
+	}
+
+	testWAFKey         = "AWSLogs/123456779121/WAFLogs/us-east-1/webacl/aws-waf-logs-example.log.gz"
+	testWAFEventRecord = events.S3EventRecord{
+		S3: events.S3Entity{
+			Bucket: events.S3Bucket{Name: "waf-bucket"},
+			Object: events.S3Object{URLDecodedKey: testWAFKey},
 		},
 	}
 )
@@ -125,7 +132,7 @@ func TestProcessS3Record(t *testing.T) {
 						Body: io.NopCloser(strings.NewReader("2024-01-15 ERROR NullPointer\n    at com.foo.Bar\n2024-01-15 INFO started")),
 					}, nil)
 			},
-			cfg:         &config.Config{S3MultilineLogRegex: regexp.MustCompile(`\d{4}-\d{2}-\d{2}`)},
+			cfg:         testutil.Config(t, testutil.WithMultilineRegex(`\d{4}-\d{2}-\d{2}`)),
 			eventRecord: testS3EventRecord,
 			want: []model.LogEntry{
 				wantS3Entry("2024-01-15 ERROR NullPointer\n    at com.foo.Bar\n", "s3", "s3", nil),
@@ -139,7 +146,7 @@ func TestProcessS3Record(t *testing.T) {
 						Body: io.NopCloser(strings.NewReader("2024-01-15 ERROR\n    stacktrace")),
 					}, nil)
 			},
-			cfg:         &config.Config{S3MultilineLogRegex: regexp.MustCompile(`\d{4}-\d{2}-\d{2}`)},
+			cfg:         testutil.Config(t, testutil.WithMultilineRegex(`\d{4}-\d{2}-\d{2}`)),
 			eventRecord: testS3EventRecord,
 			want:        []model.LogEntry{wantS3Entry("2024-01-15 ERROR\n    stacktrace", "s3", "s3", nil)},
 		},
@@ -150,7 +157,7 @@ func TestProcessS3Record(t *testing.T) {
 						Body: io.NopCloser(strings.NewReader("line1")),
 					}, nil)
 			},
-			cfg:         &config.Config{Tags: model.Tags{"env:prod", "team:aws"}},
+			cfg:         testutil.Config(t, testutil.WithTags("env:prod", "team:aws")),
 			eventRecord: testS3EventRecord,
 			want:        []model.LogEntry{wantS3Entry("line1", "s3", "s3", model.Tags{"env:prod", "team:aws"})},
 		},
@@ -206,6 +213,77 @@ func TestProcessS3Record(t *testing.T) {
 				),
 			},
 		},
+		"waf single line": {
+			mockSetup: func(m *MockS3APIClient) {
+				data := testutil.MustGzip(t, []byte(`{"httpRequest":{"headers":[{"name":"Host","value":"example.com"}]}}`))
+				m.EXPECT().GetObject(gomock.Any(), gomock.Any()).
+					Return(&s3.GetObjectOutput{
+						Body: io.NopCloser(bytes.NewReader(data)),
+					}, nil)
+			},
+			cfg:         testutil.EmptyConfig(),
+			eventRecord: testWAFEventRecord,
+			want:        []model.LogEntry{wantWAFEntry(`{"httpRequest":{"headers":{"Host":"example.com"}}}`)},
+		},
+		"waf multiple lines": {
+			mockSetup: func(m *MockS3APIClient) {
+				lines := `{"httpRequest":{"headers":[{"name":"h1","value":"v1"}]}}` + "\n" +
+					`{"httpRequest":{"headers":[{"name":"h2","value":"v2"}]}}`
+				data := testutil.MustGzip(t, []byte(lines))
+				m.EXPECT().GetObject(gomock.Any(), gomock.Any()).
+					Return(&s3.GetObjectOutput{
+						Body: io.NopCloser(bytes.NewReader(data)),
+					}, nil)
+			},
+			cfg:         testutil.EmptyConfig(),
+			eventRecord: testWAFEventRecord,
+			want: []model.LogEntry{
+				wantWAFEntry(`{"httpRequest":{"headers":{"h1":"v1"}}}`),
+				wantWAFEntry(`{"httpRequest":{"headers":{"h2":"v2"}}}`),
+			},
+		},
+		"waf does not apply multiline regex": {
+			mockSetup: func(m *MockS3APIClient) {
+				lines := `{"action":"ALLOW"}` + "\n" + `{"action":"BLOCK"}`
+				data := testutil.MustGzip(t, []byte(lines))
+				m.EXPECT().GetObject(gomock.Any(), gomock.Any()).
+					Return(&s3.GetObjectOutput{
+						Body: io.NopCloser(bytes.NewReader(data)),
+					}, nil)
+			},
+			cfg:         testutil.Config(t, testutil.WithMultilineRegex(`\{`)),
+			eventRecord: testWAFEventRecord,
+			want: []model.LogEntry{
+				wantWAFEntry(`{"action":"ALLOW"}`),
+				wantWAFEntry(`{"action":"BLOCK"}`),
+			},
+		},
+		"waf exclude at match": {
+			mockSetup: func(m *MockS3APIClient) {
+				lines := `{"action":"ALLOW","httpRequest":{}}` + "\n" + `{"action":"BLOCK","httpRequest":{}}`
+				data := testutil.MustGzip(t, []byte(lines))
+				m.EXPECT().GetObject(gomock.Any(), gomock.Any()).
+					Return(&s3.GetObjectOutput{
+						Body: io.NopCloser(bytes.NewReader(data)),
+					}, nil)
+			},
+			cfg:         testutil.Config(t, testutil.WithExcludeFilter(`"action":"BLOCK"`)),
+			eventRecord: testWAFEventRecord,
+			want:        []model.LogEntry{wantWAFEntry(`{"action":"ALLOW","httpRequest":{}}`)},
+		},
+		"waf include at match": {
+			mockSetup: func(m *MockS3APIClient) {
+				lines := `{"action":"ALLOW","httpRequest":{}}` + "\n" + `{"action":"BLOCK","httpRequest":{}}`
+				data := testutil.MustGzip(t, []byte(lines))
+				m.EXPECT().GetObject(gomock.Any(), gomock.Any()).
+					Return(&s3.GetObjectOutput{
+						Body: io.NopCloser(bytes.NewReader(data)),
+					}, nil)
+			},
+			cfg:         testutil.Config(t, testutil.WithIncludeFilter(`"action":"ALLOW"`)),
+			eventRecord: testWAFEventRecord,
+			want:        []model.LogEntry{wantWAFEntry(`{"action":"ALLOW","httpRequest":{}}`)},
+		},
 	}
 
 	for name, tc := range tests {
@@ -246,6 +324,18 @@ func wantCloudTrailEntry(message, host string) model.LogEntry {
 	entry.Metadata = model.S3Metadata{
 		LambdaOrigin: testutil.LambdaOrigin(),
 		Origin:       model.S3Origin{Bucket: "trail-bucket", Key: testCloudTrailKey},
+	}
+	return entry
+}
+
+func wantWAFEntry(message string) model.LogEntry {
+	entry := model.NewLogEntry()
+	entry.Message = message
+	entry.Source = sourceWAF
+	entry.Service = sourceWAF
+	entry.Metadata = model.S3Metadata{
+		LambdaOrigin: testutil.LambdaOrigin(),
+		Origin:       model.S3Origin{Bucket: "waf-bucket", Key: testWAFKey},
 	}
 	return entry
 }

--- a/aws/logs_monitoring_go/internal/handling/waf.go
+++ b/aws/logs_monitoring_go/internal/handling/waf.go
@@ -1,0 +1,133 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-Present Datadog, Inc.
+
+package handling
+
+import "encoding/json"
+
+const ruleIDKey = "ruleId"
+
+func flattenWAFMessage(message string) string {
+	var msg map[string]any
+	if err := json.Unmarshal([]byte(message), &msg); err != nil {
+		return message
+	}
+
+	flattenHeaders(msg)
+	flattenRuleGroupList(msg)
+	flattenByKey(msg, "rateBasedRuleList", "rateBasedRuleName")
+	flattenByKey(msg, "nonTerminatingMatchingRules", ruleIDKey)
+
+	out, err := json.Marshal(msg)
+	if err != nil {
+		return message
+	}
+	return string(out)
+}
+
+func flattenHeaders(msg map[string]any) {
+	httpReq, ok := msg["httpRequest"].(map[string]any)
+	if !ok {
+		return
+	}
+	headers, ok := httpReq["headers"].([]any)
+	if !ok {
+		return
+	}
+
+	result := make(map[string]any, len(headers))
+	for _, h := range headers {
+		header, ok := h.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := header["name"].(string)
+		if name == "" {
+			continue
+		}
+		result[name] = header["value"]
+	}
+	httpReq["headers"] = result
+}
+
+func flattenByKey(msg map[string]any, field, keyField string) {
+	arr, ok := msg[field].([]any)
+	if !ok {
+		return
+	}
+
+	result := make(map[string]any, len(arr))
+	for _, item := range arr {
+		entry, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		key, _ := entry[keyField].(string)
+		if key == "" {
+			continue
+		}
+		delete(entry, keyField)
+		result[key] = entry
+	}
+	msg[field] = result
+}
+
+func flattenRuleGroupList(msg map[string]any) {
+	arr, ok := msg["ruleGroupList"].([]any)
+	if !ok {
+		return
+	}
+
+	result := make(map[string]any, len(arr))
+	for _, item := range arr {
+		group, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		groupID, _ := group["ruleGroupId"].(string)
+		delete(group, "ruleGroupId")
+
+		existing, ok := result[groupID].(map[string]any)
+		if !ok {
+			existing = make(map[string]any)
+			result[groupID] = existing
+		}
+
+		flattenRuleGroupField(group, existing, "terminatingRule")
+		flattenRuleGroupField(group, existing, "nonTerminatingMatchingRules")
+		flattenRuleGroupField(group, existing, "excludedRules")
+	}
+	msg["ruleGroupList"] = result
+}
+
+func flattenRuleGroupField(group, dest map[string]any, field string) {
+	val, exists := group[field]
+	if !exists {
+		return
+	}
+
+	target, ok := dest[field].(map[string]any)
+	if !ok {
+		target = make(map[string]any)
+		dest[field] = target
+	}
+
+	switch v := val.(type) {
+	case map[string]any: // terminatingRule
+		id, _ := v[ruleIDKey].(string)
+		delete(v, ruleIDKey)
+		target[id] = v
+	case []any: // nonTerminatingMatchingRules, excludedRules
+		for _, item := range v {
+			entry, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			id, _ := entry[ruleIDKey].(string)
+			delete(entry, ruleIDKey)
+			target[id] = entry
+		}
+	}
+}

--- a/aws/logs_monitoring_go/internal/handling/waf_test.go
+++ b/aws/logs_monitoring_go/internal/handling/waf_test.go
@@ -1,0 +1,74 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-Present Datadog, Inc.
+
+package handling
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlattenWAFMessage(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		input string
+		want  string
+	}{
+		"headers": {
+			input: `{"httpRequest":{"headers":[{"name":"header1","value":"value1"},{"name":"header2","value":"value2"}]}}`,
+			want:  `{"httpRequest":{"headers":{"header1":"value1","header2":"value2"}}}`,
+		},
+		"nonTerminatingMatchingRules": {
+			input: `{"nonTerminatingMatchingRules":[{"ruleId":"nonterminating1","action":"COUNT"},{"ruleId":"nonterminating2","action":"COUNT"}]}`,
+			want:  `{"nonTerminatingMatchingRules":{"nonterminating1":{"action":"COUNT"},"nonterminating2":{"action":"COUNT"}}}`,
+		},
+		"rateBasedRuleList": {
+			input: `{"rateBasedRuleList":[{"limitValue":"195.154.122.189","rateBasedRuleName":"tf-rate-limit-5-min","rateBasedRuleId":"arn:aws:wafv2:ap-southeast-2:068133125972","maxRateAllowed":300,"limitKey":"IP"},{"limitValue":"195.154.122.189","rateBasedRuleName":"no-rate-limit","rateBasedRuleId":"arn:aws:wafv2:ap-southeast-2:068133125972","maxRateAllowed":300,"limitKey":"IP"}]}`,
+			want:  `{"rateBasedRuleList":{"tf-rate-limit-5-min":{"limitValue":"195.154.122.189","rateBasedRuleId":"arn:aws:wafv2:ap-southeast-2:068133125972","maxRateAllowed":300,"limitKey":"IP"},"no-rate-limit":{"limitValue":"195.154.122.189","rateBasedRuleId":"arn:aws:wafv2:ap-southeast-2:068133125972","maxRateAllowed":300,"limitKey":"IP"}}}`,
+		},
+		"ruleGroupList with all sub-fields": {
+			input: `{"ruleGroupList":[{"ruleGroupId":"AWS#AWSManagedRulesSQLiRuleSet","terminatingRule":{"ruleId":"SQLi_QUERYARGUMENTS","action":"BLOCK"},"nonTerminatingMatchingRules":[{"exclusionType":"REGULAR","ruleId":"first_nonterminating"},{"exclusionType":"REGULAR","ruleId":"second_nonterminating"}],"excludedRules":[{"exclusionType":"EXCLUDED_AS_COUNT","ruleId":"GenericRFI_BODY"},{"exclusionType":"EXCLUDED_AS_COUNT","ruleId":"second_exclude"}]}]}`,
+			want:  `{"ruleGroupList":{"AWS#AWSManagedRulesSQLiRuleSet":{"terminatingRule":{"SQLi_QUERYARGUMENTS":{"action":"BLOCK"}},"nonTerminatingMatchingRules":{"first_nonterminating":{"exclusionType":"REGULAR"},"second_nonterminating":{"exclusionType":"REGULAR"}},"excludedRules":{"GenericRFI_BODY":{"exclusionType":"EXCLUDED_AS_COUNT"},"second_exclude":{"exclusionType":"EXCLUDED_AS_COUNT"}}}}}`,
+		},
+		"ruleGroupList with two rules same group id": {
+			input: `{"ruleGroupList":[{"ruleGroupId":"AWS#AWSManagedRulesSQLiRuleSet","terminatingRule":{"ruleId":"SQLi_QUERYARGUMENTS","action":"BLOCK"}},{"ruleGroupId":"AWS#AWSManagedRulesSQLiRuleSet","terminatingRule":{"ruleId":"secondRULE","action":"BLOCK"}}]}`,
+			want:  `{"ruleGroupList":{"AWS#AWSManagedRulesSQLiRuleSet":{"terminatingRule":{"SQLi_QUERYARGUMENTS":{"action":"BLOCK"},"secondRULE":{"action":"BLOCK"}}}}}`,
+		},
+		"ruleGroupList with three rules two group ids": {
+			input: `{"ruleGroupList":[{"ruleGroupId":"AWS#AWSManagedRulesSQLiRuleSet","terminatingRule":{"ruleId":"SQLi_QUERYARGUMENTS","action":"BLOCK"}},{"ruleGroupId":"AWS#AWSManagedRulesSQLiRuleSet","terminatingRule":{"ruleId":"secondRULE","action":"BLOCK"}},{"ruleGroupId":"A_DIFFERENT_ID","terminatingRule":{"ruleId":"thirdRULE","action":"BLOCK"}}]}`,
+			want:  `{"ruleGroupList":{"AWS#AWSManagedRulesSQLiRuleSet":{"terminatingRule":{"SQLi_QUERYARGUMENTS":{"action":"BLOCK"},"secondRULE":{"action":"BLOCK"}}},"A_DIFFERENT_ID":{"terminatingRule":{"thirdRULE":{"action":"BLOCK"}}}}}`,
+		},
+		"no waf fields": {
+			input: `{"timestamp":123,"action":"ALLOW"}`,
+			want:  `{"timestamp":123,"action":"ALLOW"}`,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := flattenWAFMessage(tc.input)
+			assert.JSONEq(t, tc.want, got)
+		})
+	}
+}
+
+func TestFlattenWAFMessagePassthrough(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"invalid json": "not json at all",
+		"empty string": "",
+	}
+
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, input, flattenWAFMessage(input))
+		})
+	}
+}

--- a/aws/logs_monitoring_go/internal/parsing/eventbridge.go
+++ b/aws/logs_monitoring_go/internal/parsing/eventbridge.go
@@ -38,7 +38,7 @@ func parseEventBridge(event json.RawMessage) ([]ParsedEvent, error) {
 
 func decodeEventBridgeEnvelope(event json.RawMessage) (source, detailType string, detail json.RawMessage, err error) {
 	dec := json.NewDecoder(bytes.NewReader(event))
-	if err := skipBrace(dec); err != nil {
+	if err := SkipBrace(dec); err != nil {
 		return "", "", nil, err
 	}
 
@@ -62,7 +62,7 @@ func decodeEventBridgeEnvelope(event json.RawMessage) (source, detailType string
 				return "", "", nil, fmt.Errorf("detail: %w", err)
 			}
 		default:
-			if err := skip(dec); err != nil {
+			if err := Skip(dec); err != nil {
 				return "", "", nil, err
 			}
 		}
@@ -96,7 +96,7 @@ func buildS3EventFromEventBridge(detail json.RawMessage) (json.RawMessage, error
 func decodeEventBridgeS3Detail(detail json.RawMessage) (bucket, key string, err error) {
 	dec := json.NewDecoder(bytes.NewReader(detail))
 
-	if err := skipBrace(dec); err != nil {
+	if err := SkipBrace(dec); err != nil {
 		return "", "", err
 	}
 
@@ -124,7 +124,7 @@ func decodeEventBridgeS3Detail(detail json.RawMessage) (bucket, key string, err 
 			}
 			key = o.Key
 		default:
-			if err := skip(dec); err != nil {
+			if err := Skip(dec); err != nil {
 				return "", "", err
 			}
 		}

--- a/aws/logs_monitoring_go/internal/parsing/parse.go
+++ b/aws/logs_monitoring_go/internal/parsing/parse.go
@@ -186,7 +186,7 @@ func skipToEnd(dec *json.Decoder) error {
 		if _, err := dec.Token(); err != nil {
 			return err
 		}
-		if err := skip(dec); err != nil {
+		if err := Skip(dec); err != nil {
 			return err
 		}
 	}

--- a/aws/logs_monitoring_go/internal/parsing/parse.go
+++ b/aws/logs_monitoring_go/internal/parsing/parse.go
@@ -27,7 +27,7 @@ const (
 
 func Parse(event json.RawMessage) ([]ParsedEvent, error) {
 	dec := json.NewDecoder(bytes.NewReader(event))
-	if err := skipBrace(dec); err != nil {
+	if err := SkipBrace(dec); err != nil {
 		return nil, err
 	}
 
@@ -53,8 +53,8 @@ func Parse(event json.RawMessage) ([]ParsedEvent, error) {
 			}
 			return parsed, nil
 		default:
-			if err := skip(dec); err != nil {
-				return nil, fmt.Errorf("decode: %w", err)
+			if err := Skip(dec); err != nil {
+				return nil, err
 			}
 		}
 	}
@@ -63,10 +63,10 @@ func Parse(event json.RawMessage) ([]ParsedEvent, error) {
 }
 
 func parseRecords(event json.RawMessage, dec *json.Decoder) ([]ParsedEvent, error) {
-	if err := skipBracket(dec); err != nil {
+	if err := SkipBracket(dec); err != nil {
 		return nil, err
 	}
-	if err := skipBrace(dec); err != nil {
+	if err := SkipBrace(dec); err != nil {
 		return nil, err
 	}
 
@@ -83,7 +83,7 @@ func parseRecords(event json.RawMessage, dec *json.Decoder) ([]ParsedEvent, erro
 
 		// SNS uses "EventSource" so we compare case-insensitively.
 		if !strings.EqualFold(keyStr, eventSourceKey) {
-			if err := skip(dec); err != nil {
+			if err := Skip(dec); err != nil {
 				return nil, err
 			}
 			continue
@@ -124,21 +124,21 @@ func parseRecords(event json.RawMessage, dec *json.Decoder) ([]ParsedEvent, erro
 	return nil, errors.New("no eventSource found")
 }
 
-func skipBrace(dec *json.Decoder) error {
+func SkipBrace(dec *json.Decoder) error {
 	if t, err := dec.Token(); err != nil || t != json.Delim('{') {
 		return fmt.Errorf("expected '{': %w", err)
 	}
 	return nil
 }
 
-func skipBracket(dec *json.Decoder) error {
+func SkipBracket(dec *json.Decoder) error {
 	if t, err := dec.Token(); err != nil || t != json.Delim('[') {
 		return fmt.Errorf("expected '[': %w", err)
 	}
 	return nil
 }
 
-func skipToKey(dec *json.Decoder, key string) error {
+func SkipToKey(dec *json.Decoder, key string) error {
 	for dec.More() {
 		k, err := dec.Token()
 		if err != nil {
@@ -146,7 +146,7 @@ func skipToKey(dec *json.Decoder, key string) error {
 		}
 
 		if k != key {
-			if err := skip(dec); err != nil {
+			if err := Skip(dec); err != nil {
 				return err
 			}
 			continue
@@ -158,24 +158,24 @@ func skipToKey(dec *json.Decoder, key string) error {
 	return &KeyNotFoundError{key}
 }
 
-func skipToRecords(dec *json.Decoder) error {
-	if err := skipBrace(dec); err != nil {
+func SkipToRecords(dec *json.Decoder) error {
+	if err := SkipBrace(dec); err != nil {
 		return err
 	}
 
-	if err := skipToKey(dec, recordsKey); err != nil {
+	if err := SkipToKey(dec, recordsKey); err != nil {
 		return err
 	}
 
-	if err := skipBracket(dec); err != nil {
+	if err := SkipBracket(dec); err != nil {
 		return err
 	}
 	return nil
 }
 
-func skip(dec *json.Decoder) error {
-	var s json.RawMessage
-	if err := dec.Decode(&s); err != nil {
+func Skip(dec *json.Decoder) error {
+	var skip json.RawMessage
+	if err := dec.Decode(&skip); err != nil {
 		return fmt.Errorf("skip: %w", err)
 	}
 	return nil

--- a/aws/logs_monitoring_go/internal/parsing/sns.go
+++ b/aws/logs_monitoring_go/internal/parsing/sns.go
@@ -14,7 +14,7 @@ import (
 func parseSNS(event json.RawMessage) ([]ParsedEvent, error) {
 	dec := json.NewDecoder(bytes.NewReader(event))
 
-	if err := skipToRecords(dec); err != nil {
+	if err := SkipToRecords(dec); err != nil {
 		return nil, fmt.Errorf("skip to records: %w", err)
 	}
 
@@ -26,16 +26,16 @@ func parseSNS(event json.RawMessage) ([]ParsedEvent, error) {
 		}
 
 		recDec := json.NewDecoder(bytes.NewReader(record))
-		if err := skipBrace(recDec); err != nil {
+		if err := SkipBrace(recDec); err != nil {
 			return nil, err
 		}
-		if err := skipToKey(recDec, "Sns"); err != nil {
+		if err := SkipToKey(recDec, "Sns"); err != nil {
 			return nil, fmt.Errorf("skip to key: %w", err)
 		}
-		if err := skipBrace(recDec); err != nil {
+		if err := SkipBrace(recDec); err != nil {
 			return nil, err
 		}
-		if err := skipToKey(recDec, "Message"); err != nil {
+		if err := SkipToKey(recDec, "Message"); err != nil {
 			return nil, fmt.Errorf("skip to key: %w", err)
 		}
 
@@ -59,13 +59,13 @@ func parseSNS(event json.RawMessage) ([]ParsedEvent, error) {
 func isS3(message json.RawMessage) bool {
 	dec := json.NewDecoder(bytes.NewReader(message))
 
-	if err := skipToRecords(dec); err != nil {
+	if err := SkipToRecords(dec); err != nil {
 		return false
 	}
 
-	if err := skipBrace(dec); err != nil {
+	if err := SkipBrace(dec); err != nil {
 		return false
 	}
 
-	return skipToKey(dec, "s3") == nil
+	return SkipToKey(dec, "s3") == nil
 }

--- a/aws/logs_monitoring_go/internal/parsing/sqs.go
+++ b/aws/logs_monitoring_go/internal/parsing/sqs.go
@@ -15,7 +15,7 @@ import (
 
 func parseSQS(event json.RawMessage) ([]ParsedEvent, error) {
 	dec := json.NewDecoder(bytes.NewReader(event))
-	if err := skipToRecords(dec); err != nil {
+	if err := SkipToRecords(dec); err != nil {
 		return nil, fmt.Errorf("skip to records: %w", err)
 	}
 
@@ -45,11 +45,11 @@ func parseSQS(event json.RawMessage) ([]ParsedEvent, error) {
 }
 
 func extractBody(dec *json.Decoder) (string, error) {
-	if err := skipBrace(dec); err != nil {
+	if err := SkipBrace(dec); err != nil {
 		return "", err
 	}
 
-	if err := skipToKey(dec, "body"); err != nil {
+	if err := SkipToKey(dec, "body"); err != nil {
 		return "", fmt.Errorf("skip to key: %w", err)
 	}
 
@@ -69,7 +69,7 @@ func parseSQSBody(body string) (ParsedEvent, error) {
 	inner := json.RawMessage(body)
 	dec := json.NewDecoder(bytes.NewReader(inner))
 
-	if err := skipBrace(dec); err != nil {
+	if err := SkipBrace(dec); err != nil {
 		return ParsedEvent{}, err
 	}
 
@@ -95,7 +95,7 @@ func parseSQSBody(body string) (ParsedEvent, error) {
 			}
 			return ParsedEvent{}, errUnknownEvent
 		default:
-			if err := skip(dec); err != nil {
+			if err := Skip(dec); err != nil {
 				return ParsedEvent{}, err
 			}
 		}

--- a/aws/logs_monitoring_go/internal/testutil/testutil.go
+++ b/aws/logs_monitoring_go/internal/testutil/testutil.go
@@ -11,9 +11,11 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"regexp"
 	"testing"
 
 	"github.com/DataDog/datadog-serverless-functions/aws/logs_monitoring_go/internal/config"
+	"github.com/DataDog/datadog-serverless-functions/aws/logs_monitoring_go/internal/filtering"
 	"github.com/DataDog/datadog-serverless-functions/aws/logs_monitoring_go/internal/model"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambdacontext"
@@ -36,6 +38,66 @@ func EmptyConfig() *config.Config {
 	return &config.Config{}
 }
 
+type ConfigOption func(t *testing.T, cfg *config.Config)
+
+func Config(t *testing.T, opts ...ConfigOption) *config.Config {
+	t.Helper()
+	cfg := EmptyConfig()
+	for _, opt := range opts {
+		opt(t, cfg)
+	}
+	return cfg
+}
+
+func WithIncludeFilter(pattern string) ConfigOption {
+	return func(t *testing.T, cfg *config.Config) {
+		t.Helper()
+		f, err := filtering.NewFilter(pattern, "")
+		if err != nil {
+			t.Fatalf("include filter: %v", err)
+		}
+		cfg.Filter = f
+	}
+}
+
+func WithExcludeFilter(pattern string) ConfigOption {
+	return func(t *testing.T, cfg *config.Config) {
+		t.Helper()
+		f, err := filtering.NewFilter("", pattern)
+		if err != nil {
+			t.Fatalf("exclude filter: %v", err)
+		}
+		cfg.Filter = f
+	}
+}
+
+func WithMultilineRegex(pattern string) ConfigOption {
+	return func(t *testing.T, cfg *config.Config) {
+		t.Helper()
+		cfg.S3MultilineLogRegex = regexp.MustCompile(pattern)
+	}
+}
+
+func WithTags(tags ...string) ConfigOption {
+	return func(_ *testing.T, cfg *config.Config) {
+		cfg.Tags = tags
+	}
+}
+
+func MustGzip(t *testing.T, data []byte) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	if _, err := w.Write(data); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
 func MustGzipJSON(t *testing.T, v any) []byte {
 	t.Helper()
 
@@ -43,17 +105,7 @@ func MustGzipJSON(t *testing.T, v any) []byte {
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-
-	var buf bytes.Buffer
-	w := gzip.NewWriter(&buf)
-	if _, err := w.Write(raw); err != nil {
-		t.Fatalf("gzip write: %v", err)
-	}
-	if err := w.Close(); err != nil {
-		t.Fatalf("gzip close: %v", err)
-	}
-
-	return buf.Bytes()
+	return MustGzip(t, raw)
 }
 
 func MustCloudwatchEvent(t *testing.T, data []byte) json.RawMessage {


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Adds WAF logs coming from S3.
<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes
- Exported some parsing package function to use them in the CloudTrail decoding logic.
- Deleted the old simple `_CloudTrail_` S3 source key. We use the regex because it's more robust.
- Because of edge cases from sources (CloudTrail, WAF, VPCFlowLogs, and SecurityHub in the future), we dispatch the logic to different methods based on the detected sources. Some basic S3 source need message extraction, CloudTrail need the host and a specific decoder, VPCFlowLogs needs the header skip, WAF needs the transformation and disable custom regex on the scanner.
- We might want to support WAF logs from CloudWatch in the future (also not supported in the Python forwarder).
<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
