### PR TITLE
Bump ddtrace to 4.14.0

### DIFF
--- a/aws/logs_monitoring/requirements.txt
+++ b/aws/logs_monitoring/requirements.txt
@@ -6,7 +6,7 @@ charset-normalizer
 datadog-lambda==8.122.0
 datadog==0.52.0
 ddsketch==3.0.1
-ddtrace==4.11.1
+ddtrace==4.14.0
 deprecated
 envier
 exceptiongroup


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

Bumping ddtrace version to 4.14.0
datadog-lambda 8.122.0 allows ddtrace<5,>=4.1.1, so it needs no change.

### Motivation

<!--- What inspired you to submit this pull request? --->

Removes the ply CVE-2025-56005 finding from the forwarder bundle.

ddtrace vendored ply transitively through jsonpath-ng, used only by botocore payload tagging. dd-trace-py#19489 replaced that with vendored python-jsonpath and deleted both ply and jsonpath-ng. That change is on the 4.14 release.


### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [ ] This PR passes the unit tests 
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
