### PR TITLE
fix(forwarder): update API key page link to /organization-settings/api-keys

### DIFF
--- a/aws/logs_monitoring/settings.py
+++ b/aws/logs_monitoring/settings.py
@@ -33,7 +33,7 @@ def get_env_var(envvar, default, boolean=False):
 ## It can be found here:
 ##
 ##   * Datadog US Site: https://app.datadoghq.com/organization-settings/api-keys
-##   * Datadog EU Site: https://app.datadoghq.eu/account/settings#api
+##   * Datadog EU Site: https://app.datadoghq.eu/organization-settings/api-keys
 ##
 ## Must be set if one of the following is not set: DD_API_KEY_SECRET_ARN, DD_API_KEY_SSM_NAME, DD_KMS_API_KEY
 #

--- a/aws/logs_monitoring/template.yaml
+++ b/aws/logs_monitoring/template.yaml
@@ -10,7 +10,7 @@ Parameters:
     Type: String
     NoEcho: true
     Default: ""
-    Description: The Datadog API key, which can be found from the APIs page (/account/settings#api). It will be stored in AWS Secrets Manager securely. If DdApiKeySecretArn is also set, this value is ignored.
+    Description: The Datadog API key, which can be found on the API Keys page (/organization-settings/api-keys). It will be stored in AWS Secrets Manager securely. If DdApiKeySecretArn is also set, this value is ignored.
   DdApiKeySecretArn:
     Type: String
     AllowedPattern: "arn:.*:secretsmanager:.*"


### PR DESCRIPTION
## What

The Forwarder's `DdApiKey` CloudFormation parameter description and the EU-site line in `settings.py` directed users to the deprecated `/account/settings#api` page to find their API key. Both now point to the current `/organization-settings/api-keys` path.

- `aws/logs_monitoring/template.yaml` - `DdApiKey` parameter description
- `aws/logs_monitoring/settings.py` - EU-site line in the manual-config comment block (the US-site line there was already correct)

## Why

The docs team received customer feedback that the in-template instruction is out of date; the docs site itself already uses the correct path. Reported via #serverless-aws.

## Note

The published artifact (`datadog-cloudformation-template.s3.amazonaws.com/aws/forwarder/latest.yaml`) is regenerated by the Forwarder release (`release.sh`, version bump), so this reaches customers with the next release rather than on merge.

Jira: https://datadoghq.atlassian.net/browse/AWSINTS-3805
