### PR TITLE
fix(go-forwarder): skip vpcflowlogs header

### DIFF
--- a/aws/logs_monitoring_go/internal/handling/s3.go
+++ b/aws/logs_monitoring_go/internal/handling/s3.go
@@ -22,9 +22,10 @@ import (
 )
 
 const (
-	s3KeyWAF1    = "aws-waf-logs"
-	s3KeyWAF2    = "waflogs"
-	s3KeyKinesis = "amazon_kinesis"
+	s3KeyKinesis     = "amazon_kinesis"
+	s3KeyVpcFlowLogs = "vpcflowlogs"
+	s3KeyWAF1        = "aws-waf-logs"
+	s3KeyWAF2        = "waflogs"
 )
 
 type S3Handler struct {
@@ -112,10 +113,18 @@ func S3Source(key string) string {
 }
 
 func (h S3Handler) S3(ctx context.Context, out chan<- model.LogEntry, r io.Reader, eventRecord events.S3EventRecord, lambdaOrigin model.LambdaOrigin) error {
+	var headerSkipped bool
+	isVpcFlowLogs := strings.Contains(eventRecord.S3.Object.URLDecodedKey, s3KeyVpcFlowLogs)
+
 	base := h.newBaseEntry(eventRecord, lambdaOrigin)
 	for message, err := range scan(r, h.cfg.S3MultilineLogRegex) {
 		if err != nil {
 			return err
+		}
+
+		if isVpcFlowLogs && !headerSkipped {
+			headerSkipped = true
+			continue
 		}
 
 		tags, service, message := extractFromMessage(message)

--- a/aws/logs_monitoring_go/internal/handling/s3_test.go
+++ b/aws/logs_monitoring_go/internal/handling/s3_test.go
@@ -38,6 +38,14 @@ var (
 		},
 	}
 
+	testVpcFlowLogsKey         = "AWSLogs/123456789012/vpcflowlogs/us-east-1/2024/01/01/log.log.gz"
+	testVpcFlowLogsEventRecord = events.S3EventRecord{
+		S3: events.S3Entity{
+			Bucket: events.S3Bucket{Name: "vpc-bucket"},
+			Object: events.S3Object{URLDecodedKey: testVpcFlowLogsKey},
+		},
+	}
+
 	testWAFKey         = "AWSLogs/123456779121/WAFLogs/us-east-1/webacl/aws-waf-logs-example.log.gz"
 	testWAFEventRecord = events.S3EventRecord{
 		S3: events.S3Entity{
@@ -213,6 +221,20 @@ func TestProcessS3Record(t *testing.T) {
 				),
 			},
 		},
+		"vpc flow logs skips header line": {
+			mockSetup: func(m *MockS3APIClient) {
+				m.EXPECT().GetObject(gomock.Any(), gomock.Any()).
+					Return(&s3.GetObjectOutput{
+						Body: io.NopCloser(strings.NewReader("version account-id interface-id srcaddr dstaddr srcport dstport protocol\n2 123456789012 eni-abc123 10.0.0.1 10.0.0.2 443 49152 6\n2 123456789012 eni-abc123 10.0.0.2 10.0.0.1 49152 443 6")),
+					}, nil)
+			},
+			cfg:         testutil.EmptyConfig(),
+			eventRecord: testVpcFlowLogsEventRecord,
+			want: []model.LogEntry{
+				wantVpcFlowLogsEntry("2 123456789012 eni-abc123 10.0.0.1 10.0.0.2 443 49152 6"),
+				wantVpcFlowLogsEntry("2 123456789012 eni-abc123 10.0.0.2 10.0.0.1 49152 443 6"),
+			},
+		},
 		"waf single line": {
 			mockSetup: func(m *MockS3APIClient) {
 				data := testutil.MustGzip(t, []byte(`{"httpRequest":{"headers":[{"name":"Host","value":"example.com"}]}}`))
@@ -335,6 +357,18 @@ func wantCloudTrailEntry(message, host string) model.LogEntry {
 	entry.Metadata = model.S3Metadata{
 		LambdaOrigin: testutil.LambdaOrigin(),
 		Origin:       model.S3Origin{Bucket: "trail-bucket", Key: testCloudTrailKey},
+	}
+	return entry
+}
+
+func wantVpcFlowLogsEntry(message string) model.LogEntry {
+	entry := model.NewLogEntry()
+	entry.Message = message
+	entry.Source = sourceS3
+	entry.Service = sourceS3
+	entry.Metadata = model.S3Metadata{
+		LambdaOrigin: testutil.LambdaOrigin(),
+		Origin:       model.S3Origin{Bucket: "vpc-bucket", Key: testVpcFlowLogsKey},
 	}
 	return entry
 }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Skips VPC flow logs header
<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes
Same as https://github.com/DataDog/datadog-serverless-functions/pull/1124
<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
