### PR TITLE
Update version from 5.4.4 to 5.4.5

### DIFF
--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -344,7 +344,7 @@ DD_SOURCE = "ddsource"
 DD_CUSTOM_TAGS = "ddtags"
 DD_SERVICE = "service"
 DD_HOST = "host"
-DD_FORWARDER_VERSION = "5.4.4"
+DD_FORWARDER_VERSION = "5.4.5"
 
 # CONST STRINGS
 AWS_STRING = "aws"

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -3,8 +3,8 @@ Description: Pushes logs, metrics and traces from AWS to Datadog.
 Mappings:
   Constants:
     DdForwarder:
-      Version: 5.4.4
-      LayerVersion: "103"
+      Version: 5.4.5
+      LayerVersion: "104"
 Parameters:
   DdApiKey:
     Type: String


### PR DESCRIPTION
This PR updates the AWS Forwarder version to 5.4.5 and the layer version to 104.