### PR TITLE
fix(go-forwarder): add custom lambda log group source identification

### DIFF
--- a/aws/logs_monitoring_go/Makefile
+++ b/aws/logs_monitoring_go/Makefile
@@ -13,7 +13,7 @@ package: build
 
 .PHONY: test
 test:
-	go test -race ./...
+	go test -shuffle=on -race ./...
 
 .PHONY: lint
 lint:

--- a/aws/logs_monitoring_go/internal/handling/cloudwatch.go
+++ b/aws/logs_monitoring_go/internal/handling/cloudwatch.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -31,6 +32,11 @@ const (
 	logGroupSNS           = "sns/"
 	logStreamStepFunction = "states/"
 	logStreamCloudtrail   = "_CloudTrail_"
+)
+
+// Custom log groups use the log stream format: YYYY/MM/DD/<function_name>[<function_version>][<execution_environment_GUID>]
+var lambdaLogStreamRegex = regexp.MustCompile(
+	`^\d{4}/[01]\d/[0-3]\d/[\w.-]{1,75}\[(\$LATEST|[\w-]{1,129})\][0-9a-f]{32}$`,
 )
 
 type cloudwatchHandler struct {
@@ -160,7 +166,7 @@ func CloudwatchSource(logGroup, logStream string) string {
 	if strings.HasPrefix(logGroup, logGroupKinesis) {
 		return sourceKinesis
 	}
-	if strings.HasPrefix(logGroup, logGroupLambda) {
+	if strings.HasPrefix(logGroup, logGroupLambda) || lambdaLogStreamRegex.MatchString(logStream) {
 		return sourceLambda
 	}
 	if strings.HasPrefix(logGroup, logGroupSNS) {

--- a/aws/logs_monitoring_go/internal/handling/cloudwatch_test.go
+++ b/aws/logs_monitoring_go/internal/handling/cloudwatch_test.go
@@ -255,14 +255,17 @@ func TestCloudwatchSource(t *testing.T) {
 		logStream string
 		want      string
 	}{
-		"step function":             {logGroup: "/aws/vendedlogs", logStream: "states/my-machine/abc", want: "stepfunction"},
-		"cloudtrail via log stream": {logGroup: "/aws/something", logStream: "123_CloudTrail_us-east-1", want: "cloudtrail"},
-		"cloudtrail via log group":  {logGroup: "_cloudtrail_logs", logStream: "stream", want: "cloudtrail"},
-		"cloudtrail via contains":   {logGroup: "my-cloudtrail-group", logStream: "stream", want: "cloudtrail"},
-		"kinesis":                   {logGroup: "/aws/kinesis/my-stream", logStream: "stream", want: "kinesis"},
-		"lambda":                    {logGroup: "/aws/lambda/my-function", logStream: "stream", want: "lambda"},
-		"sns":                       {logGroup: "sns/us-east-1/123/topic", logStream: "stream", want: "sns"},
-		"fallback cloudwatch":       {logGroup: "/aws/rds/cluster", logStream: "stream", want: "cloudwatch"},
+		"step function":                           {logGroup: "/aws/vendedlogs", logStream: "states/my-machine/abc", want: "stepfunction"},
+		"cloudtrail via log stream":               {logGroup: "/aws/something", logStream: "123_CloudTrail_us-east-1", want: "cloudtrail"},
+		"cloudtrail via log group":                {logGroup: "_cloudtrail_logs", logStream: "stream", want: "cloudtrail"},
+		"cloudtrail via contains":                 {logGroup: "my-cloudtrail-group", logStream: "stream", want: "cloudtrail"},
+		"kinesis":                                 {logGroup: "/aws/kinesis/my-stream", logStream: "stream", want: "kinesis"},
+		"lambda":                                  {logGroup: "/aws/lambda/my-function", logStream: "stream", want: "lambda"},
+		"sns":                                     {logGroup: "sns/us-east-1/123/topic", logStream: "stream", want: "sns"},
+		"lambda log stream with $LATEST":          {logGroup: "my-custom-group", logStream: "2023/11/06/my-lambda-function-name[$LATEST]13e304cba4b9446eb7ef082a00038990", want: "lambda"},
+		"lambda log stream with version":          {logGroup: "my-custom-group", logStream: "2023/11/06/my-lambda-function-name[version2023_11]13e304cba4b9446eb7ef082a00038990", want: "lambda"},
+		"lambda log stream without function name": {logGroup: "my-custom-group", logStream: "2023/11/04/[$LATEST]4426346c2cdf4c54a74d3bd2b929fc44", want: "cloudwatch"},
+		"fallback cloudwatch":                     {logGroup: "/aws/rds/cluster", logStream: "stream", want: "cloudwatch"},
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
Adds lambda source identification for custom lambda log groups.
See the ticket for more context.

(test failure is noise from a previous PR)