### PR TITLE
fix(go-forwarder): reduce binary size

### DIFF
--- a/aws/logs_monitoring_go/Makefile
+++ b/aws/logs_monitoring_go/Makefile
@@ -5,7 +5,7 @@ ZIP_NAME := forwarder.zip
 
 .PHONY: build
 build:
-	GOOS=linux GOARCH=arm64 go build -ldflags="-s" -installsuffix nocgo -o $(BINARY_NAME) ./cmd/forwarder/
+	GOOS=linux GOARCH=arm64 go build -tags lambda.norpc -ldflags="-s" -installsuffix nocgo -o $(BINARY_NAME) ./cmd/forwarder/
 
 .PHONY: package
 package: build
@@ -37,7 +37,7 @@ clean:
 # Used only by SAM
 .PHONY: build-ForwarderFunction
 build-ForwarderFunction:
-	GOOS=linux GOARCH=arm64 go build -ldflags="-s" -installsuffix nocgo -o $(ARTIFACTS_DIR)/bootstrap ./cmd/forwarder/
+	GOOS=linux GOARCH=arm64 go build -tags lambda.norpc -ldflags="-s" -installsuffix nocgo -o $(ARTIFACTS_DIR)/bootstrap ./cmd/forwarder/
 
 .PHONY: sam-build
 sam-build:


### PR DESCRIPTION
See https://docs.aws.amazon.com/lambda/latest/dg/golang-package.html#golang-package-mac-linux.

_"You can use the optional lambda.norpc tag to exclude the Remote Procedure Call (RPC) component of the [lambda](https://github.com/aws/aws-lambda-go/tree/master/lambda) library. The RPC component is only required if you are using the deprecated Go 1.x runtime. Excluding the RPC reduces the size of the deployment package."_