### PR TITLE
refactor(go-forwarder): stop sending on first error

### DIFF
--- a/aws/logs_monitoring_go/cmd/forwarder/main.go
+++ b/aws/logs_monitoring_go/cmd/forwarder/main.go
@@ -80,10 +80,12 @@ func handleRequest(cfg *config.Config) func(ctx context.Context, event json.RawM
 			CompressionLevel: cfg.CompressionLevel,
 		}
 
-		storageOpts := storing.Options{Enabled: cfg.StoreOnFail, FIPS: cfg.UseFIPS, S3Bucket: cfg.S3RetryBucketName}
-		storage, err := storing.NewStorage(ctx, storageOpts)
-		if err != nil {
-			return fmt.Errorf("new storage: %w", err)
+		var storage storing.Storage
+		if cfg.StoreOnFail {
+			storageOpts := storing.Options{FIPS: cfg.UseFIPS, S3Bucket: cfg.S3RetryBucketName}
+			if storage, err = storing.NewStorage(ctx, storageOpts); err != nil {
+				return fmt.Errorf("new storage: %w", err)
+			}
 		}
 
 		forwarder := forwarding.NewForwarder(

--- a/aws/logs_monitoring_go/internal/batching/batcher.go
+++ b/aws/logs_monitoring_go/internal/batching/batcher.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 
 	"github.com/DataDog/datadog-serverless-functions/aws/logs_monitoring_go/internal/concurrent"
@@ -26,7 +27,7 @@ type Batcher struct {
 	batchSize int
 }
 
-func NewBatcher() *Batcher {
+func New() *Batcher {
 	return &Batcher{
 		batch: make([][]byte, 0, maxItemsPerBatch),
 	}
@@ -44,8 +45,7 @@ func (b *Batcher) Batch(ctx context.Context, in <-chan model.LogEntry, out chan<
 
 		data, err := json.Marshal(entry)
 		if err != nil {
-			slog.Warn("failed to marshal log entry, skipped", slog.Any("error", err))
-			continue
+			return fmt.Errorf("marshal: %w", err)
 		}
 
 		if len(data) > maxItemSize {

--- a/aws/logs_monitoring_go/internal/batching/batcher_test.go
+++ b/aws/logs_monitoring_go/internal/batching/batcher_test.go
@@ -64,7 +64,7 @@ func TestBatch(t *testing.T) {
 			}
 			close(in)
 
-			batcher := NewBatcher()
+			batcher := New()
 			err := batcher.Batch(t.Context(), in, out)
 			require.NoError(t, err)
 			close(out)

--- a/aws/logs_monitoring_go/internal/config/apikey.go
+++ b/aws/logs_monitoring_go/internal/config/apikey.go
@@ -79,9 +79,10 @@ func (c *Config) ValidateAPIKey(ctx context.Context) error {
 	defer httpclient.DrainClose(resp)
 
 	if resp.StatusCode == http.StatusForbidden {
-		slog.Warn("invalid Datadog API key")
-	} else if resp.StatusCode != http.StatusOK {
-		slog.Warn("unexpected response from validation endpoint", slog.String("status", resp.Status))
+		return errors.New("invalid Datadog API key")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("key validation (http/%d)", resp.StatusCode)
 	}
 
 	return nil

--- a/aws/logs_monitoring_go/internal/forwarding/forwarding.go
+++ b/aws/logs_monitoring_go/internal/forwarding/forwarding.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -96,31 +97,19 @@ func (f *Forwarder) Start(ctx context.Context, in <-chan model.LogEntry, storage
 					onceSent.Do(func() { sentErr = err })
 				}
 
-				if err := f.store(ctx, batch, storageTag); err != nil {
-					return fmt.Errorf("store: %w", err)
+				if f.storage == nil {
+					break
+				}
+
+				if err := f.storage.Put(ctx, batch, storageTag); err != nil {
+					return fmt.Errorf("put: %w", err)
 				}
 			}
 			return nil
 		})
 	}
 
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-
-	return sentErr
-}
-
-func (f *Forwarder) store(ctx context.Context, batch []byte, storageTag string) error {
-	if f.storage == nil {
-		return nil
-	}
-
-	if err := f.storage.Put(ctx, batch, storageTag); err != nil {
-		return fmt.Errorf("put: %w", err)
-	}
-
-	return nil
+	return errors.Join(eg.Wait(), sentErr)
 }
 
 func (f *Forwarder) Retry(ctx context.Context) error {

--- a/aws/logs_monitoring_go/internal/forwarding/forwarding.go
+++ b/aws/logs_monitoring_go/internal/forwarding/forwarding.go
@@ -14,7 +14,6 @@ import (
 	"log/slog"
 	"net/http"
 	"sync"
-	"sync/atomic"
 
 	"github.com/DataDog/datadog-serverless-functions/aws/logs_monitoring_go/internal/batching"
 	"github.com/DataDog/datadog-serverless-functions/aws/logs_monitoring_go/internal/concurrent"
@@ -67,6 +66,7 @@ func NewForwarder(cfg Config, client *http.Client, storage storing.Storage) *For
 
 func (f *Forwarder) Start(ctx context.Context, in <-chan model.LogEntry, storageTag string) error {
 	eg, ctx := errgroup.WithContext(ctx)
+	eg.SetLimit(1 + httpclient.MaxConcurrency)
 
 	batches := make(chan []byte)
 	eg.Go(func() error {
@@ -77,36 +77,38 @@ func (f *Forwarder) Start(ctx context.Context, in <-chan model.LogEntry, storage
 		return nil
 	})
 
-	var stopSending atomic.Bool
+	var sentErr error
+	var onceSent sync.Once
 	for range httpclient.MaxConcurrency {
 		eg.Go(func() error {
-			var sendingErr error
 			for {
 				batch, ok, _ := concurrent.SafeReader(ctx, batches)
 				if !ok {
 					break
 				}
 
-				if !stopSending.Load() {
-					sendingErr = f.send(ctx, batch, storageTag)
-					if sendingErr == nil {
+				if sentErr == nil {
+					err := f.send(ctx, batch, storageTag)
+					if err == nil {
 						continue
 					}
 
-					stopSending.Store(true)
-					slog.WarnContext(ctx, "failed to send batch", slog.Any("error", sendingErr))
+					onceSent.Do(func() { sentErr = err })
 				}
 
 				if err := f.store(ctx, batch, storageTag); err != nil {
 					return fmt.Errorf("store: %w", err)
 				}
 			}
-
-			return sendingErr
+			return nil
 		})
 	}
 
-	return eg.Wait()
+	if err := eg.Wait(); err != nil {
+		return err
+	}
+
+	return sentErr
 }
 
 func (f *Forwarder) store(ctx context.Context, batch []byte, storageTag string) error {

--- a/aws/logs_monitoring_go/internal/forwarding/forwarding.go
+++ b/aws/logs_monitoring_go/internal/forwarding/forwarding.go
@@ -9,12 +9,12 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"sync"
+	"sync/atomic"
 
 	"github.com/DataDog/datadog-serverless-functions/aws/logs_monitoring_go/internal/batching"
 	"github.com/DataDog/datadog-serverless-functions/aws/logs_monitoring_go/internal/concurrent"
@@ -44,10 +44,6 @@ type Config struct {
 }
 
 func NewForwarder(cfg Config, client *http.Client, storage storing.Storage) *Forwarder {
-	if storage == nil {
-		slog.Warn("failed event storage not configured, can lead to event loss")
-	}
-
 	header := http.Header{
 		"DD-API-KEY":            []string{cfg.APIKey},
 		"DD-EVP-ORIGIN":         []string{"aws_forwarder"},
@@ -70,49 +66,59 @@ func NewForwarder(cfg Config, client *http.Client, storage storing.Storage) *For
 }
 
 func (f *Forwarder) Start(ctx context.Context, in <-chan model.LogEntry, storageTag string) error {
-	batches := make(chan []byte, httpclient.MaxConcurrency)
-	batcher := batching.NewBatcher()
+	eg, ctx := errgroup.WithContext(ctx)
 
-	producerErrCh := make(chan error, 1)
-	go func() {
+	batches := make(chan []byte)
+	eg.Go(func() error {
 		defer close(batches)
-		producerErrCh <- batcher.Batch(ctx, in, batches)
-	}()
-
-	var eg errgroup.Group
-	eg.SetLimit(httpclient.MaxConcurrency)
-
-	var errs []error
-	var mu sync.Mutex
-
-	for {
-		body, ok, _ := concurrent.SafeReader(ctx, batches)
-		if !ok {
-			break
+		if err := batching.New().Batch(ctx, in, batches); err != nil {
+			return fmt.Errorf("batch: %w", err)
 		}
+		return nil
+	})
 
+	var stopSending atomic.Bool
+	for range httpclient.MaxConcurrency {
 		eg.Go(func() error {
-			err := f.send(ctx, body, storageTag)
-			if err == nil {
-				return nil
-			}
+			var sendingErr error
+			for {
+				batch, ok, _ := concurrent.SafeReader(ctx, batches)
+				if !ok {
+					break
+				}
 
-			mu.Lock()
-			errs = append(errs, err)
-			mu.Unlock()
+				if !stopSending.Load() {
+					sendingErr = f.send(ctx, batch, storageTag)
+					if sendingErr == nil {
+						continue
+					}
 
-			if f.storage != nil {
-				if storeErr := f.storage.Put(ctx, body, storageTag); storeErr != nil {
-					slog.WarnContext(ctx, "failed to store batch, dropping", slog.Any("error", storeErr))
+					stopSending.Store(true)
+					slog.WarnContext(ctx, "failed to send batch", slog.Any("error", sendingErr))
+				}
+
+				if err := f.store(ctx, batch, storageTag); err != nil {
+					return fmt.Errorf("store: %w", err)
 				}
 			}
 
-			return nil
+			return sendingErr
 		})
 	}
-	_ = eg.Wait()
 
-	return errors.Join(append(errs, <-producerErrCh)...)
+	return eg.Wait()
+}
+
+func (f *Forwarder) store(ctx context.Context, batch []byte, storageTag string) error {
+	if f.storage == nil {
+		return nil
+	}
+
+	if err := f.storage.Put(ctx, batch, storageTag); err != nil {
+		return fmt.Errorf("put: %w", err)
+	}
+
+	return nil
 }
 
 func (f *Forwarder) Retry(ctx context.Context) error {

--- a/aws/logs_monitoring_go/internal/httpclient/client.go
+++ b/aws/logs_monitoring_go/internal/httpclient/client.go
@@ -19,7 +19,7 @@ const (
 	tlsHandshakeTimeout  = 2 * time.Second
 	RequestTimeout       = 7 * time.Second
 	DefaultMaxAttempts   = 3
-	MaxConcurrency       = 5
+	MaxConcurrency       = 20
 )
 
 var Client *http.Client

--- a/aws/logs_monitoring_go/internal/storing/storage.go
+++ b/aws/logs_monitoring_go/internal/storing/storage.go
@@ -21,16 +21,11 @@ type Storage interface {
 }
 
 type Options struct {
-	Enabled  bool
 	FIPS     bool
 	S3Bucket string
 }
 
 func NewStorage(ctx context.Context, opts Options) (Storage, error) {
-	if !opts.Enabled {
-		return nil, nil
-	}
-
 	if opts.S3Bucket != "" {
 		s3Client, err := sdkclient.GetS3(ctx, opts.FIPS)
 		if err != nil {


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Refactors the storage creation into main and stop on first intake error.
<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
