### PR TITLE
refactor(go-forwarder): delete FIPS-related logic

### DIFF
--- a/aws/logs_monitoring_go/cmd/forwarder/main.go
+++ b/aws/logs_monitoring_go/cmd/forwarder/main.go
@@ -71,7 +71,6 @@ func handleRequest(cfg *config.Config) func(ctx context.Context, event json.RawM
 			Source:              cfg.Source,
 			Tags:                cfg.Tags,
 			S3MultilineLogRegex: cfg.S3MultilineLogRegex,
-			UseFIPS:             cfg.UseFIPS,
 		}
 
 		forwarderCfg := forwarding.Config{
@@ -82,7 +81,7 @@ func handleRequest(cfg *config.Config) func(ctx context.Context, event json.RawM
 
 		var storage storing.Storage
 		if cfg.StoreOnFail {
-			storageOpts := storing.Options{FIPS: cfg.UseFIPS, S3Bucket: cfg.S3RetryBucketName}
+			storageOpts := storing.Options{S3Bucket: cfg.S3RetryBucketName}
 			if storage, err = storing.NewStorage(ctx, storageOpts); err != nil {
 				return fmt.Errorf("new storage: %w", err)
 			}

--- a/aws/logs_monitoring_go/internal/config/config.go
+++ b/aws/logs_monitoring_go/internal/config/config.go
@@ -26,7 +26,6 @@ const (
 	EnvURL                      = "DD_URL"
 	EnvAPIURL                   = "DD_API_URL"
 	EnvLogLevel                 = "DD_LOG_LEVEL"
-	EnvUseFIPS                  = "DD_USE_FIPS"
 	EnvPort                     = "DD_PORT"
 	EnvUseHTTP                  = "DD_NO_SSL"
 	EnvSkipServerCertificate    = "DD_SKIP_SSL_VALIDATION"
@@ -52,7 +51,6 @@ type Config struct {
 	IntakeURL             string
 	CompressionLevel      int
 	SkipServerCertificate bool
-	UseFIPS               bool
 	Host                  string
 	Source                string
 	Service               string
@@ -117,8 +115,6 @@ func (c *Config) loadEnv() {
 
 	c.IntakeURL = envOrDefault(EnvURL, protocol+"://http-intake.logs."+site+":"+port+"/api/v2/logs")
 	c.APIURL = envOrDefault(EnvAPIURL, protocol+"://api."+site)
-
-	c.UseFIPS = envOrDefaultBool(EnvUseFIPS, false)
 
 	c.Source = envOrDefault(EnvSource, "")
 	c.Host = envOrDefault(EnvHost, "")

--- a/aws/logs_monitoring_go/internal/config/config_test.go
+++ b/aws/logs_monitoring_go/internal/config/config_test.go
@@ -37,10 +37,6 @@ func TestLoad(t *testing.T) {
 			env:  map[string]string{EnvSource: "custom", EnvHost: "my-host"},
 			want: Config{IntakeURL: defaultURL, APIURL: defaultAPI, Source: "custom", Host: "my-host"},
 		},
-		"fips enabled": {
-			env:  map[string]string{EnvUseFIPS: "true"},
-			want: Config{IntakeURL: defaultURL, APIURL: defaultAPI, UseFIPS: true},
-		},
 		"valid multiline regex": {
 			env:       map[string]string{EnvMultilineLogRegex: `\d{4}-\d{2}-\d{2}`},
 			want:      Config{IntakeURL: defaultURL, APIURL: defaultAPI},
@@ -70,7 +66,6 @@ func TestLoad(t *testing.T) {
 			assert.Equal(t, tc.want.APIURL, got.APIURL)
 			assert.Equal(t, tc.want.Source, got.Source)
 			assert.Equal(t, tc.want.Host, got.Host)
-			assert.Equal(t, tc.want.UseFIPS, got.UseFIPS)
 			assert.Equal(t, tc.wantRegex, got.S3MultilineLogRegex != nil)
 		})
 	}

--- a/aws/logs_monitoring_go/internal/config/kms.go
+++ b/aws/logs_monitoring_go/internal/config/kms.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (c *Config) resolveAPIKeyFromKMS(ctx context.Context, ciphertext string) (string, error) {
-	kmsClient, err := sdkclient.NewKMS(ctx, c.UseFIPS)
+	kmsClient, err := sdkclient.NewKMS(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/aws/logs_monitoring_go/internal/config/secretsmanager.go
+++ b/aws/logs_monitoring_go/internal/config/secretsmanager.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (c *Config) resolveAPIKeyFromSecretsManager(ctx context.Context, arn string) (string, error) {
-	smClient, err := sdkclient.NewSecretsManager(ctx, c.UseFIPS)
+	smClient, err := sdkclient.NewSecretsManager(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/aws/logs_monitoring_go/internal/config/ssm.go
+++ b/aws/logs_monitoring_go/internal/config/ssm.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (c *Config) resolveAPIKeyFromSSM(ctx context.Context, name string) (string, error) {
-	ssmClient, err := sdkclient.NewSSM(ctx, c.UseFIPS)
+	ssmClient, err := sdkclient.NewSSM(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/aws/logs_monitoring_go/internal/handling/handler.go
+++ b/aws/logs_monitoring_go/internal/handling/handler.go
@@ -28,7 +28,6 @@ type Config struct {
 	Source              string
 	Tags                model.Tags
 	S3MultilineLogRegex *regexp.Regexp
-	UseFIPS             bool
 }
 
 func NewHandler(ctx context.Context, hcfg Config, scrubber *scrubbing.Scrubber, filterer *filtering.Filterer, ct parsing.ContentType) (Handler, error) {
@@ -38,7 +37,7 @@ func NewHandler(ctx context.Context, hcfg Config, scrubber *scrubbing.Scrubber, 
 		return newCloudwatch(&hcfg, scrubber, filterer), nil
 
 	case parsing.ContentTypeS3:
-		client, err := sdkclient.GetS3(ctx, hcfg.UseFIPS)
+		client, err := sdkclient.GetS3(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/aws/logs_monitoring_go/internal/sdkclient/kms.go
+++ b/aws/logs_monitoring_go/internal/sdkclient/kms.go
@@ -11,10 +11,8 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"log/slog"
 	"strings"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
@@ -24,31 +22,13 @@ type KMS interface {
 	Decrypt(ctx context.Context, params *kms.DecryptInput, optFns ...func(*kms.Options)) (*kms.DecryptOutput, error)
 }
 
-func NewKMS(ctx context.Context, useFIPS bool) (KMS, error) {
+func NewKMS(ctx context.Context) (KMS, error) {
 	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithHTTPClient(awshttp.NewBuildableClient().WithTimeout(timeout)))
 	if err != nil {
 		return nil, err
 	}
 
-	resolver := kms.NewDefaultEndpointResolverV2()
-	params := kms.EndpointParameters{
-		Region:  aws.String(cfg.Region),
-		UseFIPS: aws.Bool(useFIPS),
-	}
-
-	endpoint, err := resolver.ResolveEndpoint(ctx, params)
-	if err != nil && useFIPS {
-		slog.Warn("FIPS endpoint not available, falling back to standard endpoint", slog.String("service", "kms"), slog.String("region", cfg.Region))
-		params.UseFIPS = aws.Bool(false)
-		endpoint, err = resolver.ResolveEndpoint(ctx, params)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("resolve endpoint: %w", err)
-	}
-
-	return kms.NewFromConfig(cfg, func(o *kms.Options) {
-		o.BaseEndpoint = aws.String(endpoint.URI.String())
-	}), nil
+	return kms.NewFromConfig(cfg), nil
 }
 
 func DecryptKMSCiphertext(ctx context.Context, kmsClient KMS, ciphertext string) (string, error) {

--- a/aws/logs_monitoring_go/internal/sdkclient/s3.go
+++ b/aws/logs_monitoring_go/internal/sdkclient/s3.go
@@ -9,12 +9,9 @@ package sdkclient
 
 import (
 	"context"
-	"fmt"
-	"log/slog"
 	"sync"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -36,36 +33,18 @@ type S3 interface {
 	DeleteObject(ctx context.Context, params *s3.DeleteObjectInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
 }
 
-func GetS3(ctx context.Context, useFIPS bool) (S3, error) {
+func GetS3(ctx context.Context) (S3, error) {
 	s3ClientOnce.Do(func() {
-		s3Client, s3ClientErr = newS3(ctx, useFIPS)
+		s3Client, s3ClientErr = newS3(ctx)
 	})
 	return s3Client, s3ClientErr
 }
 
-func newS3(ctx context.Context, useFIPS bool) (S3, error) {
+func newS3(ctx context.Context) (S3, error) {
 	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithHTTPClient(awshttp.NewBuildableClient().WithTimeout(timeout)))
 	if err != nil {
 		return nil, err
 	}
 
-	resolver := s3.NewDefaultEndpointResolverV2()
-	params := s3.EndpointParameters{
-		Region:  aws.String(cfg.Region),
-		UseFIPS: aws.Bool(useFIPS),
-	}
-
-	endpoint, err := resolver.ResolveEndpoint(ctx, params)
-	if err != nil && useFIPS {
-		slog.Warn("FIPS endpoint not available, falling back to standard endpoint", slog.String("service", "s3"), slog.String("region", cfg.Region))
-		params.UseFIPS = aws.Bool(false)
-		endpoint, err = resolver.ResolveEndpoint(ctx, params)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("resolve endpoint: %w", err)
-	}
-
-	return s3.NewFromConfig(cfg, func(o *s3.Options) {
-		o.BaseEndpoint = aws.String(endpoint.URI.String())
-	}), nil
+	return s3.NewFromConfig(cfg), nil
 }

--- a/aws/logs_monitoring_go/internal/sdkclient/secrets_manager.go
+++ b/aws/logs_monitoring_go/internal/sdkclient/secrets_manager.go
@@ -10,7 +10,6 @@ package sdkclient
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -23,31 +22,13 @@ type SecretsManager interface {
 	GetSecretValue(ctx context.Context, params *secretsmanager.GetSecretValueInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error)
 }
 
-func NewSecretsManager(ctx context.Context, useFIPS bool) (SecretsManager, error) {
+func NewSecretsManager(ctx context.Context) (SecretsManager, error) {
 	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithHTTPClient(awshttp.NewBuildableClient().WithTimeout(timeout)))
 	if err != nil {
 		return nil, err
 	}
 
-	resolver := secretsmanager.NewDefaultEndpointResolverV2()
-	params := secretsmanager.EndpointParameters{
-		Region:  aws.String(cfg.Region),
-		UseFIPS: aws.Bool(useFIPS),
-	}
-
-	endpoint, err := resolver.ResolveEndpoint(ctx, params)
-	if err != nil && useFIPS {
-		slog.Warn("FIPS endpoint not available, falling back to standard endpoint", slog.String("service", "secretsmanager"), slog.String("region", cfg.Region))
-		params.UseFIPS = aws.Bool(false)
-		endpoint, err = resolver.ResolveEndpoint(ctx, params)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("resolve endpoint: %w", err)
-	}
-
-	return secretsmanager.NewFromConfig(cfg, func(o *secretsmanager.Options) {
-		o.BaseEndpoint = aws.String(endpoint.URI.String())
-	}), nil
+	return secretsmanager.NewFromConfig(cfg), nil
 }
 
 func FetchSecret(ctx context.Context, smClient SecretsManager, arn string) (string, error) {

--- a/aws/logs_monitoring_go/internal/sdkclient/ssm.go
+++ b/aws/logs_monitoring_go/internal/sdkclient/ssm.go
@@ -10,7 +10,6 @@ package sdkclient
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -23,31 +22,13 @@ type SSM interface {
 	GetParameter(ctx context.Context, params *ssm.GetParameterInput, optFns ...func(*ssm.Options)) (*ssm.GetParameterOutput, error)
 }
 
-func NewSSM(ctx context.Context, useFIPS bool) (SSM, error) {
+func NewSSM(ctx context.Context) (SSM, error) {
 	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithHTTPClient(awshttp.NewBuildableClient().WithTimeout(timeout)))
 	if err != nil {
 		return nil, err
 	}
 
-	resolver := ssm.NewDefaultEndpointResolverV2()
-	params := ssm.EndpointParameters{
-		Region:  aws.String(cfg.Region),
-		UseFIPS: aws.Bool(useFIPS),
-	}
-
-	endpoint, err := resolver.ResolveEndpoint(ctx, params)
-	if err != nil && useFIPS {
-		slog.Warn("FIPS endpoint not available, falling back to standard endpoint", slog.String("service", "ssm"), slog.String("region", cfg.Region))
-		params.UseFIPS = aws.Bool(false)
-		endpoint, err = resolver.ResolveEndpoint(ctx, params)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("resolve endpoint: %w", err)
-	}
-
-	return ssm.NewFromConfig(cfg, func(o *ssm.Options) {
-		o.BaseEndpoint = aws.String(endpoint.URI.String())
-	}), nil
+	return ssm.NewFromConfig(cfg), nil
 }
 
 func FetchSSMParameter(ctx context.Context, ssmClient SSM, name string) (string, error) {

--- a/aws/logs_monitoring_go/internal/storing/storage.go
+++ b/aws/logs_monitoring_go/internal/storing/storage.go
@@ -21,13 +21,12 @@ type Storage interface {
 }
 
 type Options struct {
-	FIPS     bool
 	S3Bucket string
 }
 
 func NewStorage(ctx context.Context, opts Options) (Storage, error) {
 	if opts.S3Bucket != "" {
-		s3Client, err := sdkclient.GetS3(ctx, opts.FIPS)
+		s3Client, err := sdkclient.GetS3(ctx)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR deletes FIPS-related logic.

As discussed with the team, we will provide two forwarder binaries, one of which will be compile with `GOFIPS140=v1.26.0` (see https://go.dev/doc/security/fips140#fips-140-3-mode) and provide `AWS_USE_FIPS_ENDPOINT=true` (see https://docs.aws.amazon.com/sdkref/latest/guide/feature-endpoints.html) environment variable configured.