### PR TITLE
Bump setuptools to 83.0.0

### DIFF
--- a/aws/logs_monitoring/requirements.txt
+++ b/aws/logs_monitoring/requirements.txt
@@ -16,7 +16,7 @@ opentelemetry-api
 protobuf==6.33.5
 requests-futures
 requests==2.33.0
-setuptools==80.10.2
+setuptools==83.0.0
 six
 typing-extensions
 urllib3==2.7.0


### PR DESCRIPTION
## Summary
- `aws/logs_monitoring/requirements.txt` pins `setuptools==80.10.2`, which is vulnerable to GHSA-h35f-9h28-mq5c (CVE-2026-59890): a MANIFEST.in exclusion bypass in sdist generation via Unicode NFC/NFD normalization collisions on macOS APFS/HFS+.
- This isn't exploitable at runtime in this Lambda (no sdist building happens; runtime is Linux, not macOS), but setuptools is a genuine runtime dependency here (used for version metadata lookups), so the fixed version is bumped to clear the scanner finding.

## Test plan
- [x] Confirmed `setuptools==80.10.2` was the only pin of this dependency in the repo
- [x] Confirmed 83.0.0 is the version where GHSA-h35f-9h28-mq5c is fixed per the advisory