### PR TITLE
perf(go-forwarder): fast-exit on when ddtags not detected

### DIFF
--- a/aws/logs_monitoring_go/internal/handling/message.go
+++ b/aws/logs_monitoring_go/internal/handling/message.go
@@ -14,28 +14,34 @@ import (
 )
 
 func extractFromMessage(message string) (model.Tags, string, string) {
-	var tags model.Tags
-	var service string
-	var jsonMessage map[string]any
-	if err := json.Unmarshal([]byte(message), &jsonMessage); err != nil {
-		return nil, service, message
+	if !strings.Contains(message, "ddtags") {
+		return nil, "", message
 	}
 
-	ddtagsRaw, ok := jsonMessage[config.DdtagsJSONKey]
-	if !ok {
-		return nil, service, message
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(message), &fields); err != nil {
+		return nil, "", message
 	}
 
-	ddtagsStr, ok := ddtagsRaw.(string)
+	ddtagsRaw, ok := fields[config.DdtagsJSONKey]
 	if !ok {
-		return nil, service, message
+		return nil, "", message
+	}
+
+	var ddtagsStr string
+	if err := json.Unmarshal(ddtagsRaw, &ddtagsStr); err != nil {
+		return nil, "", message
 	}
 
 	ddtagsStr = strings.ReplaceAll(ddtagsStr, " ", "")
+
+	var tags model.Tags
+	var service string
 	for tag := range strings.SplitSeq(ddtagsStr, config.TagSeparator) {
 		if tag == "" {
 			continue
 		}
+
 		v, found := strings.CutPrefix(tag, config.ServiceKey)
 		if found {
 			if service == "" {
@@ -43,14 +49,15 @@ func extractFromMessage(message string) (model.Tags, string, string) {
 			}
 			continue
 		}
+
 		tags = append(tags, tag)
 	}
 
-	delete(jsonMessage, config.DdtagsJSONKey)
+	delete(fields, config.DdtagsJSONKey)
 
-	newMessage, err := json.Marshal(jsonMessage)
+	newMessage, err := json.Marshal(fields)
 	if err != nil {
-		return nil, service, message
+		return nil, "", message
 	}
 
 	return tags, service, string(newMessage)


### PR DESCRIPTION
- Fast exit when `ddtags` not in message (most use-cases)
- Shallow `json.RawMessage` instead of `any`

Before
<img width="1917" height="813" alt="75MB_s3_128MB_unlimited_cpu" src="https://github.com/user-attachments/assets/b4da6cb1-ea8e-4bf6-92bf-7fb2c19c6815" />

After
<img width="1509" height="770" alt="Screenshot 2026-08-06 at 17 20 04" src="https://github.com/user-attachments/assets/0873cac7-fcbd-4acf-a424-4ce39fd598b2" />

27% execution time gain