### PR TITLE
perf(go-forwarder): reduce batcher.construct() duration by 45%

### DIFF
--- a/aws/logs_monitoring_go/internal/batching/batcher.go
+++ b/aws/logs_monitoring_go/internal/batching/batcher.go
@@ -110,10 +110,15 @@ func (b *Batcher[T]) construct() (json.RawMessage, bool, error) {
 		return nil, false, nil
 	}
 
-	batch, err := json.Marshal(&b.batch)
-	if err != nil {
-		return nil, false, fmt.Errorf("marshal: %w", err)
+	batch := make([]byte, 0, b.batchSize)
+	batch = append(batch, '[')
+	for i, item := range b.batch {
+		if i > 0 {
+			batch = append(batch, ',')
+		}
+		batch = append(batch, item...)
 	}
+	batch = append(batch, ']')
 
 	slog.Debug("batch constructed", slog.Int("items", len(b.batch)), slog.Int("size_bytes", len(batch)))
 


### PR DESCRIPTION
`item` is already in a json form, so we construct the json shape directly instead of relying on `json.Marshal` which heavily relies on reflection.

Before
<img width="1918" height="485" alt="Screenshot 2026-08-06 at 18 19 06" src="https://github.com/user-attachments/assets/7c88da40-25b8-4bc1-ae14-c86ac679c69f" />

After
<img width="1917" height="542" alt="Screenshot 2026-08-06 at 18 18 56" src="https://github.com/user-attachments/assets/57179d4b-50eb-4d43-970e-be01e0c50439" />

45% gain