### PR TITLE
Bump dev-only requests pin in setup.py to 2.33.0

### DIFF
--- a/aws/logs_monitoring/setup.py
+++ b/aws/logs_monitoring/setup.py
@@ -17,7 +17,7 @@ setup(
     keywords="datadog aws lambda layer",
     python_requires=">=3.14, <3.15",
     extras_require={
-        "dev": ["nose2==0.9.1", "flake8==3.7.9", "requests==2.22.0", "boto3==1.10.33"]
+        "dev": ["nose2==0.9.1", "flake8==3.7.9", "requests==2.33.0", "boto3==1.10.33"]
     },
     py_modules=[],
 )


### PR DESCRIPTION
## Summary
- `aws/logs_monitoring/setup.py` pinned `requests==2.22.0` in the `extras_require["dev"]` list, which is unrelated to the runtime dependency (`requirements.txt` already pins `requests==2.33.0`).
- Grype (and other scanners) parse `setup.py` and flag this stale dev-only string as an installed vulnerable version, producing false positives for:
  - GHSA-j8r2-6x86-q33q (CVE-2023-32681)
  - GHSA-9hjg-9r4m-mvj7 (CVE-2024-47081)
  - GHSA-9wx4-h78v-vm56 (CVE-2024-35195)
  - GHSA-gc5v-m9x4-r6x2 (CVE-2026-25645)
- Bumping the dev pin to 2.33.0 (matching `requirements.txt`) removes the stale version string so these scanner findings no longer trigger.

## Test plan
- [x] Confirmed `requests==2.22.0` is not referenced anywhere else in the repo (`grep -rn "requests=="`)
- [x] Confirmed `requirements.txt` already pins `requests==2.33.0`, so this aligns dev and runtime pins