### PR TITLE
feat(forwarder): add SKIP_REGIONS env var for layer publishing

### DIFF
--- a/aws/logs_monitoring/release.sh
+++ b/aws/logs_monitoring/release.sh
@@ -24,6 +24,29 @@ log_error() {
     exit 1
 }
 
+log_warning() {
+    local YELLOW='\033[0;33m'
+    local RESET='\033[0m'
+
+    printf -- "%b%b%b\n" "${YELLOW}" "${*}" "${RESET}" 1>&2
+}
+
+print_restart_hint_on_failure() {
+    local exit_code=$?
+    if [[ ${exit_code} -eq 0 ]]; then
+        return
+    fi
+    if [[ ${ACCOUNT:-} != "prod" ]]; then
+        return
+    fi
+    log_warning ""
+    log_warning "Release failed (exit ${exit_code}). To restart from the asset-push step (after the version-bump PR has been merged), run:"
+    log_warning "\tPROD_GITHUB_RESTART=true ./release.sh ${FORWARDER_VERSION:-<version>} prod"
+    log_warning "If a specific region is in an outage, also pass SKIP_REGIONS, e.g.:"
+    log_warning "\tPROD_GITHUB_RESTART=true SKIP_REGIONS=me-south-1 ./release.sh ${FORWARDER_VERSION:-<version>} prod"
+}
+trap print_restart_hint_on_failure EXIT
+
 user_read_input() {
     if [[ ${#} -lt 2 ]]; then
         var_red "Usage: var_read_input VAR_PROMPT VAR_NAME"
@@ -278,6 +301,8 @@ prod_release() {
     fi
 
     log_info "You are about to\n\t- bump the version from ${CURRENT_VERSION} to ${FORWARDER_VERSION}\n\t- create lambda layer version ${LAYER_VERSION}\n\t- create a release of aws-dd-forwarder-${FORWARDER_VERSION} on GitHub\n\t- upload the template.yaml to s3://${BUCKET}/aws/forwarder/${FORWARDER_VERSION}.yaml\n"
+
+    log_info "Tip: if this script fails after the version-bump PR is merged, you can restart from the asset-push step with:\n\tPROD_GITHUB_RESTART=true ./release.sh ${FORWARDER_VERSION} prod\nTo skip regions during an AWS outage, pass SKIP_REGIONS=region-a,region-b (e.g. SKIP_REGIONS=me-south-1).\n"
 
     # Confirm to proceed
     if ! user_confirm "Continue"; then

--- a/aws/logs_monitoring/tools/publish_layers.sh
+++ b/aws/logs_monitoring/tools/publish_layers.sh
@@ -97,6 +97,20 @@ LAYER_PATHS=(".forwarder/aws-dd-forwarder-${FORWARDER_VERSION}-layer.zip")
 AVAILABLE_LAYERS=("Datadog-Forwarder")
 AVAILABLE_REGIONS=$(aws ec2 describe-regions | jq -r '.[] | .[] | .RegionName')
 
+# SKIP_REGIONS is a comma-separated list of regions to skip (e.g. during a
+# regional outage). Example: SKIP_REGIONS=me-south-1,ap-northeast-1
+is_region_skipped() {
+    local region=$1
+    if [[ -z ${SKIP_REGIONS:-} ]]; then
+        return 1
+    fi
+    local clean_skip="${SKIP_REGIONS// /}"
+    if [[ ",${clean_skip}," == *",${region},"* ]]; then
+        return 0
+    fi
+    return 1
+}
+
 # Check that the layer files exist
 for layer_file in "${LAYER_PATHS[@]}"; do
     if [[ ! -f ${layer_file} ]]; then
@@ -131,6 +145,10 @@ if [[ -z ${LAYER_VERSION:-} ]]; then
     log_error "Layer version not specified"
 else
     log_info "Layer version specified: $LAYER_VERSION"
+fi
+
+if [[ -n ${SKIP_REGIONS:-} ]]; then
+    log_warning "Skipping regions (SKIP_REGIONS): ${SKIP_REGIONS}"
 fi
 
 if [[ ${NO_INPUT:-} == "true" ]]; then
@@ -176,6 +194,11 @@ publish_layer() {
 }
 
 for region in $REGIONS; do
+    if is_region_skipped "$region"; then
+        log_warning "Skipping region $region (SKIP_REGIONS)"
+        continue
+    fi
+
     log_info "Starting publishing layer for region $region..."
 
     # Publish the layers for each version of python


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adds a `SKIP_REGIONS` env var (comma-separated), so you can skip specific AWS regions during layer publishing (e.g. during a regional outage), and surfaces the existing `PROD_GITHUB_RESTART=true` restart flow in
  `release.sh` via a startup tip and an EXIT-trap hint on failure.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

There is an existing outage in `me-south-1` that prevents us from publishing Lambda layers, and as a result the release fails.

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
