### PR TITLE
fix(go-forwarder): delete unused env vars

### DIFF
--- a/aws/logs_monitoring_go/cmd/forwarder/main.go
+++ b/aws/logs_monitoring_go/cmd/forwarder/main.go
@@ -67,7 +67,6 @@ func handleRequest(cfg *config.Config, client *http.Client) func(ctx context.Con
 		filterer := filtering.NewFilterer(cfg.FilterInclude, cfg.FilterExclude)
 		scrubber := scrubbing.NewScrubber(cfg.ScrubbingRegex, cfg.ScrubbingReplacement, cfg.ScrubIP, cfg.ScrubEmail)
 		handlerCfg := handling.Config{
-			Host:                cfg.Host,
 			Service:             cfg.Service,
 			Source:              cfg.Source,
 			Tags:                cfg.Tags,

--- a/aws/logs_monitoring_go/internal/config/config.go
+++ b/aws/logs_monitoring_go/internal/config/config.go
@@ -33,7 +33,6 @@ const (
 	EnvSkipServerCertificate    = "DD_SKIP_SSL_VALIDATION"
 	EnvCompressionLevel         = "DD_COMPRESSION_LEVEL"
 	EnvSource                   = "DD_SOURCE"
-	EnvHost                     = "DD_HOST"
 	EnvTags                     = "DD_TAGS"
 	EnvMultilineLogRegex        = "DD_MULTILINE_LOG_REGEX_PATTERN"
 	EnvScrubbingRule            = "DD_SCRUBBING_RULE"
@@ -65,7 +64,6 @@ type Config struct {
 	IntakeURL             string
 	CompressionLevel      int
 	SkipServerCertificate bool
-	Host                  string
 	Source                string
 	Service               string
 	Tags                  model.Tags
@@ -137,7 +135,6 @@ func (c *Config) loadEnv() {
 	c.IntakeURL, c.APIURL = buildURLs(protocol, site, port)
 
 	c.Source = envOrDefault(EnvSource, "")
-	c.Host = envOrDefault(EnvHost, "")
 
 	c.S3RetryBucketName = envOrDefault(EnvS3RetryBucketName, "")
 	c.SQSQueueURL = envOrDefault(EnvSQSQueueURL, "")
@@ -192,7 +189,6 @@ func (c *Config) LogValue() slog.Value {
 		slog.String("s3_retry_bucket", c.S3RetryBucketName),
 		slog.String("sqs_queue_url", c.SQSQueueURL),
 		slog.String("source_override", c.Source),
-		slog.String("host_override", c.Host),
 		slog.Bool("filter_include", c.FilterInclude != nil),
 		slog.Bool("filter_exclude", c.FilterExclude != nil),
 		slog.Bool("scrub_ip", c.ScrubIP),

--- a/aws/logs_monitoring_go/internal/config/config.go
+++ b/aws/logs_monitoring_go/internal/config/config.go
@@ -26,7 +26,6 @@ const (
 	DefaultLogLevel             = "INFO"
 	EnvAPIKey                   = "DD_API_KEY"
 	EnvSite                     = "DD_SITE"
-	EnvAPIURL                   = "DD_API_URL"
 	EnvLogLevel                 = "DD_LOG_LEVEL"
 	EnvPort                     = "DD_PORT"
 	EnvUseHTTP                  = "DD_NO_SSL"

--- a/aws/logs_monitoring_go/internal/config/environment.go
+++ b/aws/logs_monitoring_go/internal/config/environment.go
@@ -16,6 +16,7 @@ var deprecatedEnvironmentVariables = []struct {
 	reason string
 }{
 	{"DD_API_KEY", "Plain text API keys are not supported for security reasons. Please use DD_API_KEY_SECRET_ARN, DD_API_KEY_SSM_NAME, or DD_KMS_API_KEY."},
+	{"DD_API_URL", "This version only supports logs forwarding. For metrics and traces, please use the Datadog Lambda Extension (https://docs.datadoghq.com/serverless/libraries_integrations/extension/)."},
 	{"DD_ENRICH_CLOUDWATCH_TAGS", "Tag enrichment has moved to the Datadog backend. No configuration required."},
 	{"DD_ENRICH_S3_TAGS", "Tag enrichment has moved to the Datadog backend. No configuration required."},
 	{"DD_FETCH_LAMBDA_TAGS", "Tag enrichment has moved to the Datadog backend. No configuration required."},
@@ -26,7 +27,7 @@ var deprecatedEnvironmentVariables = []struct {
 	{"DD_HOST", "The host is derived from the log source and can no longer be overridden globally."},
 	{"DD_STORE_FAILED_EVENTS", "Replaced by DD_S3_BUCKET_NAME or DD_SQS_QUEUE_URL."},
 	{"DD_TAGS_CACHE_TTL_SECONDS", "Tag caching is no longer required. Tag enrichment has moved to the Datadog backend. No configuration required."},
-	{"DD_TRACE_INTAKE_URL", "This version only supports log forwarding. For metrics and traces, please use the Datadog Lambda Extension (https://docs.datadoghq.com/serverless/libraries_integrations/extension/)."},
+	{"DD_TRACE_INTAKE_URL", "This version only supports logs forwarding. For metrics and traces, please use the Datadog Lambda Extension (https://docs.datadoghq.com/serverless/libraries_integrations/extension/)."},
 	{"DD_USE_COMPRESSION", "Set DD_COMPRESSION_LEVEL to 0 to disable compression."},
 	{"DD_USE_VPC", "No longer required. S3 access through VPC endpoints works without additional configuration."},
 }

--- a/aws/logs_monitoring_go/internal/config/environment.go
+++ b/aws/logs_monitoring_go/internal/config/environment.go
@@ -23,6 +23,7 @@ var deprecatedEnvironmentVariables = []struct {
 	{"DD_FETCH_S3_TAGS", "Tag enrichment has moved to the Datadog backend. No configuration required."},
 	{"DD_FETCH_STEP_FUNCTIONS_TAGS", "Tag enrichment has moved to the Datadog backend. No configuration required."},
 	{"DD_FORWARD_LOG", "This version only supports log forwarding. For metrics and traces, please use the Datadog Lambda Extension (https://docs.datadoghq.com/serverless/libraries_integrations/extension/)."},
+	{"DD_HOST", "The host is derived from the log source and can no longer be overridden globally."},
 	{"DD_STORE_FAILED_EVENTS", "Replaced by DD_S3_BUCKET_NAME or DD_SQS_QUEUE_URL."},
 	{"DD_TAGS_CACHE_TTL_SECONDS", "Tag caching is no longer required. Tag enrichment has moved to the Datadog backend. No configuration required."},
 	{"DD_TRACE_INTAKE_URL", "This version only supports log forwarding. For metrics and traces, please use the Datadog Lambda Extension (https://docs.datadoghq.com/serverless/libraries_integrations/extension/)."},

--- a/aws/logs_monitoring_go/internal/handling/cloudwatch.go
+++ b/aws/logs_monitoring_go/internal/handling/cloudwatch.go
@@ -136,7 +136,7 @@ func (h cloudwatchHandler) newCloudwatchBaseEntry(data events.CloudwatchLogsData
 
 	entry := model.NewLogEntry()
 	entry.Source = cmp.Or(h.cfg.Source, source)
-	entry.Host = cmp.Or(h.cfg.Host, logGroup)
+	entry.Host = logGroup
 	entry.Metadata = metadata
 
 	if entry.Source == sourceLambda {

--- a/aws/logs_monitoring_go/internal/handling/cloudwatch_test.go
+++ b/aws/logs_monitoring_go/internal/handling/cloudwatch_test.go
@@ -198,7 +198,7 @@ func TestCloudwatchHandler_Handle(t *testing.T) {
 				},
 			},
 		},
-		"config overrides source, host, service and tags": {
+		"config overrides source, service and tags": {
 			event: testutil.MustCloudwatchEvent(t, testutil.MustGzipJSON(t, map[string]any{
 				"messageType": "DATA_MESSAGE",
 				"owner":       "111111111111",
@@ -210,7 +210,6 @@ func TestCloudwatchHandler_Handle(t *testing.T) {
 			})),
 			config: &Config{
 				Source:  "custom-source",
-				Host:    "custom-host",
 				Service: "custom-service",
 				Tags:    model.Tags{"env:prod", "team:infra"},
 			},
@@ -220,7 +219,7 @@ func TestCloudwatchHandler_Handle(t *testing.T) {
 					Message: "hello", Source: "custom-source", SourceCategory: "aws",
 					Service: "custom-service",
 					Tags:    model.Tags{"env:prod", "team:infra"},
-					Host:    "custom-host", ID: "ev1", Timestamp: 1000,
+					Host:    "/aws/lambda/fn", ID: "ev1", Timestamp: 1000,
 					Metadata: model.CloudwatchMetadata{
 						LambdaOrigin: model.LambdaOrigin{ARN: "arn:aws:lambda:us-east-1:123456789012:function:forwarder"},
 						Origin:       model.CloudwatchOrigin{LogGroup: "/aws/lambda/fn", LogStream: "stream", Owner: "111111111111"},

--- a/aws/logs_monitoring_go/internal/handling/handler.go
+++ b/aws/logs_monitoring_go/internal/handling/handler.go
@@ -23,7 +23,6 @@ type Handler interface {
 }
 
 type Config struct {
-	Host                string
 	Service             string
 	Source              string
 	Tags                model.Tags


### PR DESCRIPTION
DD_API_URL was for metrics/trace.
DD_HOST was not in the previous versions.