### PR TITLE
fix(rds_enhanced_monitoring, vpc_flow_log_monitoring): read the API key from the region in its ARN

### DIFF
--- a/aws/rds_enhanced_monitoring/README.md
+++ b/aws/rds_enhanced_monitoring/README.md
@@ -228,11 +228,15 @@ a. **Recommended**: AWS KMS
 
 b. AWS Secrets Manager
    1. Create a plaintext secret in AWS Secrets Manager using your API key as the value
-   2. Store the ARN of the secret as the `DD_API_KEY_SECRET_ARN` environment variable
+   2. Store the ARN of the secret as the `DD_API_KEY_SECRET_ARN` environment variable.
+      The secret may live in a different region than the function, as the region is
+      read from the ARN.
 
 c. AWS SSM
    1.  Create a parameter in AWS SSM using your API key as the value
-   2.  Store the Name of the parameter as the `DD_API_KEY_SSM_NAME` environment variable
+   2.  Store the Name of the parameter as the `DD_API_KEY_SSM_NAME` environment
+       variable, or its full ARN when the parameter lives in a different region
+       than the function
 
 d. **Not Recommended**: Plaintext
    1. Set your API key in plaintext as the `DD_API_KEY` environment variable.

--- a/aws/rds_enhanced_monitoring/lambda_function.py
+++ b/aws/rds_enhanced_monitoring/lambda_function.py
@@ -20,6 +20,24 @@ import boto3
 DD_SITE = os.getenv("DD_SITE", default="datadoghq.com")
 
 
+def get_region_from_arn(arn):
+    """
+    Return the region encoded in an ARN, or None when the value is not an ARN.
+
+    boto3 resolves the client region from the environment, which on Lambda is
+    always the region the function runs in. Secrets Manager and SSM do not
+    redirect a request based on the ARN it carries, so a secret or parameter
+    that lives in another region is only reachable when its region is passed
+    to the client explicitly. Returning None keeps the default resolution for
+    values that are not ARNs, such as a plain SSM parameter name.
+    """
+    # arn:<partition>:<service>:<region>:<account-id>:<resource>
+    parts = arn.split(":")
+    if len(parts) < 6 or parts[0] != "arn" or not parts[3]:
+        return None
+    return parts[3]
+
+
 def _datadog_keys():
     if "kmsEncryptedKeys" in os.environ:
         KMS_ENCRYPTED_KEYS = os.environ["kmsEncryptedKeys"]
@@ -37,16 +55,17 @@ def _datadog_keys():
 
     if "DD_API_KEY_SECRET_ARN" in os.environ:
         SECRET_ARN = os.environ["DD_API_KEY_SECRET_ARN"]
-        DD_API_KEY = boto3.client("secretsmanager").get_secret_value(
-            SecretId=SECRET_ARN
-        )["SecretString"]
+        # Fetch the secret from the region the ARN points to
+        DD_API_KEY = boto3.client(
+            "secretsmanager", region_name=get_region_from_arn(SECRET_ARN)
+        ).get_secret_value(SecretId=SECRET_ARN)["SecretString"]
         return {"api_key": DD_API_KEY}
 
     if "DD_API_KEY_SSM_NAME" in os.environ:
         SECRET_NAME = os.environ["DD_API_KEY_SSM_NAME"]
-        DD_API_KEY = boto3.client("ssm").get_parameter(
-            Name=SECRET_NAME, WithDecryption=True
-        )["Parameter"]["Value"]
+        DD_API_KEY = boto3.client(
+            "ssm", region_name=get_region_from_arn(SECRET_NAME)
+        ).get_parameter(Name=SECRET_NAME, WithDecryption=True)["Parameter"]["Value"]
         return {"api_key": DD_API_KEY}
 
     if "DD_KMS_API_KEY" in os.environ:

