### PR TITLE
fix(forwarder): pin layer version from template.yaml on release restart

### DIFF
--- a/aws/logs_monitoring/release.sh
+++ b/aws/logs_monitoring/release.sh
@@ -377,11 +377,21 @@ prod_asset_push() {
 aws_login aws sts get-caller-identity
 
 CURRENT_ACCOUNT="$(aws_login aws sts get-caller-identity --query Account --output text)"
-CURRENT_LAYER_VERSION=$(get_max_layer_version)
-LAYER_VERSION=$((CURRENT_LAYER_VERSION + 1))
 
-if [[ ${ACCOUNT} != "datadog" ]]; then
-    log_info "Current layer version is ${CURRENT_LAYER_VERSION}, next layer version will be ${LAYER_VERSION}"
+if [[ ${ACCOUNT} == "prod" && ${PROD_GITHUB_RESTART:-} == "true" ]]; then
+    # On a restart the version-bump PR is already merged, so template.yaml holds the
+    # authoritative layer version. Re-deriving it from AWS (get_max_layer_version + 1)
+    # would return the already-published version + 1, publishing a spurious layer and
+    # mislabeling the GitHub release. Read it from template.yaml instead.
+    LAYER_VERSION=$(yq '.Mappings.Constants.DdForwarder.LayerVersion' "template.yaml")
+    log_info "Restart: using layer version ${LAYER_VERSION} from template.yaml"
+else
+    CURRENT_LAYER_VERSION=$(get_max_layer_version)
+    LAYER_VERSION=$((CURRENT_LAYER_VERSION + 1))
+
+    if [[ ${ACCOUNT} != "datadog" ]]; then
+        log_info "Current layer version is ${CURRENT_LAYER_VERSION}, next layer version will be ${LAYER_VERSION}"
+    fi
 fi
 
 log_info "Validating template.yaml..."


### PR DESCRIPTION
## What

On the prod release restart path (`PROD_GITHUB_RESTART=true ./release.sh <version> prod`), derive `LAYER_VERSION` from `template.yaml` (`.Mappings.Constants.DdForwarder.LayerVersion`) instead of recomputing it as `get_max_layer_version + 1`.

## Why

A restart is used to resume a release that failed *after* the layers were already published (e.g. the GitHub release step failing). In that state, `get_max_layer_version + 1` returns the version *after* the one just published — so the restart would publish a spurious extra layer across every region and title the GitHub release with the wrong layer version, inconsistent with the already-merged `template.yaml`.

Since the version-bump PR is merged before a restart, `template.yaml` already holds the authoritative layer version. Reading it from there makes restarts idempotent: regions already at the target version are skipped, any lagging/previously-skipped regions are topped up, and the version can never roll forward by accident.

## Scope

Only the prod restart path changes. Fresh prod releases, and the `datadog` and `sandbox` paths, keep the existing `get_max_layer_version + 1` behavior.