### PR TITLE
fix(forwader): catch response errors on key verification

### DIFF
--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -250,24 +250,30 @@ def is_api_key_valid():
     # Validate the API key
     logger.debug("Validating the Datadog API key")
 
-    with requests.Session() as s:
-        retries = requests.adapters.Retry(
-            total=5, backoff_factor=1, status_forcelist=[429, 500, 502, 503, 504]
-        )
-
-        s.mount("http://", requests.adapters.HTTPAdapter(max_retries=retries))
-        s.mount("https://", requests.adapters.HTTPAdapter(max_retries=retries))
-
-        validation_res = s.get(
-            "{}/api/v1/validate?api_key={}".format(DD_API_URL, DD_API_KEY),
-            verify=(not DD_SKIP_SSL_VALIDATION),
-            timeout=10,
-        )
-        if not validation_res.ok:
-            logger.error(
-                f"Datadog API key validation failed (HTTP {validation_res.status_code}). Verify your API key is correct and DD_SITE matches your Datadog account region (current: {DD_SITE}). See: https://docs.datadoghq.com/getting_started/site/"
+    try:
+        with requests.Session() as s:
+            retries = requests.adapters.Retry(
+                total=5, backoff_factor=1, status_forcelist=[429, 500, 502, 503, 504]
             )
-            return False
+
+            s.mount("http://", requests.adapters.HTTPAdapter(max_retries=retries))
+            s.mount("https://", requests.adapters.HTTPAdapter(max_retries=retries))
+
+            validation_res = s.get(
+                "{}/api/v1/validate?api_key={}".format(DD_API_URL, DD_API_KEY),
+                verify=(not DD_SKIP_SSL_VALIDATION),
+                timeout=10,
+            )
+            if not validation_res.ok:
+                logger.error(
+                    f"Datadog API key validation failed (HTTP {validation_res.status_code}). Verify your API key is correct and DD_SITE matches your Datadog account region (current: {DD_SITE}). See: https://docs.datadoghq.com/getting_started/site/"
+                )
+                return False
+    except requests.exceptions.RequestException as e:
+        logger.warning(
+            f"Could not validate Datadog API key due to a network error: {e}. "
+            "Proceeding without validation — forwarding errors will surface if the key is invalid."
+        )
 
     return True
 

--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -272,7 +272,7 @@ def is_api_key_valid():
     except requests.exceptions.RequestException as e:
         logger.warning(
             f"Could not validate Datadog API key due to a network error: {e}. "
-            "Proceeding without validation — forwarding errors will surface if the key is invalid."
+            "Proceeding without validation."
         )
 
     return True

--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -274,6 +274,7 @@ def is_api_key_valid():
             f"Could not validate Datadog API key due to a network error: {e}. "
             "Proceeding without validation."
         )
+        return False
 
     return True
 