--- a/aws/rds_enhanced_monitoring/tests/test_datadog_keys.py
+++ b/aws/rds_enhanced_monitoring/tests/test_datadog_keys.py
@@ -1,0 +1,99 @@
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+env_patch = patch.dict(
+    os.environ,
+    {
+        "DD_API_KEY": "11111111111111111111111111111111",
+    },
+)
+env_patch.start()
+from lambda_function import _datadog_keys, get_region_from_arn
+
+env_patch.stop()
+
+# A key that is not also valid JSON, so it round-trips through the plain-string
+# branch of the Secrets Manager and SSM lookups
+STORED_API_KEY = "abcdef1234567890abcdef1234567890"
+SECRET_ARN = "arn:aws:secretsmanager:eu-west-1:123456789012:secret:dd-api-key-AbCdEf"
+PARAMETER_ARN = "arn:aws:ssm:us-west-2:123456789012:parameter/datadog/api-key"
+
+
+class TestGetRegionFromArn(unittest.TestCase):
+    def test_secret_arn(self):
+        self.assertEqual(get_region_from_arn(SECRET_ARN), "eu-west-1")
+
+    def test_ssm_parameter_arn(self):
+        self.assertEqual(get_region_from_arn(PARAMETER_ARN), "us-west-2")
+
+    def test_arn_in_another_partition(self):
+        self.assertEqual(
+            get_region_from_arn(
+                "arn:aws-us-gov:secretsmanager:us-gov-west-1:123456789012:secret:dd-api-key"
+            ),
+            "us-gov-west-1",
+        )
+
+    def test_ssm_parameter_name(self):
+        self.assertIsNone(get_region_from_arn("/datadog/api-key"))
+
+    def test_secret_friendly_name(self):
+        self.assertIsNone(get_region_from_arn("dd-api-key"))
+
+    def test_arn_without_a_region(self):
+        self.assertIsNone(
+            get_region_from_arn("arn:aws:iam::123456789012:role/dd-forwarder")
+        )
+
+    def test_truncated_arn(self):
+        self.assertIsNone(get_region_from_arn("arn:aws:secretsmanager:eu-west-1"))
+
+
+class TestApiKeyClientRegion(unittest.TestCase):
+    def _boto3_client(self):
+        boto3_client = MagicMock()
+        boto3_client.return_value.get_secret_value.return_value = {
+            "SecretString": STORED_API_KEY
+        }
+        boto3_client.return_value.get_parameter.return_value = {
+            "Parameter": {"Value": STORED_API_KEY}
+        }
+        return boto3_client
+
+    @patch.dict(os.environ, {"DD_API_KEY_SECRET_ARN": SECRET_ARN})
+    def test_secret_client_targets_the_secret_region(self):
+        boto3_client = self._boto3_client()
+
+        with patch("lambda_function.boto3.client", boto3_client):
+            keys = _datadog_keys()
+
+        self.assertEqual(keys, {"api_key": STORED_API_KEY})
+        self.assertEqual(boto3_client.call_args.args[0], "secretsmanager")
+        self.assertEqual(boto3_client.call_args.kwargs["region_name"], "eu-west-1")
+
+    @patch.dict(os.environ, {"DD_API_KEY_SSM_NAME": PARAMETER_ARN})
+    def test_ssm_client_targets_the_parameter_region(self):
+        boto3_client = self._boto3_client()
+
+        with patch("lambda_function.boto3.client", boto3_client):
+            keys = _datadog_keys()
+
+        self.assertEqual(keys, {"api_key": STORED_API_KEY})
+        self.assertEqual(boto3_client.call_args.args[0], "ssm")
+        self.assertEqual(boto3_client.call_args.kwargs["region_name"], "us-west-2")
+
+    @patch.dict(os.environ, {"DD_API_KEY_SSM_NAME": "/datadog/api-key"})
+    def test_ssm_client_keeps_the_default_region_for_a_parameter_name(self):
+        boto3_client = self._boto3_client()
+
+        with patch("lambda_function.boto3.client", boto3_client):
+            keys = _datadog_keys()
+
+        self.assertEqual(keys, {"api_key": STORED_API_KEY})
+        self.assertEqual(boto3_client.call_args.args[0], "ssm")
+        self.assertIsNone(boto3_client.call_args.kwargs["region_name"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/aws/vpc_flow_log_monitoring/lambda_function.py
+++ b/aws/vpc_flow_log_monitoring/lambda_function.py
@@ -24,6 +24,24 @@ logger.info("Loading function")
 DD_SITE = os.getenv("DD_SITE", default="datadoghq.com")
 
 
+def get_region_from_arn(arn):
+    """
+    Return the region encoded in an ARN, or None when the value is not an ARN.
+
+    boto3 resolves the client region from the environment, which on Lambda is
+    always the region the function runs in. Secrets Manager and SSM do not
+    redirect a request based on the ARN it carries, so a secret or parameter
+    that lives in another region is only reachable when its region is passed
+    to the client explicitly. Returning None keeps the default resolution for
+    values that are not ARNs, such as a plain SSM parameter name.
+    """
+    # arn:<partition>:<service>:<region>:<account-id>:<resource>
+    parts = arn.split(":")
+    if len(parts) < 6 or parts[0] != "arn" or not parts[3]:
+        return None
+    return parts[3]
+
+
 def _datadog_keys():
     if "kmsEncryptedKeys" in os.environ:
         KMS_ENCRYPTED_KEYS = os.environ["kmsEncryptedKeys"]
@@ -41,16 +59,17 @@ def _datadog_keys():
 
     if "DD_API_KEY_SECRET_ARN" in os.environ:
         SECRET_ARN = os.environ["DD_API_KEY_SECRET_ARN"]
-        DD_API_KEY = boto3.client("secretsmanager").get_secret_value(
-            SecretId=SECRET_ARN
-        )["SecretString"]
+        # Fetch the secret from the region the ARN points to
+        DD_API_KEY = boto3.client(
+            "secretsmanager", region_name=get_region_from_arn(SECRET_ARN)
+        ).get_secret_value(SecretId=SECRET_ARN)["SecretString"]
         return {"api_key": DD_API_KEY}
 
     if "DD_API_KEY_SSM_NAME" in os.environ:
         SECRET_NAME = os.environ["DD_API_KEY_SSM_NAME"]
-        DD_API_KEY = boto3.client("ssm").get_parameter(
-            Name=SECRET_NAME, WithDecryption=True
-        )["Parameter"]["Value"]
+        DD_API_KEY = boto3.client(
+            "ssm", region_name=get_region_from_arn(SECRET_NAME)
+        ).get_parameter(Name=SECRET_NAME, WithDecryption=True)["Parameter"]["Value"]
         return {"api_key": DD_API_KEY}
 
     if "DD_KMS_API_KEY" in os.environ:

--- a/aws/vpc_flow_log_monitoring/tests/test_datadog_keys.py
+++ b/aws/vpc_flow_log_monitoring/tests/test_datadog_keys.py
@@ -1,0 +1,99 @@
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+env_patch = patch.dict(
+    os.environ,
+    {
+        "DD_API_KEY": "11111111111111111111111111111111",
+    },
+)
+env_patch.start()
+from lambda_function import _datadog_keys, get_region_from_arn
+
+env_patch.stop()
+
+# A key that is not also valid JSON, so it round-trips through the plain-string
+# branch of the Secrets Manager and SSM lookups
+STORED_API_KEY = "abcdef1234567890abcdef1234567890"
+SECRET_ARN = "arn:aws:secretsmanager:eu-west-1:123456789012:secret:dd-api-key-AbCdEf"
+PARAMETER_ARN = "arn:aws:ssm:us-west-2:123456789012:parameter/datadog/api-key"
+
+
+class TestGetRegionFromArn(unittest.TestCase):
+    def test_secret_arn(self):
+        self.assertEqual(get_region_from_arn(SECRET_ARN), "eu-west-1")
+
+    def test_ssm_parameter_arn(self):
+        self.assertEqual(get_region_from_arn(PARAMETER_ARN), "us-west-2")
+
+    def test_arn_in_another_partition(self):
+        self.assertEqual(
+            get_region_from_arn(
+                "arn:aws-us-gov:secretsmanager:us-gov-west-1:123456789012:secret:dd-api-key"
+            ),
+            "us-gov-west-1",
+        )
+
+    def test_ssm_parameter_name(self):
+        self.assertIsNone(get_region_from_arn("/datadog/api-key"))
+
+    def test_secret_friendly_name(self):
+        self.assertIsNone(get_region_from_arn("dd-api-key"))
+
+    def test_arn_without_a_region(self):
+        self.assertIsNone(
+            get_region_from_arn("arn:aws:iam::123456789012:role/dd-forwarder")
+        )
+
+    def test_truncated_arn(self):
+        self.assertIsNone(get_region_from_arn("arn:aws:secretsmanager:eu-west-1"))
+
+
+class TestApiKeyClientRegion(unittest.TestCase):
+    def _boto3_client(self):
+        boto3_client = MagicMock()
+        boto3_client.return_value.get_secret_value.return_value = {
+            "SecretString": STORED_API_KEY
+        }
+        boto3_client.return_value.get_parameter.return_value = {
+            "Parameter": {"Value": STORED_API_KEY}
+        }
+        return boto3_client
+
+    @patch.dict(os.environ, {"DD_API_KEY_SECRET_ARN": SECRET_ARN})
+    def test_secret_client_targets_the_secret_region(self):
+        boto3_client = self._boto3_client()
+
+        with patch("lambda_function.boto3.client", boto3_client):
+            keys = _datadog_keys()
+
+        self.assertEqual(keys, {"api_key": STORED_API_KEY})
+        self.assertEqual(boto3_client.call_args.args[0], "secretsmanager")
+        self.assertEqual(boto3_client.call_args.kwargs["region_name"], "eu-west-1")
+
+    @patch.dict(os.environ, {"DD_API_KEY_SSM_NAME": PARAMETER_ARN})
+    def test_ssm_client_targets_the_parameter_region(self):
+        boto3_client = self._boto3_client()
+
+        with patch("lambda_function.boto3.client", boto3_client):
+            keys = _datadog_keys()
+
+        self.assertEqual(keys, {"api_key": STORED_API_KEY})
+        self.assertEqual(boto3_client.call_args.args[0], "ssm")
+        self.assertEqual(boto3_client.call_args.kwargs["region_name"], "us-west-2")
+
+    @patch.dict(os.environ, {"DD_API_KEY_SSM_NAME": "/datadog/api-key"})
+    def test_ssm_client_keeps_the_default_region_for_a_parameter_name(self):
+        boto3_client = self._boto3_client()
+
+        with patch("lambda_function.boto3.client", boto3_client):
+            keys = _datadog_keys()
+
+        self.assertEqual(keys, {"api_key": STORED_API_KEY})
+        self.assertEqual(boto3_client.call_args.args[0], "ssm")
+        self.assertIsNone(boto3_client.call_args.kwargs["region_name"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### What does this PR do?

Builds the Secrets Manager and SSM clients in `aws/rds_enhanced_monitoring` and `aws/vpc_flow_log_monitoring` with the region encoded in the ARN of `DD_API_KEY_SECRET_ARN` / `DD_API_KEY_SSM_NAME`, instead of letting boto3 fall back to the region the function runs in.

This is the same fix #1192 made in `logs_monitoring`, applied to the two remaining functions that resolve the API key the same way. `get_region_from_arn` returns `None` for values that are not ARNs, so a plain SSM parameter name or a friendly secret name keeps the current default region resolution.

### Motivation

Both functions do `boto3.client("secretsmanager").get_secret_value(SecretId=SECRET_ARN)`. boto3 resolves the client region from the environment, which on Lambda is always the region the function runs in, and neither Secrets Manager nor SSM redirects a request based on the ARN it carries. A secret or parameter that lives in another region is therefore unreachable, and since `datadog_keys = _datadog_keys()` runs at import time the function fails to initialize rather than degrading.

This matters for setups that keep the Datadog API key in one central account and region while running the forwarders in many regions — after #1192 the log forwarder handles it, but the RDS enhanced monitoring and VPC flow log functions still do not.

### Testing Guidelines

`aws/rds_enhanced_monitoring/tests/test_datadog_keys.py` and `aws/vpc_flow_log_monitoring/tests/test_datadog_keys.py` cover `get_region_from_arn` (secret ARN, SSM parameter ARN, non-default partition, plain parameter name, friendly secret name, region-less ARN, truncated ARN) and assert that `_datadog_keys()` builds the client with the ARN's region, and with `region_name=None` for a plain SSM parameter name.

Run locally on Python 3.14 with the same commands as CI:

```
python -m unittest discover ./aws/rds_enhanced_monitoring/   # 15 tests, OK
python -m unittest discover ./aws/vpc_flow_log_monitoring/   # 11 tests, OK
flake8 ./aws/rds_enhanced_monitoring/ ./aws/vpc_flow_log_monitoring/ --count --select=E9,F --show-source --statistics
black --check --diff ./aws/rds_enhanced_monitoring ./aws/vpc_flow_log_monitoring
```

### Additional Notes

No change in behaviour for same-region setups: the previous code and `region_name=None` both resolve to the function's own region.

The RDS enhanced monitoring README now states that the secret may live in another region and that the SSM parameter can be given as a full ARN. The VPC flow log README only documents the KMS path, so it is unchanged. Neither SAM template exposes these as parameters, so no template change is needed.

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
- [x] This PR passes the unit tests
- [ ] This PR passes the installation tests (ask a Datadog member to run the tests)
