### PR TITLE
tests(go-forwarder): add approval testing on non-external AWS API events

### DIFF
--- a/aws/logs_monitoring_go/cmd/forwarder/main.go
+++ b/aws/logs_monitoring_go/cmd/forwarder/main.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"log"
 	"log/slog"
+	"net/http"
 	"sync"
 
 	"github.com/DataDog/datadog-serverless-functions/aws/logs_monitoring_go/internal/apikey"
@@ -47,10 +48,10 @@ func main() {
 		slog.Error("API key validation", slog.Any("error", err))
 	}
 
-	lambda.Start(handleRequest(cfg))
+	lambda.Start(handleRequest(cfg, httpclient.Client))
 }
 
-func handleRequest(cfg *config.Config) func(ctx context.Context, awsevent json.RawMessage) (any, error) {
+func handleRequest(cfg *config.Config, client *http.Client) func(ctx context.Context, awsevent json.RawMessage) (any, error) {
 	return func(ctx context.Context, awsevent json.RawMessage) (any, error) {
 		var wg sync.WaitGroup
 
@@ -87,7 +88,7 @@ func handleRequest(cfg *config.Config) func(ctx context.Context, awsevent json.R
 
 		forwarder := forwarding.NewForwarder(
 			forwarderCfg,
-			httpclient.Client,
+			client,
 			storage,
 		)
 

--- a/aws/logs_monitoring_go/cmd/forwarder/main.go
+++ b/aws/logs_monitoring_go/cmd/forwarder/main.go
@@ -39,16 +39,16 @@ func main() {
 	if cfg.SkipServerCertificate {
 		tlsOpts = append(tlsOpts, httpclient.WithCertificateSkip())
 	}
-	httpclient.Init(tlsOpts...)
+	client := httpclient.New(tlsOpts...)
 
-	if err = apikey.Validate(context.Background(), httpclient.Client, cfg.APIURL, cfg.APIKey); err != nil {
+	if err = apikey.Validate(context.Background(), client, cfg.APIURL, cfg.APIKey); err != nil {
 		if !cfg.StoreOnFail {
 			log.Fatal(fmt.Errorf("no failed event storage set, validate API key: %w", err))
 		}
 		slog.Error("API key validation", slog.Any("error", err))
 	}
 
-	lambda.Start(handleRequest(cfg, httpclient.Client))
+	lambda.Start(handleRequest(cfg, client))
 }
 
 func handleRequest(cfg *config.Config, client *http.Client) func(ctx context.Context, awsevent json.RawMessage) (any, error) {

--- a/aws/logs_monitoring_go/cmd/forwarder/main_test.go
+++ b/aws/logs_monitoring_go/cmd/forwarder/main_test.go
@@ -1,0 +1,87 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-Present Datadog, Inc.
+
+package main
+
+import (
+	"compress/gzip"
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/DataDog/datadog-serverless-functions/aws/logs_monitoring_go/internal/config"
+	"github.com/DataDog/datadog-serverless-functions/aws/logs_monitoring_go/internal/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+var update = flag.Bool("update", false, "update .golden files")
+
+func load(t *testing.T, path string) json.RawMessage {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	gzipped := testutil.MustGzip(t, data)
+	name := filepath.Base(path)
+
+	switch {
+	case strings.HasPrefix(name, "cloudwatch"):
+		return testutil.MustCloudwatchEvent(t, gzipped)
+	case strings.HasPrefix(name, "kinesis"):
+		return testutil.MustKinesisEvent(t, gzipped)
+	default:
+		return data
+	}
+}
+
+func TestHandleRequest(t *testing.T) {
+	inputs, err := filepath.Glob("testdata/*.input.json")
+	require.NoError(t, err)
+	require.NotEmpty(t, inputs, "no .input.json files found in testdata/")
+
+	for _, input := range inputs {
+		name := strings.TrimSuffix(filepath.Base(input), ".input.json")
+		golden := strings.TrimSuffix(input, ".input.json") + ".golden.json"
+
+		t.Run(name, func(t *testing.T) {
+			rec := newRecorder(t)
+			cfg := &config.Config{
+				APIKey:           "abcdefghijklmnopqrstuvwxyz012345",
+				IntakeURL:        rec.URL,
+				CompressionLevel: gzip.DefaultCompression,
+			}
+			ctx := testutil.LambdaContext(t)
+			event := load(t, input)
+
+			_, err := handleRequest(cfg, rec.Server.Client())(ctx, event)
+
+			require.NoError(t, err)
+			assertGolden(t, golden, rec.snapshot(t))
+		})
+	}
+}
+
+func assertGolden(t *testing.T, goldenPath string, actual any) {
+	t.Helper()
+
+	actualJSON, err := json.MarshalIndent(actual, "", "  ")
+	require.NoError(t, err)
+
+	actualJSON = append(actualJSON, '\n')
+
+	if *update {
+		require.NoError(t, os.WriteFile(goldenPath, actualJSON, 0o644))
+		t.Logf("updated %s", goldenPath)
+		return
+	}
+
+	expected, err := os.ReadFile(goldenPath)
+	require.NoError(t, err, "%q golden file missing, run with -update to create it", goldenPath)
+	require.JSONEq(t, string(expected), string(actualJSON))
+}

--- a/aws/logs_monitoring_go/cmd/forwarder/main_test.go
+++ b/aws/logs_monitoring_go/cmd/forwarder/main_test.go
@@ -59,10 +59,11 @@ func TestHandleRequest(t *testing.T) {
 			ctx := testutil.LambdaContext(t)
 			event := load(t, input)
 
-			_, err := handleRequest(cfg, rec.Server.Client())(ctx, event)
+			_, err := handleRequest(cfg, rec.Client())(ctx, event)
 
 			require.NoError(t, err)
-			assertGolden(t, golden, rec.snapshot(t))
+			require.NotEmpty(t, rec.request, "recorder received no requests")
+			assertGolden(t, golden, rec.request)
 		})
 	}
 }

--- a/aws/logs_monitoring_go/cmd/forwarder/recorder_test.go
+++ b/aws/logs_monitoring_go/cmd/forwarder/recorder_test.go
@@ -1,0 +1,70 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-Present Datadog, Inc.
+
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type recordedRequest struct {
+	Headers map[string]string `json:"headers"`
+	Body    json.RawMessage   `json:"body"`
+}
+
+type recorder struct {
+	*httptest.Server
+	request recordedRequest
+}
+
+func newRecorder(t *testing.T) *recorder {
+	t.Helper()
+
+	rec := &recorder{}
+	rec.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		if r.Header.Get("Content-Encoding") == "gzip" {
+			gr, err := gzip.NewReader(bytes.NewReader(body))
+			require.NoError(t, err)
+
+			body, err = io.ReadAll(gr)
+			require.NoError(t, err)
+
+			gr.Close()
+		}
+
+		headers := make(map[string]string)
+		for key, vals := range r.Header {
+			switch key {
+			case "Content-Length", "Accept-Encoding": // non-deterministic
+				continue
+			}
+			headers[key] = vals[0]
+		}
+
+		rec.request = recordedRequest{Headers: headers, Body: body}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(rec.Close)
+
+	return rec
+}
+
+func (r *recorder) snapshot(t *testing.T) any {
+	t.Helper()
+
+	require.NotEmpty(t, r.request, "recorder received no requests")
+	return r.request
+}

--- a/aws/logs_monitoring_go/cmd/forwarder/recorder_test.go
+++ b/aws/logs_monitoring_go/cmd/forwarder/recorder_test.go
@@ -42,7 +42,7 @@ func newRecorder(t *testing.T) *recorder {
 			body, err = io.ReadAll(gr)
 			require.NoError(t, err)
 
-			gr.Close()
+			require.NoError(t, gr.Close())
 		}
 
 		headers := make(map[string]string)
@@ -60,11 +60,4 @@ func newRecorder(t *testing.T) *recorder {
 	t.Cleanup(rec.Close)
 
 	return rec
-}
-
-func (r *recorder) snapshot(t *testing.T) any {
-	t.Helper()
-
-	require.NotEmpty(t, r.request, "recorder received no requests")
-	return r.request
 }

--- a/aws/logs_monitoring_go/cmd/forwarder/testdata/cloudwatch.golden.json
+++ b/aws/logs_monitoring_go/cmd/forwarder/testdata/cloudwatch.golden.json
@@ -1,0 +1,49 @@
+{
+  "headers": {
+    "Content-Encoding": "gzip",
+    "Content-Type": "application/json",
+    "Dd-Api-Key": "abcdefghijklmnopqrstuvwxyz012345",
+    "Dd-Evp-Origin": "aws_forwarder",
+    "Dd-Evp-Origin-Version": "6.0",
+    "Dd-Storage-Tag": "cloudwatch",
+    "User-Agent": "Go-http-client/1.1"
+  },
+  "body": [
+    {
+      "host": "testLogGroup",
+      "id": "eventId1",
+      "timestamp": 1440442987000,
+      "message": "[ERROR] First test message",
+      "service": "cloudwatch",
+      "ddsource": "cloudwatch",
+      "ddsourcecategory": "aws",
+      "ddtags": "",
+      "aws": {
+        "invoked_function_arn": "arn:aws:lambda:us-east-1:123456789012:function:forwarder",
+        "awslogs": {
+          "logGroup": "testLogGroup",
+          "logStream": "testLogStream",
+          "owner": "123456789123"
+        }
+      }
+    },
+    {
+      "host": "testLogGroup",
+      "id": "eventId2",
+      "timestamp": 1440442987001,
+      "message": "[ERROR] Second test message",
+      "service": "cloudwatch",
+      "ddsource": "cloudwatch",
+      "ddsourcecategory": "aws",
+      "ddtags": "",
+      "aws": {
+        "invoked_function_arn": "arn:aws:lambda:us-east-1:123456789012:function:forwarder",
+        "awslogs": {
+          "logGroup": "testLogGroup",
+          "logStream": "testLogStream",
+          "owner": "123456789123"
+        }
+      }
+    }
+  ]
+}

--- a/aws/logs_monitoring_go/cmd/forwarder/testdata/cloudwatch.input.json
+++ b/aws/logs_monitoring_go/cmd/forwarder/testdata/cloudwatch.input.json
@@ -1,0 +1,19 @@
+{
+	"messageType": "DATA_MESSAGE",
+	"owner": "123456789123",
+	"logGroup": "testLogGroup",
+	"logStream": "testLogStream",
+	"subscriptionFilters": ["testFilter"],
+	"logEvents": [
+		{
+			"id": "eventId1",
+			"timestamp": 1440442987000,
+			"message": "[ERROR] First test message"
+		},
+		{
+			"id": "eventId2",
+			"timestamp": 1440442987001,
+			"message": "[ERROR] Second test message"
+		}
+	]
+}

--- a/aws/logs_monitoring_go/cmd/forwarder/testdata/cloudwatch_cloudtrail.golden.json
+++ b/aws/logs_monitoring_go/cmd/forwarder/testdata/cloudwatch_cloudtrail.golden.json
@@ -1,0 +1,31 @@
+{
+  "headers": {
+    "Content-Encoding": "gzip",
+    "Content-Type": "application/json",
+    "Dd-Api-Key": "abcdefghijklmnopqrstuvwxyz012345",
+    "Dd-Evp-Origin": "aws_forwarder",
+    "Dd-Evp-Origin-Version": "6.0",
+    "Dd-Storage-Tag": "cloudwatch",
+    "User-Agent": "Go-http-client/1.1"
+  },
+  "body": [
+    {
+      "host": "i-08014e4f62ccf762d",
+      "id": "37199773595581154154810589279545129148442535997644275712",
+      "timestamp": 1620000808000,
+      "message": "{\"eventVersion\":\"1.08\",\"userIdentity\":{\"type\":\"AssumedRole\",\"arn\":\"arn:aws:sts::601427279990:assumed-role/MyRole/i-08014e4f62ccf762d\"},\"eventTime\":\"2021-05-02T23:53:28Z\",\"eventSource\":\"dynamodb.amazonaws.com\",\"eventName\":\"DescribeTable\",\"awsRegion\":\"us-east-1\"}",
+      "service": "cloudtrail",
+      "ddsource": "cloudtrail",
+      "ddsourcecategory": "aws",
+      "ddtags": "",
+      "aws": {
+        "invoked_function_arn": "arn:aws:lambda:us-east-1:123456789012:function:forwarder",
+        "awslogs": {
+          "logGroup": "/aws/cloudtrail",
+          "logStream": "601427279990_CloudTrail_us-east-1",
+          "owner": "601427279990"
+        }
+      }
+    }
+  ]
+}

--- a/aws/logs_monitoring_go/cmd/forwarder/testdata/cloudwatch_cloudtrail.input.json
+++ b/aws/logs_monitoring_go/cmd/forwarder/testdata/cloudwatch_cloudtrail.input.json
@@ -1,0 +1,13 @@
+{
+  "messageType": "DATA_MESSAGE",
+  "owner": "601427279990",
+  "logGroup": "/aws/cloudtrail",
+  "logStream": "601427279990_CloudTrail_us-east-1",
+  "logEvents": [
+    {
+      "id": "37199773595581154154810589279545129148442535997644275712",
+      "timestamp": 1620000808000,
+      "message": "{\"eventVersion\":\"1.08\",\"userIdentity\":{\"type\":\"AssumedRole\",\"arn\":\"arn:aws:sts::601427279990:assumed-role/MyRole/i-08014e4f62ccf762d\"},\"eventTime\":\"2021-05-02T23:53:28Z\",\"eventSource\":\"dynamodb.amazonaws.com\",\"eventName\":\"DescribeTable\",\"awsRegion\":\"us-east-1\"}"
+    }
+  ]
+}

--- a/aws/logs_monitoring_go/cmd/forwarder/testdata/cloudwatch_datadog.golden.json
+++ b/aws/logs_monitoring_go/cmd/forwarder/testdata/cloudwatch_datadog.golden.json
@@ -1,0 +1,31 @@
+{
+  "headers": {
+    "Content-Encoding": "gzip",
+    "Content-Type": "application/json",
+    "Dd-Api-Key": "abcdefghijklmnopqrstuvwxyz012345",
+    "Dd-Evp-Origin": "aws_forwarder",
+    "Dd-Evp-Origin-Version": "6.0",
+    "Dd-Storage-Tag": "cloudwatch",
+    "User-Agent": "Go-http-client/1.1"
+  },
+  "body": [
+    {
+      "host": "testLogGroup",
+      "id": "eventId1",
+      "timestamp": 1440442987000,
+      "message": "{\"message\":\"hello world\"}",
+      "service": "custom_service",
+      "ddsource": "cloudwatch",
+      "ddsourcecategory": "aws",
+      "ddtags": "custom_tag1:value1,custom_tag2:value2",
+      "aws": {
+        "invoked_function_arn": "arn:aws:lambda:us-east-1:123456789012:function:forwarder",
+        "awslogs": {
+          "logGroup": "testLogGroup",
+          "logStream": "testLogStream",
+          "owner": "123456789123"
+        }
+      }
+    }
+  ]
+}

--- a/aws/logs_monitoring_go/cmd/forwarder/testdata/cloudwatch_datadog.input.json
+++ b/aws/logs_monitoring_go/cmd/forwarder/testdata/cloudwatch_datadog.input.json
@@ -1,0 +1,14 @@
+{
+	"messageType": "DATA_MESSAGE",
+	"owner": "123456789123",
+	"logGroup": "testLogGroup",
+	"logStream": "testLogStream",
+	"subscriptionFilters": ["testFilter"],
+	"logEvents": [
+		{
+			"id": "eventId1",
+			"timestamp": 1440442987000,
+			"message": "{\"message\": \"hello world\", \"ddtags\": \"service:custom_service,custom_tag1:value1,custom_tag2:value2\"}\n"
+		}
+	]
+}

--- a/aws/logs_monitoring_go/cmd/forwarder/testdata/cloudwatch_lambda_coldstart.golden.json
+++ b/aws/logs_monitoring_go/cmd/forwarder/testdata/cloudwatch_lambda_coldstart.golden.json
@@ -1,0 +1,67 @@
+{
+  "headers": {
+    "Content-Encoding": "gzip",
+    "Content-Type": "application/json",
+    "Dd-Api-Key": "abcdefghijklmnopqrstuvwxyz012345",
+    "Dd-Evp-Origin": "aws_forwarder",
+    "Dd-Evp-Origin-Version": "6.0",
+    "Dd-Storage-Tag": "cloudwatch",
+    "User-Agent": "Go-http-client/1.1"
+  },
+  "body": [
+    {
+      "host": "/aws/lambda/storms-cloudwatch-event",
+      "id": "35486831490800643125153606102923171443962457178576257024",
+      "timestamp": 1591284559098,
+      "message": "START RequestId: db275f87-a934-471a-8980-b63bf4dc1beb Version: $LATEST\\n",
+      "service": "lambda",
+      "ddsource": "lambda",
+      "ddsourcecategory": "aws",
+      "ddtags": "",
+      "aws": {
+        "invoked_function_arn": "arn:aws:lambda:us-east-1:123456789012:function:forwarder",
+        "awslogs": {
+          "logGroup": "/aws/lambda/storms-cloudwatch-event",
+          "logStream": "2020/06/04/[$LATEST]af2b1e1843b84a2d80c67840ae3ffa72",
+          "owner": "601427279990"
+        }
+      }
+    },
+    {
+      "host": "/aws/lambda/storms-cloudwatch-event",
+      "id": "35486831490867545360749197972347778598780402263094198273",
+      "timestamp": 1591284559101,
+      "message": "END RequestId: db275f87-a934-471a-8980-b63bf4dc1beb\\n",
+      "service": "lambda",
+      "ddsource": "lambda",
+      "ddsourcecategory": "aws",
+      "ddtags": "",
+      "aws": {
+        "invoked_function_arn": "arn:aws:lambda:us-east-1:123456789012:function:forwarder",
+        "awslogs": {
+          "logGroup": "/aws/lambda/storms-cloudwatch-event",
+          "logStream": "2020/06/04/[$LATEST]af2b1e1843b84a2d80c67840ae3ffa72",
+          "owner": "601427279990"
+        }
+      }
+    },
+    {
+      "host": "/aws/lambda/storms-cloudwatch-event",
+      "id": "35486831490867545360749197972347778598780402263094198274",
+      "timestamp": 1591284559101,
+      "message": "REPORT RequestId: db275f87-a934-471a-8980-b63bf4dc1beb\\tDuration: 1.76 ms\\tBilled Duration: 100 ms\\tMemory Size: 128 MB\\tMax Memory Used: 48 MB\\tInit Duration: 120.96 ms\\t\\n",
+      "service": "lambda",
+      "ddsource": "lambda",
+      "ddsourcecategory": "aws",
+      "ddtags": "",
+      "aws": {
+        "invoked_function_arn": "arn:aws:lambda:us-east-1:123456789012:function:forwarder",
+        "awslogs": {
+          "logGroup": "/aws/lambda/storms-cloudwatch-event",
+          "logStream": "2020/06/04/[$LATEST]af2b1e1843b84a2d80c67840ae3ffa72",
+          "owner": "601427279990"
+        }
+      }
+    }
+  ]
+}

--- a/aws/logs_monitoring_go/cmd/forwarder/testdata/cloudwatch_lambda_coldstart.input.json
+++ b/aws/logs_monitoring_go/cmd/forwarder/testdata/cloudwatch_lambda_coldstart.input.json
@@ -1,0 +1,25 @@
+{
+  "messageType": "DATA_MESSAGE",
+  "owner": "601427279990",
+  "logGroup": "/aws/lambda/storms-cloudwatch-event",
+  "logStream": "2020/06/04/[$LATEST]af2b1e1843b84a2d80c67840ae3ffa72",
+  "subscriptionFilters": [
+    "myevent"
+  ],
+  "logEvents": [{
+      "id": "35486831490800643125153606102923171443962457178576257024",
+      "timestamp": 1591284559098,
+      "message": "START RequestId: db275f87-a934-471a-8980-b63bf4dc1beb Version: $LATEST\\n"
+    },
+    {
+      "id": "35486831490867545360749197972347778598780402263094198273",
+      "timestamp": 1591284559101,
+      "message": "END RequestId: db275f87-a934-471a-8980-b63bf4dc1beb\\n"
+    },
+    {
+      "id": "35486831490867545360749197972347778598780402263094198274",
+      "timestamp": 1591284559101,
+      "message": "REPORT RequestId: db275f87-a934-471a-8980-b63bf4dc1beb\\tDuration: 1.76 ms\\tBilled Duration: 100 ms\\tMemory Size: 128 MB\\tMax Memory Used: 48 MB\\tInit Duration: 120.96 ms\\t\\n"
+    }
+  ]
+}

--- a/aws/logs_monitoring_go/cmd/forwarder/testdata/cloudwatch_lambda_custom_log_group.golden.json
+++ b/aws/logs_monitoring_go/cmd/forwarder/testdata/cloudwatch_lambda_custom_log_group.golden.json
@@ -1,0 +1,67 @@
+{
+  "headers": {
+    "Content-Encoding": "gzip",
+    "Content-Type": "application/json",
+    "Dd-Api-Key": "abcdefghijklmnopqrstuvwxyz012345",
+    "Dd-Evp-Origin": "aws_forwarder",
+    "Dd-Evp-Origin-Version": "6.0",
+    "Dd-Storage-Tag": "cloudwatch",
+    "User-Agent": "Go-http-client/1.1"
+  },
+  "body": [
+    {
+      "host": "/aws/vendedlogs/states/anyLogGroupName",
+      "id": "35311576111948622874033876462979853992919938886093242368",
+      "timestamp": 1583425836114,
+      "message": "2020-03-05T16:30:36.113Z\tf08bb4c8-d6b2-4f05-ac17-af7e2ba005fb\tDEBUG\t[dd.trace_id=3172564172058669914 dd.span_id=14292093692483532556] {\"status\":\"debug\",\"message\":\"datadog:Patched console output with trace context\"}\n",
+      "service": "lambda",
+      "ddsource": "lambda",
+      "ddsourcecategory": "aws",
+      "ddtags": "",
+      "aws": {
+        "invoked_function_arn": "arn:aws:lambda:us-east-1:123456789012:function:forwarder",
+        "awslogs": {
+          "logGroup": "/aws/vendedlogs/states/anyLogGroupName",
+          "logStream": "2020/03/05/test-customized-loggroup[$LATEST]20bddfd5a2dc4c6b97ac02800eae90d0",
+          "owner": "601427279990"
+        }
+      }
+    },
+    {
+      "host": "/aws/vendedlogs/states/anyLogGroupName",
+      "id": "35311576111948622874033876462979853992919938886093242369",
+      "timestamp": 1583425836114,
+      "message": "2020-03-05T16:30:36.114Z\tf08bb4c8-d6b2-4f05-ac17-af7e2ba005fb\tDEBUG\t[dd.trace_id=3172564172058669914 dd.span_id=14292093692483532556] {\"autoPatchHTTP\":true,\"tracerInitialized\":true,\"status\":\"debug\",\"message\":\"datadog:Not patching HTTP libraries\"}\n",
+      "service": "lambda",
+      "ddsource": "lambda",
+      "ddsourcecategory": "aws",
+      "ddtags": "",
+      "aws": {
+        "invoked_function_arn": "arn:aws:lambda:us-east-1:123456789012:function:forwarder",
+        "awslogs": {
+          "logGroup": "/aws/vendedlogs/states/anyLogGroupName",
+          "logStream": "2020/03/05/test-customized-loggroup[$LATEST]20bddfd5a2dc4c6b97ac02800eae90d0",
+          "owner": "601427279990"
+        }
+      }
+    },
+    {
+      "host": "/aws/vendedlogs/states/anyLogGroupName",
+      "id": "35311576111948622874033876462979853992919938886093242370",
+      "timestamp": 1583425836114,
+      "message": "2020-03-05T16:30:36.114Z\tf08bb4c8-d6b2-4f05-ac17-af7e2ba005fb\tDEBUG\t[dd.trace_id=3172564172058669914 dd.span_id=14292093692483532556] {\"status\":\"debug\",\"message\":\"datadog:Reading trace context from env var Root=1-5e61292c-cc1229a4dfbeae1043928548;Parent=c657b77d9514f70c;Sampled=1\"}\n",
+      "service": "lambda",
+      "ddsource": "lambda",
+      "ddsourcecategory": "aws",
+      "ddtags": "",
+      "aws": {
+        "invoked_function_arn": "arn:aws:lambda:us-east-1:123456789012:function:forwarder",
+        "awslogs": {
+          "logGroup": "/aws/vendedlogs/states/anyLogGroupName",
+          "logStream": "2020/03/05/test-customized-loggroup[$LATEST]20bddfd5a2dc4c6b97ac02800eae90d0",
+          "owner": "601427279990"
+        }
+      }
+    }
+  ]
+}

--- a/aws/logs_monitoring_go/cmd/forwarder/testdata/cloudwatch_lambda_custom_log_group.input.json
+++ b/aws/logs_monitoring_go/cmd/forwarder/testdata/cloudwatch_lambda_custom_log_group.input.json
@@ -1,0 +1,24 @@
+{
+	"messageType": "DATA_MESSAGE",
+	"owner": "601427279990",
+	"logGroup": "/aws/vendedlogs/states/anyLogGroupName",
+	"logStream": "2020/03/05/test-customized-loggroup[$LATEST]20bddfd5a2dc4c6b97ac02800eae90d0",
+	"subscriptionFilters": ["some-filter-name"],
+	"logEvents": [
+		{
+			"id": "35311576111948622874033876462979853992919938886093242368",
+			"timestamp": 1583425836114,
+			"message": "2020-03-05T16:30:36.113Z\tf08bb4c8-d6b2-4f05-ac17-af7e2ba005fb\tDEBUG\t[dd.trace_id=3172564172058669914 dd.span_id=14292093692483532556] {\"status\":\"debug\",\"message\":\"datadog:Patched console output with trace context\"}\n"
+		},
+		{
+			"id": "35311576111948622874033876462979853992919938886093242369",
+			"timestamp": 1583425836114,
+			"message":"2020-03-05T16:30:36.114Z\tf08bb4c8-d6b2-4f05-ac17-af7e2ba005fb\tDEBUG\t[dd.trace_id=3172564172058669914 dd.span_id=14292093692483532556] {\"autoPatchHTTP\":true,\"tracerInitialized\":true,\"status\":\"debug\",\"message\":\"datadog:Not patching HTTP libraries\"}\n"
+		},
+		{
+			"id": "35311576111948622874033876462979853992919938886093242370",
+			"timestamp": 1583425836114,
+			"message": "2020-03-05T16:30:36.114Z\tf08bb4c8-d6b2-4f05-ac17-af7e2ba005fb\tDEBUG\t[dd.trace_id=3172564172058669914 dd.span_id=14292093692483532556] {\"status\":\"debug\",\"message\":\"datadog:Reading trace context from env var Root=1-5e61292c-cc1229a4dfbeae1043928548;Parent=c657b77d9514f70c;Sampled=1\"}\n"
+		}
+	]
+}

--- a/aws/logs_monitoring_go/cmd/forwarder/testdata/cloudwatch_lambda_timeout.golden.json
+++ b/aws/logs_monitoring_go/cmd/forwarder/testdata/cloudwatch_lambda_timeout.golden.json
@@ -1,0 +1,85 @@
+{
+  "headers": {
+    "Content-Encoding": "gzip",
+    "Content-Type": "application/json",
+    "Dd-Api-Key": "abcdefghijklmnopqrstuvwxyz012345",
+    "Dd-Evp-Origin": "aws_forwarder",
+    "Dd-Evp-Origin-Version": "6.0",
+    "Dd-Storage-Tag": "cloudwatch",
+    "User-Agent": "Go-http-client/1.1"
+  },
+  "body": [
+    {
+      "host": "/aws/lambda/storms-cloudwatch-event",
+      "id": "35496429375792603298393743017356257146982675867810398208",
+      "timestamp": 1591714943146,
+      "message": "START RequestId: 7c9567b5-107b-4a6c-8798-0157ac21db52 Version: $LATEST\\n",
+      "service": "lambda",
+      "ddsource": "lambda",
+      "ddsourcecategory": "aws",
+      "ddtags": "",
+      "aws": {
+        "invoked_function_arn": "arn:aws:lambda:us-east-1:123456789012:function:forwarder",
+        "awslogs": {
+          "logGroup": "/aws/lambda/storms-cloudwatch-event",
+          "logStream": "2020/06/09/[$LATEST]b249865adaaf4fad80f95f8ad09725b8",
+          "owner": "601427279990"
+        }
+      }
+    },
+    {
+      "host": "/aws/lambda/storms-cloudwatch-event",
+      "id": "35496429442806342619978265557671090556291002193281548289",
+      "timestamp": 1591714946151,
+      "message": "END RequestId: 7c9567b5-107b-4a6c-8798-0157ac21db52\\n",
+      "service": "lambda",
+      "ddsource": "lambda",
+      "ddsourcecategory": "aws",
+      "ddtags": "",
+      "aws": {
+        "invoked_function_arn": "arn:aws:lambda:us-east-1:123456789012:function:forwarder",
+        "awslogs": {
+          "logGroup": "/aws/lambda/storms-cloudwatch-event",
+          "logStream": "2020/06/09/[$LATEST]b249865adaaf4fad80f95f8ad09725b8",
+          "owner": "601427279990"
+        }
+      }
+    },
+    {
+      "host": "/aws/lambda/storms-cloudwatch-event",
+      "id": "35496429442806342619978265557671090556291002193281548290",
+      "timestamp": 1591714946151,
+      "message": "REPORT RequestId: 7c9567b5-107b-4a6c-8798-0157ac21db52\\tDuration: 3003.16 ms\\tBilled Duration: 3000 ms\\tMemory Size: 128 MB\\tMax Memory Used: 48 MB\\tInit Duration: 127.02 ms\\t\\n",
+      "service": "lambda",
+      "ddsource": "lambda",
+      "ddsourcecategory": "aws",
+      "ddtags": "",
+      "aws": {
+        "invoked_function_arn": "arn:aws:lambda:us-east-1:123456789012:function:forwarder",
+        "awslogs": {
+          "logGroup": "/aws/lambda/storms-cloudwatch-event",
+          "logStream": "2020/06/09/[$LATEST]b249865adaaf4fad80f95f8ad09725b8",
+          "owner": "601427279990"
+        }
+      }
+    },
+    {
+      "host": "/aws/lambda/storms-cloudwatch-event",
+      "id": "35496429442806342619978265557671090556291002193281548291",
+      "timestamp": 1591714946151,
+      "message": "2020-06-09T15:02:26.150Z 7c9567b5-107b-4a6c-8798-0157ac21db52 Task timed out after 3.00 seconds\\n\\n",
+      "service": "lambda",
+      "ddsource": "lambda",
+      "ddsourcecategory": "aws",
+      "ddtags": "",
+      "aws": {
+        "invoked_function_arn": "arn:aws:lambda:us-east-1:123456789012:function:forwarder",
+        "awslogs": {
+          "logGroup": "/aws/lambda/storms-cloudwatch-event",
+          "logStream": "2020/06/09/[$LATEST]b249865adaaf4fad80f95f8ad09725b8",
+          "owner": "601427279990"
+        }
+      }
+    }
+  ]
+}

--- a/aws/logs_monitoring_go/cmd/forwarder/testdata/cloudwatch_lambda_timeout.input.json
+++ b/aws/logs_monitoring_go/cmd/forwarder/testdata/cloudwatch_lambda_timeout.input.json
@@ -1,0 +1,30 @@
+{
+  "messageType": "DATA_MESSAGE",
+  "owner": "601427279990",
+  "logGroup": "/aws/lambda/storms-cloudwatch-event",
+  "logStream": "2020/06/09/[$LATEST]b249865adaaf4fad80f95f8ad09725b8",
+  "subscriptionFilters": [
+    "myevent"
+  ],
+  "logEvents": [{
+      "id": "35496429375792603298393743017356257146982675867810398208",
+      "timestamp": 1591714943146,
+      "message": "START RequestId: 7c9567b5-107b-4a6c-8798-0157ac21db52 Version: $LATEST\\n"
+    },
+    {
+      "id": "35496429442806342619978265557671090556291002193281548289",
+      "timestamp": 1591714946151,
+      "message": "END RequestId: 7c9567b5-107b-4a6c-8798-0157ac21db52\\n"
+    },
+    {
+      "id": "35496429442806342619978265557671090556291002193281548290",
+      "timestamp": 1591714946151,
+      "message": "REPORT RequestId: 7c9567b5-107b-4a6c-8798-0157ac21db52\\tDuration: 3003.16 ms\\tBilled Duration: 3000 ms\\tMemory Size: 128 MB\\tMax Memory Used: 48 MB\\tInit Duration: 127.02 ms\\t\\n"
+    },
+    {
+      "id": "35496429442806342619978265557671090556291002193281548291",
+      "timestamp": 1591714946151,
+      "message": "2020-06-09T15:02:26.150Z 7c9567b5-107b-4a6c-8798-0157ac21db52 Task timed out after 3.00 seconds\\n\\n"
+    }
+  ]
+}

--- a/aws/logs_monitoring_go/cmd/forwarder/testdata/eventbridge_securityhub.golden.json
+++ b/aws/logs_monitoring_go/cmd/forwarder/testdata/eventbridge_securityhub.golden.json
@@ -1,0 +1,32 @@
+{
+  "headers": {
+    "Content-Encoding": "gzip",
+    "Content-Type": "application/json",
+    "Dd-Api-Key": "abcdefghijklmnopqrstuvwxyz012345",
+    "Dd-Evp-Origin": "aws_forwarder",
+    "Dd-Evp-Origin-Version": "6.0",
+    "User-Agent": "Go-http-client/1.1"
+  },
+  "body": [
+    {
+      "message": "{\"detail\":{\"finding\":{\"Severity\":{\"Label\":\"HIGH\"},\"Title\":\"S3 bucket without encryption\",\"resources\":{\"AwsEc2SecurityGroup\":{\"Region\":\"us-east-1\"},\"AwsIamRole\":{\"Region\":\"us-east-1\"}}}},\"detail-type\":\"Security Hub Findings - Imported\",\"source\":\"aws.securityhub\"}",
+      "service": "securityhub",
+      "ddsource": "securityhub",
+      "ddsourcecategory": "aws",
+      "ddtags": "",
+      "aws": {
+        "invoked_function_arn": "arn:aws:lambda:us-east-1:123456789012:function:forwarder"
+      }
+    },
+    {
+      "message": "{\"detail\":{\"finding\":{\"Title\":\"Open security group\",\"resources\":{\"AwsEc2SecurityGroup\":{\"Region\":\"us-west-2\"}}}},\"detail-type\":\"Security Hub Findings - Imported\",\"source\":\"aws.securityhub\"}",
+      "service": "securityhub",
+      "ddsource": "securityhub",
+      "ddsourcecategory": "aws",
+      "ddtags": "",
+      "aws": {
+        "invoked_function_arn": "arn:aws:lambda:us-east-1:123456789012:function:forwarder"
+      }
+    }
+  ]
+}

--- a/aws/logs_monitoring_go/cmd/forwarder/testdata/eventbridge_securityhub.input.json
+++ b/aws/logs_monitoring_go/cmd/forwarder/testdata/eventbridge_securityhub.input.json
@@ -1,0 +1,22 @@
+{
+  "source": "aws.securityhub",
+  "detail-type": "Security Hub Findings - Imported",
+  "detail": {
+    "findings": [
+      {
+        "Title": "S3 bucket without encryption",
+        "Severity": {"Label": "HIGH"},
+        "Resources": [
+          {"Type": "AwsEc2SecurityGroup", "Region": "us-east-1"},
+          {"Type": "AwsIamRole", "Region": "us-east-1"}
+        ]
+      },
+      {
+        "Title": "Open security group",
+        "Resources": [
+          {"Type": "AwsEc2SecurityGroup", "Region": "us-west-2"}
+        ]
+      }
+    ]
+  }
+}

--- a/aws/logs_monitoring_go/cmd/forwarder/testdata/kinesis.golden.json
+++ b/aws/logs_monitoring_go/cmd/forwarder/testdata/kinesis.golden.json
@@ -1,0 +1,31 @@
+{
+  "headers": {
+    "Content-Encoding": "gzip",
+    "Content-Type": "application/json",
+    "Dd-Api-Key": "abcdefghijklmnopqrstuvwxyz012345",
+    "Dd-Evp-Origin": "aws_forwarder",
+    "Dd-Evp-Origin-Version": "6.0",
+    "Dd-Storage-Tag": "cloudwatch",
+    "User-Agent": "Go-http-client/1.1"
+  },
+  "body": [
+    {
+      "host": "/aws/kinesis/my-stream",
+      "id": "eventId1",
+      "timestamp": 1428537600000,
+      "message": "Kinesis log message",
+      "service": "kinesis",
+      "ddsource": "kinesis",
+      "ddsourcecategory": "aws",
+      "ddtags": "",
+      "aws": {
+        "invoked_function_arn": "arn:aws:lambda:us-east-1:123456789012:function:forwarder",
+        "awslogs": {
+          "logGroup": "/aws/kinesis/my-stream",
+          "logStream": "shardId-000000000000",
+          "owner": "123456789012"
+        }
+      }
+    }
+  ]
+}

--- a/aws/logs_monitoring_go/cmd/forwarder/testdata/kinesis.input.json
+++ b/aws/logs_monitoring_go/cmd/forwarder/testdata/kinesis.input.json
@@ -1,0 +1,13 @@
+{
+  "messageType": "DATA_MESSAGE",
+  "owner": "123456789012",
+  "logGroup": "/aws/kinesis/my-stream",
+  "logStream": "shardId-000000000000",
+  "logEvents": [
+    {
+      "id": "eventId1",
+      "timestamp": 1428537600000,
+      "message": "Kinesis log message"
+    }
+  ]
+}

--- a/aws/logs_monitoring_go/cmd/forwarder/testdata/sns.golden.json
+++ b/aws/logs_monitoring_go/cmd/forwarder/testdata/sns.golden.json
@@ -1,0 +1,21 @@
+{
+  "headers": {
+    "Content-Encoding": "gzip",
+    "Content-Type": "application/json",
+    "Dd-Api-Key": "abcdefghijklmnopqrstuvwxyz012345",
+    "Dd-Evp-Origin": "aws_forwarder",
+    "Dd-Evp-Origin-Version": "6.0",
+    "User-Agent": "Go-http-client/1.1"
+  },
+  "body": [
+    {
+      "message": "example message",
+      "ddsource": "sns",
+      "ddsourcecategory": "aws",
+      "ddtags": "",
+      "aws": {
+        "invoked_function_arn": "arn:aws:lambda:us-east-1:123456789012:function:forwarder"
+      }
+    }
+  ]
+}

--- a/aws/logs_monitoring_go/cmd/forwarder/testdata/sns.input.json
+++ b/aws/logs_monitoring_go/cmd/forwarder/testdata/sns.input.json
@@ -1,0 +1,31 @@
+{
+  "Records": [
+    {
+      "EventSource": "aws:sns",
+      "EventVersion": "1.0",
+      "EventSubscriptionArn": "arn:aws:sns:us-east-1::ExampleTopic",
+      "Sns": {
+        "Type": "Notification",
+        "MessageId": "95df01b4-ee98-5cb9-9903-4c221d41eb5e",
+        "TopicArn": "arn:aws:sns:us-east-1:123456789012:ExampleTopic",
+        "Subject": "example subject",
+        "Message": "example message",
+        "Timestamp": "1970-01-01T00:00:00.000Z",
+        "SignatureVersion": "1",
+        "Signature": "EXAMPLE",
+        "SigningCertUrl": "EXAMPLE",
+        "UnsubscribeUrl": "EXAMPLE",
+        "MessageAttributes": {
+          "Test": {
+            "Type": "String",
+            "Value": "TestString"
+          },
+          "TestBinary": {
+            "Type": "Binary",
+            "Value": "TestBinary"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/aws/logs_monitoring_go/go.mod
+++ b/aws/logs_monitoring_go/go.mod
@@ -7,8 +7,10 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.12
 	github.com/aws/aws-sdk-go-v2/service/kms v1.50.4
+	github.com/aws/aws-sdk-go-v2/service/lambda v1.94.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.4
+	github.com/aws/aws-sdk-go-v2/service/sqs v1.44.0
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.68.4
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/mock v0.6.0
@@ -29,7 +31,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.94.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.8 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sqs v1.44.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.9 // indirect

--- a/aws/logs_monitoring_go/go.sum
+++ b/aws/logs_monitoring_go/go.sum
@@ -1,11 +1,7 @@
 github.com/aws/aws-lambda-go v1.53.0 h1:uAMv6W/vCP/L494BAUSxe+8KVBIPK+SGPyapFt3FuMk=
 github.com/aws/aws-lambda-go v1.53.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
-github.com/aws/aws-sdk-go-v2 v1.41.5 h1:dj5kopbwUsVUVFgO4Fi5BIT3t4WyqIDjGKCangnV/yY=
-github.com/aws/aws-sdk-go-v2 v1.41.5/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
 github.com/aws/aws-sdk-go-v2 v1.42.0 h1:XvXMJTkFQtpBKIWZnmr9ZEOc2InWM2yldjXEJ/bymhA=
 github.com/aws/aws-sdk-go-v2 v1.42.0/go.mod h1:27+ACypSLljLAEKsCYOmrjKh83vuTRkuAe9Uv/3A4bg=
-github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 h1:eBMB84YGghSocM7PsjmmPffTa+1FBUeNvGvFou6V/4o=
-github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8/go.mod h1:lyw7GFp3qENLh7kwzf7iMzAxDn+NzjXEAGjKS2UOKqI=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.13 h1:p1BBrg/Hhp6uK7zpejeI8QFXHJeC/mynzi04Sl03k9g=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.13/go.mod h1:8cIfkE9MDhkRZGpQ22aV6/lkYeYSozpz16Smrs5x4Ls=
 github.com/aws/aws-sdk-go-v2/config v1.32.12 h1:O3csC7HUGn2895eNrLytOJQdoL2xyJy0iYXhoZ1OmP0=
@@ -14,12 +10,8 @@ github.com/aws/aws-sdk-go-v2/credentials v1.19.12 h1:oqtA6v+y5fZg//tcTWahyN9PEn5
 github.com/aws/aws-sdk-go-v2/credentials v1.19.12/go.mod h1:U3R1RtSHx6NB0DvEQFGyf/0sbrpJrluENHdPy1j/3TE=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.20 h1:zOgq3uezl5nznfoK3ODuqbhVg1JzAGDUhXOsU0IDCAo=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.20/go.mod h1:z/MVwUARehy6GAg/yQ1GO2IMl0k++cu1ohP9zo887wE=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 h1:Rgg6wvjjtX8bNHcvi9OnXWwcE0a2vGpbwmtICOsvcf4=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21/go.mod h1:A/kJFst/nm//cyqonihbdpQZwiUhhzpqTsdbhDdRF9c=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 h1:f3vKqSo13fhTYb+JEcXwXefZQE26I1FB5eTSniU67ko=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29/go.mod h1:MzoLFUArKGpGD+ukmPiTPG1X5x4o6M2kq4v2dr1FiEc=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 h1:PEgGVtPoB6NTpPrBgqSE5hE/o47Ij9qk/SEZFbUOe9A=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21/go.mod h1:p+hz+PRAYlY3zcpJhPwXlLC4C+kqn70WIHwnzAfs6ps=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 h1:RdwIf/CuUsvJX3RgJagbOyotl/cxoLY4xviKuE7p2GY=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29/go.mod h1:71wt8W2EgswdZy9Mf9KNnzxZ3TiZlv4caKghPktDOkA=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 h1:qYQ4pzQ2Oz6WpQ8T3HvGHnZydA72MnLuFK9tJwmrbHw=
@@ -54,8 +46,6 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.17 h1:jzKAXIlhZhJbnYwHbvUQZEB
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.17/go.mod h1:Al9fFsXjv4KfbzQHGe6V4NZSZQXecFcvaIF4e70FoRA=
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.9 h1:Cng+OOwCHmFljXIxpEVXAGMnBia8MSU6Ch5i9PgBkcU=
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.9/go.mod h1:LrlIndBDdjA/EeXeyNBle+gyCwTlizzW5ycgWnvIxkk=
-github.com/aws/smithy-go v1.24.2 h1:FzA3bu/nt/vDvmnkg+R8Xl46gmzEDam6mZ1hzmwXFng=
-github.com/aws/smithy-go v1.24.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/aws/smithy-go v1.27.1 h1:4T340VFndXtADGF52gYa1POyL7s9E4Z1OeZ1hCscIw8=
 github.com/aws/smithy-go v1.27.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/aws/logs_monitoring_go/internal/httpclient/client.go
+++ b/aws/logs_monitoring_go/internal/httpclient/client.go
@@ -22,9 +22,7 @@ const (
 	MaxConcurrency       = 20
 )
 
-var Client *http.Client
-
-func Init(opts ...TLSOption) {
+func New(opts ...TLSOption) *http.Client {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.TLSHandshakeTimeout = tlsHandshakeTimeout
 	transport.MaxIdleConnsPerHost = MaxConcurrency
@@ -37,7 +35,7 @@ func Init(opts ...TLSOption) {
 		opt(transport.TLSClientConfig)
 	}
 
-	Client = &http.Client{Transport: WithRetry(DefaultMaxAttempts, transport)}
+	return &http.Client{Transport: WithRetry(DefaultMaxAttempts, transport)}
 }
 
 func DrainClose(resp *http.Response) {

--- a/aws/logs_monitoring_go/internal/testutil/testutil.go
+++ b/aws/logs_monitoring_go/internal/testutil/testutil.go
@@ -109,6 +109,7 @@ func MustKinesisEvent(t *testing.T, records ...[]byte) json.RawMessage {
 	var evt events.KinesisEvent
 	for _, data := range records {
 		evt.Records = append(evt.Records, events.KinesisEventRecord{
+			EventSource: "aws:kinesis",
 			Kinesis: events.KinesisRecord{
 				Data: data,
 			},


### PR DESCRIPTION
This PR adds approval testing. It reuses relevant test cases from the Python forwarder and adds new ones.

Note that approval testing was and is still not present for S3 events since we don't have the object content in-memory (we need to fetch it). It is doable but would require to either overwrite the GetS3 global variable during tests, or find another tricky solution (e.g. pass all clients to handleRequest through a struct and find a way to enrich it at runtime due to lazyloading).