### PR TITLE
fixup! fix: store failed log events on intake errors (#1131)

### DIFF
--- a/aws/logs_monitoring/tests/test_datadog_http_client.py
+++ b/aws/logs_monitoring/tests/test_datadog_http_client.py
@@ -1,14 +1,7 @@
 import unittest
 import sys
-import types
 from unittest.mock import MagicMock, patch
 
-botocore = types.ModuleType("botocore")
-botocore.config = types.ModuleType("botocore.config")
-botocore.config.Config = MagicMock()
-sys.modules["boto3"] = MagicMock()
-sys.modules["botocore"] = botocore
-sys.modules["botocore.config"] = botocore.config
 sys.modules["requests"] = MagicMock()
 sys.modules["requests_futures.sessions"] = MagicMock()
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Fixes sys.modules declaration in tests because boto3 is installed by the CI.
<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
`python -m unittest discover .`
<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