--- a/aws/logs_monitoring/tests/test_settings.py
+++ b/aws/logs_monitoring/tests/test_settings.py
@@ -1,0 +1,56 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+import settings as _settings_module
+from settings import is_api_key_valid
+
+VALID_API_KEY = "11111111111111111111111111111111"
+
+class TestIsApiKeyValid(unittest.TestCase):
+    @patch("settings.DD_API_KEY", VALID_API_KEY)
+    @patch("settings.requests.Session")
+    def test_valid_api_key(self, mock_session_cls):
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_session_cls.return_value.__enter__.return_value.get.return_value = (
+            mock_response
+        )
+        self.assertTrue(is_api_key_valid())
+
+    @patch("settings.DD_API_KEY", "")
+    def test_empty_api_key(self):
+        with self.assertRaises(Exception):
+            is_api_key_valid()
+
+    @patch("settings.DD_API_KEY", "shortapikey")
+    def test_invalid_api_key_format(self):
+        with self.assertRaises(Exception):
+            is_api_key_valid()
+
+    @patch("settings.DD_API_KEY", VALID_API_KEY)
+    @patch("settings.logger")
+    @patch("settings.requests.Session")
+    def test_on_connection_exception(self, mock_session_cls, mock_logger):
+        mock_session_cls.return_value.__enter__.return_value.get.side_effect = (
+            _settings_module.requests.exceptions.ConnectionError
+        )
+        result = is_api_key_valid()
+        self.assertFalse(result)
+        mock_logger.warning.assert_called_once()
+        self.assertIn("network error", mock_logger.warning.call_args[0][0].lower())
+
+    @patch("settings.DD_API_KEY", VALID_API_KEY)
+    @patch("settings.logger")
+    @patch("settings.requests.Session")
+    def test_on_timeout_exception(self, mock_session_cls, mock_logger):
+        mock_session_cls.return_value.__enter__.return_value.get.side_effect = (
+            _settings_module.requests.exceptions.Timeout
+        )
+        result = is_api_key_valid()
+        self.assertFalse(result)
+        mock_logger.warning.assert_called_once()
+        self.assertIn("network error", mock_logger.warning.call_args[0][0].lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/aws/logs_monitoring/tests/test_settings.py
+++ b/aws/logs_monitoring/tests/test_settings.py
@@ -6,6 +6,7 @@ from settings import is_api_key_valid
 
 VALID_API_KEY = "11111111111111111111111111111111"
 
+
 class TestIsApiKeyValid(unittest.TestCase):
     @patch("settings.DD_API_KEY", VALID_API_KEY)
     @patch("settings.requests.Session")

--- a/aws/logs_monitoring/tests/test_settings.py
+++ b/aws/logs_monitoring/tests/test_settings.py
@@ -1,7 +1,6 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-import settings as _settings_module
 from settings import is_api_key_valid
 
 VALID_API_KEY = "11111111111111111111111111111111"

--- a/aws/logs_monitoring/tests/test_settings.py
+++ b/aws/logs_monitoring/tests/test_settings.py
@@ -6,6 +6,10 @@ from settings import is_api_key_valid
 
 VALID_API_KEY = "11111111111111111111111111111111"
 
+# For the integration tests to work because of other tests set sys.modules["requests"] as a MagicMock.
+class _FakeNetworkError(Exception):
+    pass
+
 
 class TestIsApiKeyValid(unittest.TestCase):
     @patch("settings.DD_API_KEY", VALID_API_KEY)
@@ -30,10 +34,11 @@ class TestIsApiKeyValid(unittest.TestCase):
 
     @patch("settings.DD_API_KEY", VALID_API_KEY)
     @patch("settings.logger")
+    @patch("settings.requests.exceptions.RequestException", _FakeNetworkError)
     @patch("settings.requests.Session")
     def test_on_connection_exception(self, mock_session_cls, mock_logger):
         mock_session_cls.return_value.__enter__.return_value.get.side_effect = (
-            _settings_module.requests.exceptions.ConnectionError
+            _FakeNetworkError("DNS resolution failed")
         )
         result = is_api_key_valid()
         self.assertFalse(result)
@@ -42,10 +47,11 @@ class TestIsApiKeyValid(unittest.TestCase):
 
     @patch("settings.DD_API_KEY", VALID_API_KEY)
     @patch("settings.logger")
+    @patch("settings.requests.exceptions.RequestException", _FakeNetworkError)
     @patch("settings.requests.Session")
     def test_on_timeout_exception(self, mock_session_cls, mock_logger):
         mock_session_cls.return_value.__enter__.return_value.get.side_effect = (
-            _settings_module.requests.exceptions.Timeout
+            _FakeNetworkError("Request timed out")
         )
         result = is_api_key_valid()
         self.assertFalse(result)

--- a/aws/logs_monitoring/tests/test_settings.py
+++ b/aws/logs_monitoring/tests/test_settings.py
@@ -6,6 +6,7 @@ from settings import is_api_key_valid
 
 VALID_API_KEY = "11111111111111111111111111111111"
 
+
 # For the integration tests to work because of other tests set sys.modules["requests"] as a MagicMock.
 class _FakeNetworkError(Exception):
     pass


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Prevent http response error to raise an exception and lose log events (when a failed event storage is configured)
<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
`python -m unittest tests/test_settings.py`
<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
