### PR TITLE
feat(telemetry): append DD_TAGS to forwarder telemetry metric tags

### DIFF
--- a/aws/logs_monitoring/telemetry.py
+++ b/aws/logs_monitoring/telemetry.py
@@ -10,7 +10,7 @@ try:
 except ImportError:
     DD_SUBMIT_ENHANCED_METRICS = False
 
-from settings import DD_FORWARDER_VERSION
+from settings import DD_FORWARDER_VERSION, DD_TAGS
 
 DD_FORWARDER_TELEMETRY_NAMESPACE_PREFIX = "aws.dd_forwarder"
 DD_FORWARDER_TELEMETRY_TAGS = []
@@ -27,6 +27,10 @@ def set_forwarder_telemetry_tags(context, event_type):
         f"forwarder_version:{DD_FORWARDER_VERSION}",
         f"event_type:{event_type}",
     ]
+    if DD_TAGS:
+        DD_FORWARDER_TELEMETRY_TAGS += [
+            tag.strip() for tag in DD_TAGS.split(",") if tag.strip()
+        ]
 
 
 def send_forwarder_internal_metrics(name, additional_tags=[]):

--- a/aws/logs_monitoring/tests/test_telemetry.py
+++ b/aws/logs_monitoring/tests/test_telemetry.py
@@ -1,0 +1,71 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+import telemetry
+
+
+def make_context(function_name="my-forwarder", memory_limit_in_mb=128):
+    context = MagicMock()
+    context.function_name = function_name
+    context.memory_limit_in_mb = memory_limit_in_mb
+    return context
+
+
+class TestSetForwarderTelemetryTags(unittest.TestCase):
+    def setUp(self):
+        telemetry.DD_FORWARDER_TELEMETRY_TAGS = []
+
+    @patch("telemetry.DD_TAGS", "")
+    def test_base_tags_without_dd_tags(self):
+        context = make_context()
+        telemetry.set_forwarder_telemetry_tags(context, "cloudwatch-logs")
+        tags = telemetry.DD_FORWARDER_TELEMETRY_TAGS
+        self.assertIn("forwardername:my-forwarder", tags)
+        self.assertIn("forwarder_memorysize:128", tags)
+        self.assertIn("event_type:cloudwatch-logs", tags)
+        self.assertEqual(len(tags), 4)
+
+    @patch("telemetry.DD_TAGS", "env:prod,account:123456789")
+    def test_dd_tags_appended(self):
+        context = make_context()
+        telemetry.set_forwarder_telemetry_tags(context, "s3")
+        tags = telemetry.DD_FORWARDER_TELEMETRY_TAGS
+        self.assertIn("env:prod", tags)
+        self.assertIn("account:123456789", tags)
+        self.assertEqual(len(tags), 6)
+
+    @patch("telemetry.DD_TAGS", "env:staging")
+    def test_single_dd_tag_appended(self):
+        context = make_context()
+        telemetry.set_forwarder_telemetry_tags(context, "kinesis")
+        tags = telemetry.DD_FORWARDER_TELEMETRY_TAGS
+        self.assertIn("env:staging", tags)
+        self.assertEqual(len(tags), 5)
+
+    @patch("telemetry.DD_TAGS", "env:prod, account:123")
+    def test_dd_tags_whitespace_stripped(self):
+        context = make_context()
+        telemetry.set_forwarder_telemetry_tags(context, "s3")
+        tags = telemetry.DD_FORWARDER_TELEMETRY_TAGS
+        self.assertIn("account:123", tags)
+        self.assertNotIn(" account:123", tags)
+
+    @patch("telemetry.DD_TAGS", "env:prod,,account:123")
+    def test_empty_tag_segments_ignored(self):
+        context = make_context()
+        telemetry.set_forwarder_telemetry_tags(context, "s3")
+        tags = telemetry.DD_FORWARDER_TELEMETRY_TAGS
+        self.assertIn("env:prod", tags)
+        self.assertIn("account:123", tags)
+        self.assertNotIn("", tags)
+
+    @patch("telemetry.DD_TAGS", "env:prod,account:123456789")
+    def test_function_name_lowercased(self):
+        context = make_context(function_name="My-Forwarder")
+        telemetry.set_forwarder_telemetry_tags(context, "s3")
+        tags = telemetry.DD_FORWARDER_TELEMETRY_TAGS
+        self.assertIn("forwardername:my-forwarder", tags)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #1145

`DD_TAGS` is currently applied to forwarded log events but not to internal forwarder telemetry metrics (e.g. `aws.dd_forwarder.logs_forwarded`). This makes it impossible to filter or group those metrics by custom dimensions such as environment or AWS account ID.

## Changes

- `telemetry.py`: import `DD_TAGS` from `settings` and append its parsed tags to `DD_FORWARDER_TELEMETRY_TAGS` in `set_forwarder_telemetry_tags()`
- Tags are split on `,`, stripped of surrounding whitespace, and empty segments are ignored - consistent with how `DD_TAGS` is handled for log events in `steps/common.py`
- `tests/test_telemetry.py`: new test file covering base tags, single tag, multiple tags, whitespace stripping, empty segment filtering, and function name lowercasing