### PR TITLE
fix(deps): bump idna from 3.7 to 3.15 to address CVE-2026-45409

### DIFF
--- a/aws/logs_monitoring/requirements.txt
+++ b/aws/logs_monitoring/requirements.txt
@@ -10,7 +10,7 @@ ddtrace==3.19.5
 deprecated
 envier
 exceptiongroup
-idna==3.7
+idna==3.15
 importlib-metadata
 opentelemetry-api
 protobuf==6.33.5


### PR DESCRIPTION
### What does this PR do?
Bumps `idna` from 3.7 to 3.15 in `aws/logs_monitoring/requirements.txt`.

### Motivation
Addresses CVE-2026-45409, a DoS vulnerability in the `idna` library where crafted
inputs to `idna.encode()` consume excessive resources before length validation.
The fix in 3.14/3.15 rejects oversized inputs early. `idna` is a transitive
dependency pulled in by `requests`.

### Testing Guidelines
No behavior change — this is a transitive dependency not called directly by this
codebase. `requests==2.33.0` accepts `idna<4,>=2.5`, so 3.15 is fully compatible.

### Additional Notes
`idna` is not used directly in this repo; it is resolved transitively via `requests`.
The vulnerable code path (passing untrusted hostnames to `idna.encode()`) is not
reachable in this Lambda — all outbound URLs are operator-configured env vars with
hardcoded Datadog defaults.

### Types of changes
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply
- [x] This PR's description is comprehensive
- [ ] This PR passes the unit tests