### PR TITLE
[AWS] Preserve Security Hub V2 resources

### DIFF
--- a/aws/logs_monitoring/steps/transformation.py
+++ b/aws/logs_monitoring/steps/transformation.py
@@ -55,9 +55,12 @@ def separate_security_hub_findings(event):
             # Copy the original event with source and other metadata
             new_event = copy.deepcopy(event_copy)
             current_finding = findings[index]
+            new_event["detail"]["finding"] = current_finding
+            if "resources" in current_finding:
+                events.append(new_event)
+                continue
             # Get the resources array from the current finding
             resources = current_finding.get("Resources", {})
-            new_event["detail"]["finding"] = current_finding
             new_event["detail"]["finding"]["resources"] = {}
             # Separate objects in resources array into distinct attributes
             if resources:

--- a/aws/logs_monitoring/tests/test_transformation.py
+++ b/aws/logs_monitoring/tests/test_transformation.py
@@ -225,6 +225,35 @@ class TestParseSecurityHubEvents(unittest.TestCase):
         }
         verify_as_json(separate_security_hub_findings(event))
 
+    def test_security_hub_v2_preserves_ocsf_resources(self):
+        resources = [
+            {
+                "cloud_partition": "aws",
+                "owner": {},
+                "provider": "AWS",
+                "region": "us-east-1",
+                "type": "AWS::EC2::SecurityGroup",
+                "uid": "sg-clouds-8699",
+                "uid_alt": (
+                    "arn:aws:ec2:us-east-1:990703812051:"
+                    "security-group/sg-clouds-8699"
+                ),
+                "vpc_uid": "vpc-clouds-8699",
+            }
+        ]
+        event = {
+            "ddsource": "securityhub",
+            "detail-type": "Findings Imported V2",
+            "detail": {"findings": [{"resources": resources}]},
+        }
+
+        transformed = separate_security_hub_findings(event)
+
+        self.assertEqual(
+            resources,
+            transformed[0]["detail"]["finding"]["resources"],
+        )
+
 
 class TestTransform(unittest.TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
Preserves lowercase OCSF `resources` in Security Hub V2 findings while keeping the existing legacy resource transformation.

Tested with `python -m unittest tests.test_transformation`.
