### PR TITLE
fix(go-forwarder): move counter to per invocation and increase SQS po…

### DIFF
--- a/aws/logs_monitoring_go/internal/storing/s3.go
+++ b/aws/logs_monitoring_go/internal/storing/s3.go
@@ -24,11 +24,10 @@ import (
 
 const prefix = "failed_events/"
 
-var seq atomic.Int64
-
 type S3 struct {
-	client sdkclient.S3
-	bucket string
+	client   sdkclient.S3
+	bucket   string
+	sequence atomic.Int64
 }
 
 func newS3(client sdkclient.S3, bucket string) *S3 {
@@ -42,7 +41,7 @@ func (s *S3) Store(ctx context.Context, batch Batch) error {
 	}
 
 	datetime := time.Now().UTC().Format("2006/01/02/150405000")
-	key := fmt.Sprintf("%s%s_%s_%d.json", prefix, datetime, invocationID, seq.Add(1))
+	key := fmt.Sprintf("%s%s_%s_%d.json", prefix, datetime, invocationID, s.sequence.Add(1))
 
 	_, err := s.client.PutObject(ctx, &s3.PutObjectInput{
 		Bucket:   aws.String(s.bucket),

--- a/aws/logs_monitoring_go/internal/storing/sqs.go
+++ b/aws/logs_monitoring_go/internal/storing/sqs.go
@@ -23,7 +23,7 @@ import (
 const (
 	maxSizePerSQSMessage = 1000 * 1024 // Overhead for other attributes than message body
 	maxNumberOfMessages  = 10
-	polling              = 10
+	polling              = 100
 	visibilityTimeout    = 6 * 60
 	waitTimeSeconds      = 0
 )


### PR DESCRIPTION
Small PR to have better batch counter visibility on AWS S3 UI by resetting the counter between invocations and also increase s polling number for SQS (to align with S3, which retries 1000 batches)